### PR TITLE
Fix web remix client not working and premium audio quality not being available.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,7 @@ junit = "4.13.2"
 timber = "5.0.1"
 materialKolor = "3.0.1"
 kuromojiIpadic = "0.9.0"
-newpipeExtractor = "4240401"
+extractor = "2d2d9ed"
 
 [libraries]
 annotation = { module = "androidx.annotation:annotation", version.ref = "annotation" }
@@ -108,7 +108,7 @@ multidex = { module = "androidx.multidex:multidex", version.ref = "multidex" }
 
 #newpipe-extractor = { module = "com.github.libre-tube:NewPipeExtractor", version = "70abbdb" }
 #newpipe-extractor = { module = "com.github.TeamNewPipe:NewPipeExtractor", version = "dev-SNAPSHOT" }
-newpipe-extractor = { module = "com.github.InfinityLoop1308:PipePipeExtractor", version.ref = "newpipeExtractor" }
+newpipe-extractor = { module = "com.github.mostafaalagamy:MetrolistExtractor", version.ref = "extractor" }
 
 kuromoji-ipadic = { module = "com.atilika.kuromoji:kuromoji-ipadic", version.ref = "kuromojiIpadic" }
 


### PR DESCRIPTION
This PR changes the extractor to [MetrolistExtractor](https://github.com/mostafaalagamy/MetrolistExtractor) the one metrolist currently uses.
This fixes the web remix client failing to parse the deobfuscation function which also fixes premium audio quality not being available to premium subscribers, because it was using android vr client which doesnt support it.

Original error:
<img width="1080" height="1241" alt="deobf-error" src="https://github.com/user-attachments/assets/0c21454c-4a1f-4ea2-8915-43eda960c6ba" />

With MetrolistExtractor:
<img width="1080" height="1234" alt="working-deobf" src="https://github.com/user-attachments/assets/44926170-038e-4a8d-ae74-e45e9423db9e" />

Original best quality:
<img width="1080" height="1152" alt="free-quality" src="https://github.com/user-attachments/assets/0a3da073-88b5-4307-aa05-5902d0178f1a" />

With Metrolist Extractor:
<img width="1080" height="1120" alt="premium-quality" src="https://github.com/user-attachments/assets/bee8bc51-8934-44cd-9c3f-9a4aa40b7bf6" />

