### PR TITLE
Crossfade: A few improvements...

### DIFF
--- a/app/src/main/kotlin/moe/koiverse/archivetune/playback/CrossfadeAudio.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/playback/CrossfadeAudio.kt
@@ -35,6 +35,7 @@ internal class CrossfadeAudio(
     private val audioNormalizationEnabled: MutableStateFlow<Boolean>,
     private val maxSafeGainFactor: Float,
     private val overlapPlayerFactory: () -> ExoPlayer,
+    private val onCrossfadeStart: (MediaItem) -> Unit = {},
 ) {
     private var loopJob: Job? = null
 
@@ -59,6 +60,8 @@ internal class CrossfadeAudio(
     private val handoffDriftCorrectionThresholdMs = 220L
     private val handoffRampStartDriftToleranceMs = 120L
     private val handoffTimeoutMs = 5000L
+
+    fun isCrossfading(): Boolean = crossfadeActive
 
     fun start(scope: CoroutineScope) {
         if (loopJob?.isActive == true) return
@@ -202,6 +205,12 @@ internal class CrossfadeAudio(
 
     private fun beginOverlapCrossfade(fadeMs: Int, remainingMs: Long) {
         if (overlapPlayer == null) return
+
+        val targetIndex = overlapPrimedIndex
+        if (targetIndex != C.INDEX_UNSET && targetIndex < player.mediaItemCount) {
+            onCrossfadeStart(player.getMediaItemAt(targetIndex))
+        }
+
         crossfadeActive = true
         crossfadeStartElapsedMs = android.os.SystemClock.elapsedRealtime()
         crossfadeActiveDurationMs = min(fadeMs.toLong(), remainingMs).toInt().coerceAtLeast(1)

--- a/app/src/main/kotlin/moe/koiverse/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/playback/MusicService.kt
@@ -756,6 +756,33 @@ class MusicService :
                         .setSeekForwardIncrementMs(5000)
                         .build()
                 },
+                onCrossfadeStart = { mediaItem ->
+                    val metadata = mediaItem.metadata
+                    currentMediaMetadata.value = metadata
+                    // immediate update when media item transitions to avoid stale presence
+                    scope.launch {
+                        try {
+                            val token = dataStore.get(DiscordTokenKey, "")
+                            if (token.isNotBlank() && DiscordPresenceManager.isRunning()) {
+                                val mediaId = mediaItem.mediaId
+                                val song = if (mediaId != null) withContext(Dispatchers.IO) { database.song(mediaId).first() } else null
+                                val finalSong = song ?: metadata?.let { createTransientSongFromMedia(it) }
+
+                                if (canUpdatePresence()) {
+                                    DiscordPresenceManager.updateNow(
+                                        context = this@MusicService,
+                                        token = token,
+                                        song = finalSong,
+                                        positionMs = 0L,
+                                        isPaused = false
+                                    )
+                                }
+                            }
+                        } catch (e: Exception) {
+                            e.printStackTrace()
+                        }
+                    }
+                }
             ).also { it.start(scope) }
 
         // Initialize lyrics pre-load manager
@@ -3670,6 +3697,11 @@ class MusicService :
 
 
     override fun onEvents(player: Player, events: Player.Events) {
+        if (events.contains(Player.EVENT_MEDIA_METADATA_CHANGED)) {
+            if (crossfadeAudio?.isCrossfading() != true) {
+                currentMediaMetadata.value = player.currentMetadata
+            }
+        }
     val joined = togetherSessionState.value as? moe.koiverse.archivetune.together.TogetherSessionState.Joined
     if (joined?.role is moe.koiverse.archivetune.together.TogetherRole.Guest &&
         events.contains(Player.EVENT_PLAY_WHEN_READY_CHANGED)
@@ -3743,7 +3775,9 @@ class MusicService :
     }
 
        if (events.containsAny(EVENT_TIMELINE_CHANGED, EVENT_POSITION_DISCONTINUITY)) {
-            currentMediaMetadata.value = player.currentMetadata
+            if (crossfadeAudio?.isCrossfading() != true) {
+                currentMediaMetadata.value = player.currentMetadata
+            }
             // immediate update when media item transitions to avoid stale presence
             scope.launch {
                 try {

--- a/app/src/main/kotlin/moe/koiverse/archivetune/playback/PlayerConnection.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/playback/PlayerConnection.kt
@@ -20,7 +20,6 @@ import androidx.media3.common.Player.REPEAT_MODE_OFF
 import androidx.media3.common.Player.STATE_ENDED
 import androidx.media3.common.Timeline
 import moe.koiverse.archivetune.db.MusicDatabase
-import moe.koiverse.archivetune.extensions.currentMetadata
 import moe.koiverse.archivetune.extensions.getCurrentQueueIndex
 import moe.koiverse.archivetune.extensions.getQueueWindows
 import moe.koiverse.archivetune.extensions.metadata
@@ -56,7 +55,7 @@ class PlayerConnection(
             SharingStarted.Lazily,
             player.playWhenReady && player.playbackState != STATE_ENDED
         )
-    val mediaMetadata = MutableStateFlow(player.currentMetadata)
+    val mediaMetadata = service.currentMediaMetadata
     val currentSong =
         mediaMetadata.flatMapLatest {
             database.song(it?.id)
@@ -90,21 +89,12 @@ class PlayerConnection(
         playbackState.value = player.playbackState
         playWhenReady.value = player.playWhenReady
         playbackParameters.value = player.playbackParameters
-        val currentMeta = player.currentMetadata ?: service.currentMediaMetadata.value
-        mediaMetadata.value = currentMeta
         queueTitle.value = service.queueTitle
         queueWindows.value = player.getQueueWindows()
         currentWindowIndex.value = player.getCurrentQueueIndex()
         currentMediaItemIndex.value = player.currentMediaItemIndex
         shuffleModeEnabled.value = player.shuffleModeEnabled
         repeatMode.value = player.repeatMode
-        
-        if (currentMeta == null && player.mediaItemCount > 0) {
-            val mediaItem = player.currentMediaItem
-            if (mediaItem != null) {
-                mediaMetadata.value = mediaItem.metadata
-            }
-        }
     }
 
     fun playQueue(queue: Queue) {
@@ -185,8 +175,6 @@ class PlayerConnection(
         mediaItem: MediaItem?,
         reason: Int,
     ) {
-        val meta = mediaItem?.metadata ?: service.currentMediaMetadata.value
-        mediaMetadata.value = meta
         currentMediaItemIndex.value = player.currentMediaItemIndex
         currentWindowIndex.value = player.getCurrentQueueIndex()
         updateCanSkipPreviousAndNext()

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/player/Player.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/player/Player.kt
@@ -285,10 +285,10 @@ fun BottomSheetPlayer(
 
     val sliderStyle by rememberEnumPreference(SliderStyleKey, SliderStyle.Standard)
 
-    var position by rememberSaveable(playbackState) {
+    var position by rememberSaveable(mediaMetadata?.id) {
         mutableLongStateOf(playerConnection.player.currentPosition)
     }
-    var duration by rememberSaveable(playbackState) {
+    var duration by rememberSaveable(mediaMetadata?.id) {
         mutableLongStateOf(playerConnection.player.duration)
     }
     var sliderPosition by remember {
@@ -512,12 +512,30 @@ fun BottomSheetPlayer(
         mutableStateOf(false)
     }
 
-    LaunchedEffect(playbackState) {
+    LaunchedEffect(mediaMetadata?.id, playbackState) {
+        val startTime = SystemClock.elapsedRealtime()
         if (playbackState == STATE_READY) {
             while (isActive) {
                 delay(100)
-                position = playerConnection.player.currentPosition
-                duration = playerConnection.player.duration
+                val isTransitioning = playerConnection.player.currentMediaItem?.mediaId != mediaMetadata?.id
+                
+                if (isTransitioning) {
+                    val elapsedSinceStart = SystemClock.elapsedRealtime() - startTime
+                    position = elapsedSinceStart
+                    mediaMetadata?.let {
+                        val metaDuration = it.duration.toLong() * 1000
+                        duration = if (metaDuration > 0) metaDuration else 0L
+                    }
+                } else {
+                    position = playerConnection.player.currentPosition
+                    duration = playerConnection.player.duration
+                }
+            }
+        } else {
+            mediaMetadata?.let {
+                val metaDuration = it.duration.toLong() * 1000
+                duration = if (metaDuration > 0) metaDuration else 0L
+                position = 0L
             }
         }
     }
@@ -614,7 +632,15 @@ fun BottomSheetPlayer(
         val onSliderValueChange: (Long) -> Unit = { sliderPosition = it }
         val onSliderValueChangeFinished: () -> Unit = {
             sliderPosition?.let {
-                playerConnection.player.seekTo(it)
+                val isTransitioning = playerConnection.player.currentMediaItem?.mediaId != mediaMetadata?.id
+                if (isTransitioning) {
+                    // During crossfade, we want to seek in the NEXT song (the one UI is showing)
+                    // The easiest way is to skip to it and then seek
+                    playerConnection.player.seekToNext()
+                    playerConnection.player.seekTo(it)
+                } else {
+                    playerConnection.player.seekTo(it)
+                }
                 position = it
             }
             sliderPosition = null

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/player/PlayerComponents.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/player/PlayerComponents.kt
@@ -632,10 +632,13 @@ fun PlayerSlider(
     onValueChange: (Long) -> Unit,
     onValueChangeFinished: () -> Unit
 ) {
+    val safeDuration = if (duration <= 0L) 0f else duration.toFloat()
+    val safeValue = (sliderPosition ?: position).toFloat().coerceIn(0f, maxOf(0f, safeDuration))
+    
     StyledPlaybackSlider(
         sliderStyle = sliderStyle,
-        value = (sliderPosition ?: position).toFloat(),
-        valueRange = 0f..(if (duration == C.TIME_UNSET) 0f else duration.toFloat()),
+        value = safeValue,
+        valueRange = 0f..maxOf(1f, safeDuration),
         onValueChange = { onValueChange(it.toLong()) },
         onValueChangeFinished = onValueChangeFinished,
         activeColor = textButtonColor,

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/player/Thumbnail.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/player/Thumbnail.kt
@@ -101,6 +101,7 @@ import moe.koiverse.archivetune.constants.ThumbnailCornerRadiusKey
 import moe.koiverse.archivetune.constants.CropThumbnailToSquareKey
 import moe.koiverse.archivetune.constants.HidePlayerThumbnailKey
 import moe.koiverse.archivetune.extensions.metadata
+import moe.koiverse.archivetune.extensions.toMediaItem
 import moe.koiverse.archivetune.innertube.YouTube
 import moe.koiverse.archivetune.innertube.models.YouTubeClient
 import moe.koiverse.archivetune.utils.rememberEnumPreference
@@ -338,9 +339,19 @@ fun Thumbnail(
         } else null
     } else null
 
-    val currentMediaItem = try {
-        playerConnection.player.currentMediaItem
-    } catch (e: Exception) { null }
+    val currentMediaItem = remember(mediaMetadata) {
+        // Fallback to player's current item if mediaMetadata is null, 
+        // but prefer mediaMetadata for immediate updates during crossfade.
+        val metadata = mediaMetadata
+        if (metadata != null) {
+            // Use extension to convert metadata to a proper MediaItem with all fields (uri, artwork, tag)
+            metadata.toMediaItem()
+        } else {
+            try {
+                playerConnection.player.currentMediaItem
+            } catch (e: Exception) { null }
+        }
+    }
 
     val mediaItems = listOfNotNull(previousMediaMetadata, currentMediaItem, nextMediaMetadata)
     val currentMediaIndex = mediaItems.indexOf(currentMediaItem)
@@ -379,7 +390,7 @@ fun Thumbnail(
     }
 
     // Update position when song changes
-    LaunchedEffect(mediaMetadata, canSkipPrevious, canSkipNext) {
+    LaunchedEffect(mediaMetadata, currentMediaItem?.mediaId, canSkipPrevious, canSkipNext) {
         val index = maxOf(0, currentMediaIndex)
         if (index >= 0 && index < mediaItems.size) {
             try {
@@ -390,7 +401,7 @@ fun Thumbnail(
         }
     }
 
-    LaunchedEffect(playerConnection.player.currentMediaItemIndex) {
+    LaunchedEffect(playerConnection.player.currentMediaItemIndex, currentMediaItem?.mediaId) {
         val index = mediaItems.indexOf(currentMediaItem)
         if (index >= 0 && index != currentItem) {
             thumbnailLazyGridState.scrollToItem(index)


### PR DESCRIPTION
This branch is a smaller variant of Crossfade that changes some things related to how Crossfade works.

- Change thumbnails, song information, and reset the seekbar when you "start" the crossfade.
- During the crossfade process, if the user searches on the sidebar, it will be counted as searching on a new song instead of an old one.

**All feauture above has been tested on Emulator Android 16**