### PR TITLE
fix(Queue): exit selection "toolbar" mode when no items are selected

### DIFF
--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/player/Queue.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/player/Queue.kt
@@ -858,6 +858,9 @@ fun Queue(
                                                     if (trackMetadata in selectedSongs) {
                                                         selectedSongs.remove(trackMetadata)
                                                         selectedItems.remove(currentItem)
+                                                        if (selectedSongs.isEmpty()) {
+                                                            selection = false
+                                                        }
                                                     } else {
                                                         selectedSongs.add(trackMetadata)
                                                         selectedItems.add(currentItem)
@@ -965,6 +968,7 @@ fun Queue(
                             if (count == mutableQueueWindows.size) {
                                 selectedSongs.clear()
                                 selectedItems.clear()
+                                selection = false
                             } else {
                                 queueWindows
                                     .filter { it.mediaItem.metadata!! !in selectedSongs }
@@ -997,6 +1001,7 @@ fun Queue(
                                     clearAction = {
                                         selectedSongs.clear()
                                         selectedItems.clear()
+                                        selection = false
                                     },
                                     currentItems = selectedItems,
                                     onRemoveFromQueue = { windows ->


### PR DESCRIPTION
## Description
Just PR simple is fix issue if toolbar in queue not exit if deselect all song

## Video

| **Before** | **After** |
|:---:|:---:|
| <video src="https://github.com/user-attachments/assets/ec2d7411-b04c-4c01-9794-e2b06a109bac"> | <video src="https://github.com/user-attachments/assets/5d8c0edf-a791-4bc7-92a5-c987b2de212c"> |