### PR TITLE
Refactor bottom sheet drag logic into reusable modifier

### DIFF
--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/component/BottomSheet.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/component/BottomSheet.kt
@@ -73,25 +73,9 @@ fun BottomSheet(
                         .roundToPx()
                         .coerceAtLeast(0)
                 IntOffset(x = 0, y = y)
-            }.pointerInput(state) {
-                val velocityTracker = VelocityTracker()
-
-                detectVerticalDragGestures(
-                    onVerticalDrag = { change, dragAmount ->
-                        velocityTracker.addPointerInputChange(change)
-                        state.dispatchRawDelta(dragAmount)
-                    },
-                    onDragCancel = {
-                        velocityTracker.resetTracking()
-                        state.snapTo(state.collapsedBound)
-                    },
-                    onDragEnd = {
-                        val velocity = -velocityTracker.calculateVelocity().y
-                        velocityTracker.resetTracking()
-                        state.performFling(velocity, onDismiss)
-                    },
-                )
-            }.clip(
+            }
+            .bottomSheetDraggable(state, onDismiss)
+            .clip(
                 RoundedCornerShape(
                     topStart = if (!state.isExpanded) 16.dp else 0.dp,
                     topEnd = if (!state.isExpanded) 16.dp else 0.dp,
@@ -348,6 +332,32 @@ fun rememberBottomSheetState(
             coroutineScope = coroutineScope,
             animatable = animatable,
             collapsedBound = collapsedBound,
+        )
+    }
+}
+
+@Composable
+fun Modifier.bottomSheetDraggable(
+    state: BottomSheetState,
+    onDismiss: (() -> Unit)? = null,
+): Modifier {
+    return this.pointerInput(state) {
+        val velocityTracker = VelocityTracker()
+
+        detectVerticalDragGestures(
+            onVerticalDrag = { change, dragAmount ->
+                velocityTracker.addPointerInputChange(change)
+                state.dispatchRawDelta(dragAmount)
+            },
+            onDragCancel = {
+                velocityTracker.resetTracking()
+                state.snapTo(state.collapsedBound)
+            },
+            onDragEnd = {
+                val velocity = -velocityTracker.calculateVelocity().y
+                velocityTracker.resetTracking()
+                state.performFling(velocity, onDismiss)
+            },
         )
     }
 }

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/player/Queue.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/player/Queue.kt
@@ -503,6 +503,7 @@ fun Queue(
                 // Current playing song header
                 stickyHeader {
                     CurrentSongHeader(
+                        sheetState = state,
                         mediaMetadata = mediaMetadata,
                         isPlaying = isPlaying,
                         repeatMode = repeatMode,

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/player/QueueComponents.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/player/QueueComponents.kt
@@ -61,6 +61,7 @@ import moe.koiverse.archivetune.ui.component.ActionPromptDialog
 import moe.koiverse.archivetune.ui.component.BottomSheetPageState
 import moe.koiverse.archivetune.ui.component.BottomSheetState
 import moe.koiverse.archivetune.ui.component.MenuState
+import moe.koiverse.archivetune.ui.component.bottomSheetDraggable
 import moe.koiverse.archivetune.ui.menu.PlayerMenu
 import moe.koiverse.archivetune.ui.utils.ShowMediaInfo
 import moe.koiverse.archivetune.utils.makeTimeString
@@ -72,6 +73,7 @@ import kotlin.math.roundToInt
  */
 @Composable
 fun CurrentSongHeader(
+    sheetState: BottomSheetState,
     mediaMetadata: MediaMetadata?,
     isPlaying: Boolean,
     repeatMode: Int,
@@ -95,6 +97,7 @@ fun CurrentSongHeader(
             .fillMaxWidth()
             .background(backgroundColor)
             .windowInsetsPadding(WindowInsets.systemBars.only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal))
+            .bottomSheetDraggable(sheetState)
             .pointerInput(Unit) { detectTapGestures { } } // Block clicks while allowing drag
             .padding(horizontal = 16.dp, vertical = 12.dp)
     ) {


### PR DESCRIPTION
Extracted vertical drag gesture handling from BottomSheet into a new Modifier.bottomSheetDraggable extension for reuse. Updated CurrentSongHeader and BottomSheet to use the new modifier, improving code reuse and maintainability. Also passed sheetState to CurrentSongHeader for proper drag handling.