### PR TITLE
Remove unnecessary explicit multidex as it enabled by default

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -27,7 +27,6 @@ android {
         versionCode = 129
         versionName = "12.4.6"
 
-        multiDexEnabled = true
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
         
@@ -211,8 +210,6 @@ dependencies {
     implementation(libs.ktor.serialization.json)
 
     coreLibraryDesugaring(libs.desugaring)
-
-    implementation(libs.multidex)
 
     implementation(libs.timber)
     testImplementation(libs.junit)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,6 @@ hilt = "2.57.1"
 ktor = "3.3.0"
 ksp = "2.2.20-2.0.3"
 jsoup = "1.21.2"
-multidex = "2.0.1"
 coil = "3.3.0"
 guava = "33.5.0-jre"
 coroutinesGuava = "1.10.2"
@@ -103,8 +102,6 @@ desugaring = { module = "com.android.tools:desugar_jdk_libs", version.ref = "des
 junit = { module = "junit:junit", version.ref = "junit" }
 
 timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
-
-multidex = { module = "androidx.multidex:multidex", version.ref = "multidex" }
 
 #newpipe-extractor = { module = "com.github.libre-tube:NewPipeExtractor", version = "70abbdb" }
 #newpipe-extractor = { module = "com.github.TeamNewPipe:NewPipeExtractor", version = "dev-SNAPSHOT" }


### PR DESCRIPTION
It is on by default starting from Android 5 while this app requires an even never android version so we obviously don't need it.