### PR TITLE
(feat): Add option to crop YouTube thumbnail to 1:1

### DIFF
--- a/app/src/main/kotlin/moe/koiverse/archivetune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/constants/PreferenceKeys.kt
@@ -24,6 +24,7 @@ val UseNewMiniPlayerDesignKey = booleanPreferencesKey("useNewMiniPlayerDesign")
 val HidePlayerThumbnailKey = booleanPreferencesKey("hidePlayerThumbnail")
 val ArchiveTuneCanvasKey = booleanPreferencesKey("archiveTuneCanvas")
 val ThumbnailCornerRadiusKey = floatPreferencesKey("thumbnailCornerRadius")
+val CropThumbnailToSquareKey = booleanPreferencesKey("cropThumbnailToSquare")
 val SeekExtraSeconds = booleanPreferencesKey("seekExtraSeconds")
 val DisableBlurKey = booleanPreferencesKey("disableBlur")
 

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/player/MiniPlayer.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/player/MiniPlayer.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -75,6 +76,7 @@ import moe.koiverse.archivetune.constants.MiniPlayerHeight
 import moe.koiverse.archivetune.constants.SwipeSensitivityKey
 import moe.koiverse.archivetune.constants.ThumbnailCornerRadius
 import moe.koiverse.archivetune.constants.UseNewMiniPlayerDesignKey
+import moe.koiverse.archivetune.constants.CropThumbnailToSquareKey
 import moe.koiverse.archivetune.db.entities.ArtistEntity
 import moe.koiverse.archivetune.extensions.togglePlayPause
 import moe.koiverse.archivetune.models.MediaMetadata
