### PR TITLE
Feat: Add random color palette

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ core.*
 /server/data/
 /server/.env
 /server/package-lock.json
+
+# AI code review
+/.qodo/

--- a/app/src/main/kotlin/moe/koiverse/archivetune/App.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/App.kt
@@ -25,6 +25,9 @@ import coil3.request.allowHardware
 import coil3.request.crossfade
 import moe.koiverse.archivetune.constants.*
 import moe.koiverse.archivetune.extensions.*
+import moe.koiverse.archivetune.ui.screens.settings.ThemePalettes
+import moe.koiverse.archivetune.ui.theme.ThemeSeedPalette
+import moe.koiverse.archivetune.ui.theme.ThemeSeedPaletteCodec
 import moe.koiverse.archivetune.utils.dataStore
 import moe.koiverse.archivetune.utils.PreferenceStore
 import moe.koiverse.archivetune.utils.get
@@ -138,6 +141,21 @@ class App : Application(), SingletonImageLoader.Factory {
 
                 if (prefs[UseLoginForBrowse] != false) {
                     YouTube.useLoginForBrowse = true
+                }
+                
+                // Apply random theme on startup if enabled
+                if (prefs[RandomThemeOnStartupKey] == true) {
+                    val randomPalette = ThemePalettes.generateRandomPalette()
+                    val seedPalette = ThemeSeedPalette(
+                        primary = randomPalette.primary,
+                        secondary = randomPalette.secondary,
+                        tertiary = randomPalette.tertiary,
+                        neutral = randomPalette.neutral
+                    )
+                    val encodedPalette = ThemeSeedPaletteCodec.encodeForPreference(seedPalette, "Random")
+                    dataStore.edit { settings ->
+                        settings[CustomThemeColorKey] = encodedPalette
+                    }
                 }
                 
                 isInitialized = true

--- a/app/src/main/kotlin/moe/koiverse/archivetune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/constants/PreferenceKeys.kt
@@ -18,6 +18,7 @@ import java.time.ZoneOffset
 
 val DynamicThemeKey = booleanPreferencesKey("dynamicTheme")
 val CustomThemeColorKey = stringPreferencesKey("customThemeColor")
+val RandomThemeOnStartupKey = booleanPreferencesKey("randomThemeOnStartup")
 val DarkModeKey = stringPreferencesKey("darkMode")
 val PureBlackKey = booleanPreferencesKey("pureBlack")
 val UseSystemFontKey = booleanPreferencesKey("useSystemFont")

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/settings/AppearanceSettings.kt
@@ -79,6 +79,7 @@ import moe.koiverse.archivetune.constants.UseNewMiniPlayerDesignKey
 import moe.koiverse.archivetune.constants.PlayerBackgroundStyle
 import moe.koiverse.archivetune.constants.PlayerBackgroundStyleKey
 import moe.koiverse.archivetune.constants.PureBlackKey
+import moe.koiverse.archivetune.constants.RandomThemeOnStartupKey
 import moe.koiverse.archivetune.constants.UseSystemFontKey
 import moe.koiverse.archivetune.constants.PlayerButtonsStyle
 import moe.koiverse.archivetune.constants.PlayerButtonsStyleKey
@@ -127,6 +128,10 @@ fun AppearanceSettings(
     val (dynamicTheme, onDynamicThemeChange) = rememberPreference(
         DynamicThemeKey,
         defaultValue = true
+    )
+    val (randomThemeOnStartup, onRandomThemeOnStartupChange) = rememberPreference(
+        RandomThemeOnStartupKey,
+        defaultValue = false
     )
     val (darkMode, onDarkModeChange) = rememberEnumPreference(
         DarkModeKey,
@@ -407,6 +412,16 @@ fun AppearanceSettings(
             checked = dynamicTheme,
             onCheckedChange = onDynamicThemeChange,
         )
+
+        AnimatedVisibility(visible = !dynamicTheme || Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            SwitchPreference(
+                title = { Text(stringResource(R.string.random_theme_on_startup)) },
+                description = stringResource(R.string.random_theme_on_startup_desc),
+                icon = { Icon(painterResource(R.drawable.shuffle), null) },
+                checked = randomThemeOnStartup,
+                onCheckedChange = onRandomThemeOnStartupChange,
+            )
+        }
 
         AnimatedVisibility(visible = !dynamicTheme || Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
             PreferenceEntry(

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/settings/PalettePickerScreen.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/settings/PalettePickerScreen.kt
@@ -837,6 +837,51 @@ object ThemePalettes {
     fun findById(id: String): ThemePalette? {
         return allPalettes.find { it.id == id }
     }
+    
+    fun getRandomPalette(): ThemePalette {
+        return allPalettes.random()
+    }
+    
+    fun generateRandomPalette(): ThemePalette {
+        // Generate random vibrant colors using HCT color space for better visual quality
+        val random = java.util.Random()
+        
+        // Generate a random hue for primary color
+        val primaryHue = random.nextFloat() * 360f
+        val primarySaturation = 0.5f + random.nextFloat() * 0.4f // 50-90% saturation
+        val primaryLightness = 0.4f + random.nextFloat() * 0.25f // 40-65% lightness
+        
+        val primary = hctToColor(primaryHue, primarySaturation, primaryLightness)
+        
+        // Generate secondary color by shifting hue by 30-90 degrees
+        val secondaryHue = (primaryHue + 30f + random.nextFloat() * 60f) % 360f
+        val secondary = hctToColor(secondaryHue, primarySaturation * 0.9f, primaryLightness * 1.1f)
+        
+        // Generate tertiary color by shifting hue in opposite direction
+        val tertiaryHue = (primaryHue - 30f - random.nextFloat() * 60f + 360f) % 360f
+        val tertiary = hctToColor(tertiaryHue, primarySaturation * 0.8f, primaryLightness * 0.95f)
+        
+        // Generate neutral color with low saturation
+        val neutralHue = (primaryHue + random.nextFloat() * 20f - 10f) % 360f
+        val neutral = hctToColor(neutralHue, 0.1f, primaryLightness * 0.8f)
+        
+        return ThemePalette(
+            id = "random_" + System.currentTimeMillis(),
+            nameResId = R.string.palette_custom,
+            primary = primary,
+            secondary = secondary,
+            tertiary = tertiary,
+            neutral = neutral
+        )
+    }
+    
+    private fun hctToColor(hue: Float, saturation: Float, lightness: Float): Color {
+        // Convert HCT-like values to Color
+        // This is a simplified conversion using HSV as approximation
+        val hsv = floatArrayOf(hue, saturation, lightness)
+        val argb = android.graphics.Color.HSVToColor(hsv)
+        return Color(argb)
+    }
 }
 
 private fun Color.toHexString(): String {

--- a/app/src/main/res/values-ja/archivetune_strings.xml
+++ b/app/src/main/res/values-ja/archivetune_strings.xml
@@ -8,7 +8,7 @@
     <string name="no_title">タイトルなし</string>
     <string name="unknown_artist">不明なアーティスト</string>
     <string name="unknown_item_type">不明なアイテムの種類</string>
-    <string name="loading_charts">チャートを読み込んでいます...</string>
+    <string name="loading_charts">チャートを読み込んでいます…</string>
     <string name="retry_button">リトライ</string>
     <string name="album_cover_desc">アルバムカバー</string>
     <string name="top_music_videos">人気のミュージック ビデオ</string>
@@ -41,7 +41,6 @@
     <string name="added_to_play_next">次にプレイするために追加されました</string>
     <string name="added_to_queue">キューに追加されました</string>
     <string name="remove_from_cache">キャッシュから削除</string>
-    <string name="copy_link">リンクをコピー</string>
     <string name="select">すべて選択</string>
     <string name="like_all">みんなと同じように</string>
     <string name="dislike_all">全部嫌い</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -66,6 +66,8 @@
     <string name="playlist_is_empty">プレイリストは空です</string>
     <string name="remove_download_playlist_confirm">「%s」プレイリストのすべての曲をダウンロードした曲のストレージから削除してもよろしいですか?</string>
     <string name="delete_playlist_confirm">本当にプレイリストを削除しますか? \"%s\"?</string>
+    <string name="change_playlist_cover">プレイリストカバーを変更</string>
+    <string name="remove_playlist_cover">カバーを削除</string>
     <!-- Button -->
     <string name="retry">再試行</string>
     <string name="radio">ラジオ</string>
@@ -96,6 +98,17 @@
     <string name="refetch">再フェッチ</string>
     <string name="share">共有</string>
     <string name="delete">削除</string>
+    <string name="together_participants">参加者</string>
+    <string name="together_connected_count">%1$d 人接続中</string>
+    <string name="together_role_host">ホスト</string>
+    <string name="together_role_guest">ゲスト</string>
+    <string name="together_pending_approval">承認待ち</string>
+    <string name="together_waiting_approval">承認待ち</string>
+    <string name="together_host_left_session">ホストがセッションを離れました</string>
+    <string name="together_kick">Kick</string>
+    <string name="together_ban">Ban</string>
+    <string name="together_kick_confirm">%1$s をKickしますか?</string>
+    <string name="together_ban_confirm">%1$s をBanしますか?</string>
     <string name="remove_from_history">履歴から削除</string>
     <string name="remove_from_playlist">プレイリストから削除</string>
     <string name="remove_from_queue">キューから削除</string>
@@ -202,6 +215,8 @@
     <string name="appearance">外観</string>
     <string name="theme">テーマ</string>
     <string name="enable_dynamic_theme">ダイナミックテーマを有効にする</string>
+    <string name="random_theme_on_startup">起動時にランダムテーマ</string>
+    <string name="random_theme_on_startup_desc">アプリ起動時にランダムなカラーパレットを適用</string>
     <!-- Color Palette -->
     <string name="color_palette">カラーパレット</string>
     <string name="customize_theme_colors">アプリのテーマカラーを選択</string>
@@ -232,7 +247,7 @@
     <string name="palette_warm_amber">アンバー</string>
     <string name="palette_tangerine_blast">タンジェリン</string>
     <string name="palette_peach">ピーチ</string>
-    <string name="palette_mango">マンゴー</string>
+    <string name="palette_mango">망고</string>
     <!-- Purples -->
     <string name="palette_royal_purple">ロイヤルパープル</string>
     <string name="palette_lavender_dream">ラベンダー</string>
@@ -384,6 +399,8 @@
     <string name="auto_load_more_desc">可能であれば、キューの終わりに達したときに自動的に曲を追加</string>
     <string name="skip_silence">無音部分をスキップ</string>
     <string name="audio_normalization">音声正規化</string>
+    <string name="audio_offload">オーディオオフロード</string>
+    <string name="audio_offload_desc">サポートされているデバイスで低電力ハードウェアデコードを使用してオーディオを再生します。一部のオーディオ処理機能は無効になります。</string>
     <string name="auto_skip_next_on_error">エラー発生時は次の曲に自動スキップ</string>
     <string name="auto_skip_next_on_error_desc">連続再生エクスペリエンス</string>
     <string name="stop_music_on_task_clear">タスククリア時に音楽を停止</string>
@@ -533,7 +550,7 @@
     <string name="content_length_label">コンテンツの長さ</string>
     <string name="unknown_content_length">不明なコンテンツの長さ</string>
     <string name="format_label">フォーマット</string>
-    <string name="loading_format">フォーマットを読み込み中...</string>
+    <string name="loading_format">フォーマットを読み込み中…</string>
     <string name="buffer_health_label">バッファ状態</string>
     <string name="playback_speed_label">再生速度</string>
     <string name="state_label">状態</string>
@@ -641,4 +658,69 @@
     <!-- Playlist Suggestions -->
     <string name="you_might_like">あなた好み</string>
     <string name="refresh_suggestions">提案を更新</string>
+
+    <string name="music_together">ArchiveTune Music Together</string>
+    <string name="together_display_name">表示名</string>
+    <string name="together_display_name_placeholder">あなたの名前</string>
+    <string name="together_port">セッションポート</string>
+    <string name="together_allow_guests_add">ゲストは曲を追加できます</string>
+    <string name="together_allow_guests_control">ゲストは再生を制御できます</string>
+    <string name="together_require_approval">承認が必要</string>
+    <string name="together_lan">LAN</string>
+    <string name="together_online">オンライン</string>
+    <string name="together_join_link">リンク</string>
+    <string name="together_join_code">コード</string>
+    <string name="together_join_link_hint">参加リンクまたはコードを貼り付け</string>
+    <string name="together_join_code_hint">セッションコードを入力</string>
+    <string name="start_session">セッションを開始</string>
+    <string name="end_session">セッションを終了</string>
+    <string name="join_session">セッションに参加</string>
+    <string name="session_link">セッショリンク</string>
+    <string name="session_code">セッションコード</string>
+    <string name="participants">参加者</string>
+    <string name="pending_requests">参加リクエスト</string>
+    <string name="waiting_for_approval">承認待ち</string>
+    <string name="host">ホスト</string>
+    <string name="session_settings">セッション設定</string>
+    <string name="add_current_song">現在の曲を追加</string>
+    <string name="playback_controls">再生コントロール</string>
+    <string name="approve">承認</string>
+    <string name="deny">拒否</string>
+    <string name="enabled">有効</string>
+    <string name="disabled">無効</string>
+    <string name="invalid_link">無効なリンク</string>
+    <string name="invalid_code">無効なコード</string>
+    <string name="not_allowed">許可されていません</string>
+    <string name="network_unavailable">ネットワークが利用できません</string>
+    <string name="together_online_not_configured">オンラインセッションは設定されていません</string>
+    <string name="together_server_unreachable">サーバーに到達できません</string>
+    <string name="together_connection_timed_out">接続がタイムアウトしました</string>
+    <string name="together_session_not_found">セッションが見つかりません</string>
+    <string name="together_server_error">サーバーエラー、後でもう一度お試しください</string>
+    <string name="leave">離れる</string>
+    <string name="join">参加</string>
+    <string name="joined">参加しました</string>
+    <string name="loading">読み込み中</string>
+    <string name="connecting">接続中…</string>
+    <string name="copy_link">リンクをコピー</string>
+
+    <string name="together_host_section">ホスト</string>
+    <string name="together_join_section">参加</string>
+    <string name="together_status">ステータス</string>
+    <string name="together_idle">セッションしていません</string>
+    <string name="together_hosting">セッションをホスト中</string>
+    <string name="together_joining">セッションに参加中</string>
+    <string name="together_connected">接続済み</string>
+    <string name="together_error_state">エラー</string>
+
+    <string name="got_it">了解</string>
+    <string name="together_dont_show_again">これを二度と表示しない</string>
+    <string name="together_welcome_title">ArchiveTune Music Togetherへようこそ</string>
+    <string name="together_welcome_body">Music Togetherを使用すると、複数のデバイスで同期キューと再生を備えたライブセッションを共有できます。</string>
+    <string name="together_welcome_host_title">セッションをホスト</string>
+    <string name="together_welcome_host_body">「セッションを開始」をタップし、セッションリンクを共有します。ホストしている間はArchiveTuneをバックグラウンドで開いたままにしてください。</string>
+    <string name="together_welcome_join_title">別のデバイスから参加</string>
+    <string name="together_welcome_join_body">オープンな共有リンク、またはコードを入力して「参加」をタップします。キューと再生はホストに従います。</string>
+    <string name="together_welcome_permissions_title">権限と安全</string>
+    <string name="together_welcome_permissions_body">ホストは、曲の追加、再生の制御、参加の承認要求をゲストに許可するかどうかを決定できます。</string>
 </resources>

--- a/app/src/main/res/values-vi/archivetune_strings.xml
+++ b/app/src/main/res/values-vi/archivetune_strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="explore">Khám phá</string>
     <string name="local_history">Cục bộ</string>
     <string name="remote_history">Từ xa</string>
@@ -8,7 +8,7 @@
     <string name="no_title">Không có tiêu đề</string>
     <string name="unknown_artist">Nghệ sĩ không xác định</string>
     <string name="unknown_item_type">Loại mục không xác định</string>
-    <string name="loading_charts">Đang tải bảng xếp hạng...</string>
+    <string name="loading_charts">Đang tải bảng xếp hạng…</string>
     <string name="retry_button">Thử lại</string>
     <string name="album_cover_desc">Bìa album</string>
     <string name="top_music_videos">Video âm nhạc hàng đầu</string>
@@ -41,7 +41,6 @@
     <string name="added_to_play_next">Đã thêm để phát tiếp theo</string>
     <string name="added_to_queue">Đã thêm vào hàng đợi</string>
     <string name="remove_from_cache">Xóa khỏi cache</string>
-    <string name="copy_link">Sao chép liên kết</string>
     <string name="select">Chọn tất cả</string>
     <string name="manage_tags">Quản lý Thẻ</string>
     <string name="add_tag">Thêm Thẻ</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -66,6 +66,8 @@
     <string name="playlist_is_empty">Danh sách phát trống</string>
     <string name="remove_download_playlist_confirm">Bạn có muốn xóa tất cả bài hát của \"%s\" khỏi mục đã tải xuống không?</string>
     <string name="delete_playlist_confirm">Bạn có muốn xóa danh sách phát \"%s\" không?</string>
+    <string name="change_playlist_cover">Thay đổi ảnh bìa danh sách phát</string>
+    <string name="remove_playlist_cover">Xóa ảnh bìa</string>
     <!-- Button -->
     <string name="retry">Thử lại</string>
     <string name="radio">Radio</string>
@@ -96,6 +98,17 @@
     <string name="refetch">Tải lại</string>
     <string name="share">Chia sẻ</string>
     <string name="delete">Xóa</string>
+    <string name="together_participants">Người tham gia</string>
+    <string name="together_connected_count">%1$d đã kết nối</string>
+    <string name="together_role_host">Người tổ chức</string>
+    <string name="together_role_guest">Khách</string>
+    <string name="together_pending_approval">Chờ phê duyệt</string>
+    <string name="together_waiting_approval">Đang chờ phê duyệt</string>
+    <string name="together_host_left_session">Người tổ chức đã rời khỏi phiên</string>
+    <string name="together_kick">Đuổi</string>
+    <string name="together_ban">Cấm</string>
+    <string name="together_kick_confirm">Đuổi %1$s?</string>
+    <string name="together_ban_confirm">Cấm %1$s?</string>
     <string name="remove_from_history">Xóa khỏi lịch sử</string>
     <string name="remove_from_playlist">Xóa khỏi danh sách phát</string>
     <string name="remove_from_queue">Xóa khỏi hàng đợi</string>
@@ -216,6 +229,8 @@
     <string name="appearance">Giao diện</string>
     <string name="theme">Giao diện</string>
     <string name="enable_dynamic_theme">Bật giao diện động</string>
+    <string name="random_theme_on_startup">Chủ đề ngẫu nhiên khi khởi động</string>
+    <string name="random_theme_on_startup_desc">Áp dụng bảng màu ngẫu nhiên mỗi khi app khởi động</string>
     <string name="use_system_font">Sử dụng font hệ thống</string>
     <string name="use_system_font_desc">Sử dụng font thiết bị thay vì font ứng dụng</string>
     <!-- Color Palette -->
@@ -402,6 +417,8 @@
     <string name="auto_load_more_desc">Tự động thêm nhiều bài hát khi đến cuối hàng đợi. Tắt khi chế độ lặp đang hoạt động</string>
     <string name="skip_silence">Bỏ qua im lặng</string>
     <string name="audio_normalization">Chuẩn hóa âm thanh</string>
+    <string name="audio_offload">Giải phóng âm thanh</string>
+    <string name="audio_offload_desc">Cho phép các thiết bị được hỗ trợ phát âm thanh bằng giải mã phần cứng công suất thấp. Một số tính năng xử lý âm thanh sẽ bị vô hiệu hóa.</string>
     <string name="auto_skip_next_on_error">Tự động chuyển sang bài tiếp theo khi có lỗi</string>
     <string name="auto_skip_next_on_error_desc">Đảm bảo trải nghiệm phát nhạc liên tục của bạn</string>
     <string name="stop_music_on_task_clear">Dừng nhạc khi xóa tác vụ</string>
@@ -579,7 +596,7 @@ ArchiveTune sẽ chỉ trích xuất token của bạn, và mọi thứ khác đ
     <string name="content_length_label">Độ dài nội dung</string>
     <string name="unknown_content_length">Độ dài nội dung không xác định</string>
     <string name="format_label">Định dạng</string>
-    <string name="loading_format">Đang tải định dạng...</string>
+    <string name="loading_format">Đang tải định dạng…</string>
     <string name="buffer_health_label">Sức khỏe Buffer</string>
     <string name="playback_speed_label">Tốc độ phát</string>
     <string name="state_label">Trạng thái</string>
@@ -652,4 +669,69 @@ ArchiveTune sẽ chỉ trích xuất token của bạn, và mọi thứ khác đ
     <!-- Playlist Suggestions -->
     <string name="you_might_like">Có thể bạn sẽ thích</string>
     <string name="refresh_suggestions">Làm mới gợi ý</string>
+
+    <string name="music_together">ArchiveTune Music Together</string>
+    <string name="together_display_name">Tên hiển thị</string>
+    <string name="together_display_name_placeholder">Tên của bạn</string>
+    <string name="together_port">Cổng phiên</string>
+    <string name="together_allow_guests_add">Khách có thể thêm bài hát</string>
+    <string name="together_allow_guests_control">Khách có thể điều khiển phát nhạc</string>
+    <string name="together_require_approval">Yêu cầu phê duyệt</string>
+    <string name="together_lan">Mạng LAN</string>
+    <string name="together_online">Trực tuyến</string>
+    <string name="together_join_link">Liên kết</string>
+    <string name="together_join_code">Mã</string>
+    <string name="together_join_link_hint">Dán liên kết hoặc mã tham gia</string>
+    <string name="together_join_code_hint">Nhập mã phiên</string>
+    <string name="start_session">Bắt đầu phiên</string>
+    <string name="end_session">Kết thúc phiên</string>
+    <string name="join_session">Tham gia phiên</string>
+    <string name="session_link">Liên kết phiên</string>
+    <string name="session_code">Mã phiên</string>
+    <string name="participants">Người tham gia</string>
+    <string name="pending_requests">Yêu cầu tham gia</string>
+    <string name="waiting_for_approval">Đang chờ phê duyệt</string>
+    <string name="host">Người tổ chức</string>
+    <string name="session_settings">Cài đặt phiên</string>
+    <string name="add_current_song">Thêm bài hát hiện tại</string>
+    <string name="playback_controls">Điều khiển phát nhạc</string>
+    <string name="approve">Phê duyệt</string>
+    <string name="deny">Từ chối</string>
+    <string name="enabled">Đã bật</string>
+    <string name="disabled">Đã tắt</string>
+    <string name="invalid_link">Liên kết không hợp lệ</string>
+    <string name="invalid_code">Mã không hợp lệ</string>
+    <string name="not_allowed">Không được phép</string>
+    <string name="network_unavailable">Mạng không khả dụng</string>
+    <string name="together_online_not_configured">Phiên trực tuyến chưa được định cấu hình</string>
+    <string name="together_server_unreachable">Không thể kết nối máy chủ</string>
+    <string name="together_connection_timed_out">Kết nối đã hết thời gian chờ</string>
+    <string name="together_session_not_found">Không tìm thấy phiên</string>
+    <string name="together_server_error">Lỗi máy chủ, vui lòng thử lại sau</string>
+    <string name="leave">Rời đi</string>
+    <string name="join">Tham gia</string>
+    <string name="joined">Đã tham gia</string>
+    <string name="loading">Đang tải</string>
+    <string name="connecting">Đang kết nối…</string>
+    <string name="copy_link">Sao chép liên kết</string>
+
+    <string name="together_host_section">Tổ chức</string>
+    <string name="together_join_section">Tham gia</string>
+    <string name="together_status">Trạng thái</string>
+    <string name="together_idle">Không trong phiên</string>
+    <string name="together_hosting">Đang tổ chức phiên</string>
+    <string name="together_joining">Đang tham gia phiên</string>
+    <string name="together_connected">Đã kết nối</string>
+    <string name="together_error_state">Lỗi</string>
+
+    <string name="got_it">Hiểu rồi</string>
+    <string name="together_dont_show_again">Không hiển thị lại nữa</string>
+    <string name="together_welcome_title">Chào mừng đến với ArchiveTune Music Together</string>
+    <string name="together_welcome_body">Music Together cho phép nhiều thiết bị chia sẻ một phiên trực tiếp với hàng đợi đồng bộ và phát nhạc.</string>
+    <string name="together_welcome_host_title">Tổ chức một phiên</string>
+    <string name="together_welcome_host_body">Nhấn Bắt đầu phiên, sau đó chia sẻ liên kết phiên. Giữ ArchiveTune mở trong nền trong khi tổ chức.</string>
+    <string name="together_welcome_join_title">Tham gia từ thiết bị khác</string>
+    <string name="together_welcome_join_body">Mở liên kết được chia sẻ, hoặc nhập mã và nhấn Tham gia. Hàng đợi và phát nhạc của bạn sẽ theo người tổ chức.</string>
+    <string name="together_welcome_permissions_title">Quyền và an toàn</string>
+    <string name="together_welcome_permissions_body">Người tổ chức có thể quyết định liệu khách có thể thêm bài hát, điều khiển phát nhạc, hoặc yêu cầu phê duyệt để tham gia hay không.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -233,6 +233,8 @@
     <string name="appearance">Appearance</string>
     <string name="theme">Theme</string>
     <string name="enable_dynamic_theme">Enable dynamic theme</string>
+    <string name="random_theme_on_startup">Random theme on startup</string>
+    <string name="random_theme_on_startup_desc">Apply a random color palette every time the app starts</string>
     <string name="use_system_font">Use system font</string>
     <string name="use_system_font_desc">Use the device font instead of the app font</string>
     <!-- Color Palette -->
@@ -601,7 +603,7 @@ ArchiveTune will only extract your token, and everything else is stored locally.
     <string name="content_length_label">Content Length</string>
     <string name="unknown_content_length">Unknown content length</string>
     <string name="format_label">Format</string>
-    <string name="loading_format">Loading format...</string>
+    <string name="loading_format">Loading format…</string>
     <string name="buffer_health_label">Buffer Health</string>
     <string name="playback_speed_label">Playback Speed</string>
     <string name="state_label">State</string>


### PR DESCRIPTION
Add ability to apply a random color palette each time the app launches, with new preference toggle in appearance settings and randomized palette generation using HCT color space for visually appealing colors.

## Video testing

https://github.com/user-attachments/assets/8d2814dd-5681-4d77-88cd-2daff8e5e02f