### PR TITLE
fix: square thumbnail not turn back after off

### DIFF
--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/component/Items.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/component/Items.kt
@@ -1173,7 +1173,7 @@ fun ItemThumbnail(
     ) {
         val (cropThumbnailToSquare, _) = rememberPreference(CropThumbnailToSquareKey, false)
         val isYouTubeThumb = thumbnailUrl?.contains("ytimg.com", ignoreCase = true) == true
-        val shouldCropSquare = cropThumbnailToSquare && isYouTubeThumb
+        val shouldApplySquareCrop = cropThumbnailToSquare && isYouTubeThumb
         val widthPx = if (maxWidth == Dp.Infinity) null else with(density) { maxWidth.roundToPx().coerceAtLeast(1) }
         val heightPx = if (maxHeight == Dp.Infinity) null else with(density) { maxHeight.roundToPx().coerceAtLeast(1) }
 
@@ -1193,10 +1193,10 @@ fun ItemThumbnail(
                 AsyncImage(
                     model = request,
                     contentDescription = null,
-                    contentScale = ContentScale.Crop,
+                    contentScale = if (shouldApplySquareCrop) ContentScale.Crop else ContentScale.Fit,
                     modifier = Modifier
                         .fillMaxSize()
-                        .let { if (shouldCropSquare) it.aspectRatio(1f) else it }
+                        .let { if (shouldApplySquareCrop) it.aspectRatio(1f) else it }
                 )
             } else {
                 Box(
@@ -1275,7 +1275,7 @@ fun LocalThumbnail(
     ) {
         val (cropThumbnailToSquare, _) = rememberPreference(CropThumbnailToSquareKey, false)
         val isYouTubeThumb = thumbnailUrl?.contains("ytimg.com", ignoreCase = true) == true
-        val shouldCropSquare = cropThumbnailToSquare && isYouTubeThumb
+        val shouldApplySquareCrop = cropThumbnailToSquare && isYouTubeThumb
         val widthPx = if (maxWidth == Dp.Infinity) null else with(density) { maxWidth.roundToPx().coerceAtLeast(1) }
         val heightPx = if (maxHeight == Dp.Infinity) null else with(density) { maxHeight.roundToPx().coerceAtLeast(1) }
         val request = remember(thumbnailUrl, widthPx, heightPx) {
@@ -1292,8 +1292,8 @@ fun LocalThumbnail(
         AsyncImage(
             model = request,
             contentDescription = null,
-            contentScale = ContentScale.Crop,
-            modifier = Modifier.fillMaxSize().let { if (shouldCropSquare) it.aspectRatio(1f) else it }
+            contentScale = if (shouldApplySquareCrop) ContentScale.Crop else ContentScale.Fit,
+            modifier = Modifier.fillMaxSize().let { if (shouldApplySquareCrop) it.aspectRatio(1f) else it }
         )
 
         AnimatedVisibility(


### PR DESCRIPTION
### Description
Fixed an issue where video thumbnails (from YouTube) were not properly reverting to their natural 16:9 aspect ratio when the "Crop thumbnail to 1:1" setting was disabled.

### Changes
- Updated `ItemThumbnail` and `LocalThumbnail` components in `Items.kt`:
    - Changed `contentScale` of `AsyncImage` to be conditional:
        - `ContentScale.Crop` when the square crop should be applied.
        - `ContentScale.Fit` when the square crop should not be applied (allowing 16:9 images to be letterboxed instead of cropped).
    - Renamed the internal variable `shouldCropSquare` to `shouldApplySquareCrop` for better clarity.
    - Maintained the conditional `aspectRatio(1f)` modifier on the image to ensure correct layout within the 1:1 container.

These changes ensure that YouTube video thumbnails are displayed correctly according to the user's preference, while non-video thumbnails remain unaffected by the toggle. This also aligns the implementation with the pattern already used in the player's `Thumbnail.kt`.

### Verification Checklist
- [x] Video thumbnails display in 1:1 with cropped content when "Crop to 1:1" is enabled.
- [x] Video thumbnails display in 1:1 with 16:9 content (letterboxed) when "Crop to 1:1" is disabled.
- [x] Non-video thumbnails are unaffected by the setting (remain consistent).
- [x] The `cropThumbnailToSquare` preference works correctly and updates the UI immediately.
- [x] Player thumbnails continue to work as expected.

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved thumbnail scaling behavior to conditionally apply crop or fit scaling based on square-crop settings, ensuring thumbnails display correctly across different contexts.