@@ -373,6 +375,7 @@ private fun LegacyMiniMediaInfo(
     pureBlack: Boolean,
     modifier: Modifier = Modifier,
 ) {
+    val cropThumbnailToSquare by rememberPreference(CropThumbnailToSquareKey, false)
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = modifier,
@@ -390,6 +393,7 @@ private fun LegacyMiniMediaInfo(
                 contentScale = ContentScale.FillBounds,
                 modifier = Modifier
                     .fillMaxSize()
+                    .let { if (cropThumbnailToSquare) it.aspectRatio(1f) else it }
                     .graphicsLayer(
                         renderEffect = BlurEffect(
                             radiusX = 75f,
@@ -403,9 +407,10 @@ private fun LegacyMiniMediaInfo(
             AsyncImage(
                 model = mediaMetadata.thumbnailUrl,
                 contentDescription = null,
-                contentScale = ContentScale.Fit,
+                contentScale = if (cropThumbnailToSquare) ContentScale.Crop else ContentScale.Fit,
                 modifier = Modifier
                     .fillMaxSize()
+                    .let { if (cropThumbnailToSquare) it.aspectRatio(1f) else it }
                     .clip(RoundedCornerShape(ThumbnailCornerRadius)),
             )
 

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/player/Thumbnail.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/player/Thumbnail.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -85,6 +86,7 @@ import moe.koiverse.archivetune.constants.SeekExtraSeconds
 import moe.koiverse.archivetune.constants.SwipeThumbnailKey
 import moe.koiverse.archivetune.constants.ArchiveTuneCanvasKey
 import moe.koiverse.archivetune.constants.ThumbnailCornerRadiusKey
+import moe.koiverse.archivetune.constants.CropThumbnailToSquareKey
 import moe.koiverse.archivetune.constants.HidePlayerThumbnailKey
 import moe.koiverse.archivetune.extensions.metadata
 import moe.koiverse.archivetune.innertube.YouTube
@@ -125,6 +127,7 @@ fun Thumbnail(
         key = ThumbnailCornerRadiusKey,
         defaultValue = 16f
     )
+    val cropThumbnailToSquare by rememberPreference(CropThumbnailToSquareKey, false)
     val canSkipPrevious by playerConnection.canSkipPrevious.collectAsState()
     val canSkipNext by playerConnection.canSkipNext.collectAsState()
     
@@ -460,13 +463,14 @@ fun Thumbnail(
                                             )
                                         }
                                     } else {
-                                        // Blurred 
+                                        // Blurred
                                         AsyncImage(
                                             model = item.mediaMetadata.artworkUri?.toString(),
                                             contentDescription = null,
                                             contentScale = ContentScale.FillBounds,
                                             modifier = Modifier
                                                 .fillMaxSize()
+                                                .let { if (cropThumbnailToSquare) it.aspectRatio(1f) else it }
                                                 .graphicsLayer(
                                                     renderEffect = BlurEffect(radiusX = 60f, radiusY = 60f),
                                                     alpha = 0.6f
@@ -486,8 +490,10 @@ fun Thumbnail(
                                             AsyncImage(
                                                 model = item.mediaMetadata.artworkUri?.toString(),
                                                 contentDescription = null,
-                                                contentScale = ContentScale.Fit,
-                                                modifier = Modifier.fillMaxSize()
+                                                contentScale = if (cropThumbnailToSquare) ContentScale.Crop else ContentScale.Fit,
+                                                modifier = Modifier
+                                                    .fillMaxSize()
+                                                    .let { if (cropThumbnailToSquare) it.aspectRatio(1f) else it }
                                             )
                                         }
                                     }

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/settings/AppearanceSettings.kt
@@ -92,6 +92,7 @@ import moe.koiverse.archivetune.constants.SwipeToSongKey
 import moe.koiverse.archivetune.constants.HidePlayerThumbnailKey
 import moe.koiverse.archivetune.constants.ArchiveTuneCanvasKey
 import moe.koiverse.archivetune.constants.ThumbnailCornerRadiusKey
+import moe.koiverse.archivetune.constants.CropThumbnailToSquareKey
 import moe.koiverse.archivetune.constants.DisableBlurKey
 import moe.koiverse.archivetune.ui.component.DefaultDialog
 import moe.koiverse.archivetune.ui.component.EnumListPreference
@@ -146,6 +147,10 @@ fun AppearanceSettings(
     val (thumbnailCornerRadius, onThumbnailCornerRadiusChange) = rememberPreference(
         key = ThumbnailCornerRadiusKey,
         defaultValue = 16f // default dp
+    )
+    val (cropThumbnailToSquare, onCropThumbnailToSquareChange) = rememberPreference(
+        CropThumbnailToSquareKey,
+        defaultValue = false
     )
     val (playerBackground, onPlayerBackgroundChange) =
         rememberEnumPreference(
@@ -528,6 +533,14 @@ fun AppearanceSettings(
             onRadiusSelected = { selectedRadius ->
                 Timber.tag("Thumbnail").d("Radius Selector: $selectedRadius")
             }
+        )
+
+        SwitchPreference(
+            title = { Text(stringResource(R.string.crop_thumbnail_to_square)) },
+            description = stringResource(R.string.crop_thumbnail_to_square_desc),
+            icon = { Icon(painterResource(R.drawable.image), null) },
+            checked = cropThumbnailToSquare,
+            onCheckedChange = onCropThumbnailToSquareChange
         )
 
 

--- a/app/src/main/res/values-ja/archivetune_strings.xml
+++ b/app/src/main/res/values-ja/archivetune_strings.xml
@@ -54,6 +54,8 @@
     <string name="maximum_volume">最大音量</string>
     <string name="hide_player_thumbnail">プレーヤーのサムネイルを非表示にする</string>
     <string name="hide_player_thumbnail_desc">プレーヤーでアルバムのアートワークをアプリのロゴに置き換える</string>
+    <string name="crop_thumbnail_to_square">サムネイルを1:1にトリミング</string>
+    <string name="crop_thumbnail_to_square_desc">YouTubeサムネイルを16:9ではなく正方形で表示</string>
     <string name="already_in_playlist">すでにプレイリストにあります:</string>
     <plurals name="n_element">
         <item quantity="other">%d 要素</item>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -323,6 +323,8 @@
     <string name="custom_value">カスタム値</string>
     <string name="new_library_design">新しいライブラリのデザイン</string>
     <string name="new_library_design_description">新しいライブラリのデザインを有効にする(不安定な可能性があります)</string>
+    <string name="archivetune_canvas">ArchiveTune Canvas</string>
+    <string name="archivetune_canvas_desc">再生中にアルバムアートワークをアニメーション化 (BetterLyrics提供)</string>
     <string name="show_button1_description">Discord Richのボタン1の表示を切り替え プレゼンス</string>
     <string name="show_button2_description">Discord のボタン 2 の表示を切り替えます リッチ プレゼンス</string>
     <string name="discord_activity_type">アクティビティ タイプ</string>

--- a/app/src/main/res/values-ko/archivetune_strings.xml
+++ b/app/src/main/res/values-ko/archivetune_strings.xml
@@ -54,6 +54,8 @@
     <string name="maximum_volume">최대 볼륨</string>
     <string name="hide_player_thumbnail">플레이어 썸네일 숨기기</string>
     <string name="hide_player_thumbnail_desc">플레이어의 앨범 아트워크를 앱 로고로 교체</string>
+    <string name="crop_thumbnail_to_square">썸네일을 1:1로 자르기</string>
+    <string name="crop_thumbnail_to_square_desc">YouTube 썸네일을 16:9 대신 정사각형으로 표시</string>
     <string name="already_in_playlist">이미 재생목록에 있음:</string>
     <plurals name="n_element">
         <item quantity="other">%d 요소</item>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -324,6 +324,8 @@
     <string name="custom_value">사용자 지정 값</string>
     <string name="new_library_design">썸네일 모서리 반경 사용자 지정</string>
     <string name="new_library_design_description">새 라이브러리 디자인</string>
+    <string name="archivetune_canvas">ArchiveTune Canvas</string>
+    <string name="archivetune_canvas_desc">재생 중 앨범 아트워크 애니메이션 (BetterLyrics 제공)</string>
     <string name="show_button1_description">새 라이브러리 디자인 활성화(불안정할 수 있음)</string>
     <string name="show_button2_description">Discord Rich의 버튼 1 가시성 전환 현재 상태</string>
     <string name="discord_activity_type">Discord Rich Presence에서 버튼 2의 가시성 전환</string>

--- a/app/src/main/res/values-vi/archivetune_strings.xml
+++ b/app/src/main/res/values-vi/archivetune_strings.xml
@@ -68,6 +68,8 @@
     <string name="maximum_volume">Âm lượng tối đa</string>
     <string name="hide_player_thumbnail">Ẩn Thumbnail Trình phát</string>
     <string name="hide_player_thumbnail_desc">Thay thế artwork album bằng logo ứng dụng trong trình phát</string>
+    <string name="crop_thumbnail_to_square">Cắt hình thu nhỏ thành 1:1</string>
+    <string name="crop_thumbnail_to_square_desc">Hiển thị hình thu nhỏ YouTube ở định dạng vuông thay vì 16:9</string>
     <string name="show_tags_in_library">Hiển thị thẻ trong thư viện</string>
     <string name="show_tags_in_library_desc">Hiển thị chip lọc thẻ trong thư viện</string>
     <string name="already_in_playlist">Đã có trong danh sách phát:</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -343,6 +343,8 @@
     <string name="discord_activity_type">Loại hoạt động</string>
     <string name="dark_theme_follow_system">Theo hệ thống</string>
     <string name="pure_black">Đen thuần</string>
+    <string name="archivetune_canvas">ArchiveTune Canvas</string>
+    <string name="archivetune_canvas_desc">Tạo hiệu ứng động cho artwork album khi phát (Được hỗ trợ bởi BetterLyrics)</string>
     <string name="disable_blur">Tắt hiệu ứng làm mờ</string>
     <string name="disable_blur_desc">Tắt hiệu ứng làm mờ trong toàn bộ ứng dụng</string>
     <string name="customize_navigation_tabs">Tùy chỉnh tab điều hướng</string>

--- a/app/src/main/res/values/archivetune_strings.xml
+++ b/app/src/main/res/values/archivetune_strings.xml
@@ -68,6 +68,8 @@
     <string name="maximum_volume">Maximum Volume</string>
     <string name="hide_player_thumbnail">Hide Player Thumbnail</string>
     <string name="hide_player_thumbnail_desc">Replace album artwork with app logo in player</string>
+    <string name="crop_thumbnail_to_square">Crop thumbnails to 1:1</string>
+    <string name="crop_thumbnail_to_square_desc">Display YouTube thumbnails in square format instead of 16:9</string>
     <string name="show_tags_in_library">Show tags in library</string>
     <string name="show_tags_in_library_desc">Show tag filter chips in the library</string>
     <string name="already_in_playlist">Already in playlist:</string>


### PR DESCRIPTION
Just add another small featured to crop YouTube thumbnail to 1:1 for **Player**... Yeah, only player.

## Screenshot
<img width="540" height="1200" alt="Screenshot_20260130-114703" src="https://github.com/user-attachments/assets/73ae85fb-1cad-4d9c-bd16-1f9e440f1c8c" />
<img width="540" height="1200" alt="Screenshot_20260130-114547" src="https://github.com/user-attachments/assets/1bdf5e9a-461c-462f-872a-4ac5a3af99f5" />
