### PR TITLE
feat(playback): add SafeTrackSelector and improve preference components

### DIFF
--- a/app/src/main/kotlin/moe/koiverse/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/playback/MusicService.kt
@@ -75,6 +75,7 @@ import androidx.media3.exoplayer.analytics.PlaybackStats
 import androidx.media3.exoplayer.analytics.PlaybackStatsListener
 import androidx.media3.exoplayer.audio.DefaultAudioSink
 import androidx.media3.exoplayer.audio.SilenceSkippingAudioProcessor
+import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.source.ShuffleOrder.DefaultShuffleOrder
 import androidx.media3.extractor.DefaultExtractorsFactory
@@ -684,6 +685,7 @@ class MusicService :
                 .Builder(this)
                 .setMediaSourceFactory(createMediaSourceFactory())
                 .setRenderersFactory(createRenderersFactory { crossfadeAudioProcessor = it })
+                .setTrackSelector(DefaultTrackSelector(this, SafeTrackSelectionFactory()))
                 .setHandleAudioBecomingNoisy(true)
                 .setWakeMode(C.WAKE_MODE_NETWORK)
                 .setAudioAttributes(

--- a/app/src/main/kotlin/moe/koiverse/archivetune/playback/SafeTrackSelector.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/playback/SafeTrackSelector.kt
@@ -1,0 +1,44 @@
+package moe.koiverse.archivetune.playback
+
+import androidx.media3.common.Timeline
+import androidx.media3.exoplayer.source.MediaSource
+import androidx.media3.exoplayer.trackselection.AdaptiveTrackSelection
+import androidx.media3.exoplayer.trackselection.ExoTrackSelection
+import androidx.media3.exoplayer.upstream.BandwidthMeter
+
+internal class SafeTrackSelectionFactory(
+    private val delegate: ExoTrackSelection.Factory = AdaptiveTrackSelection.Factory()
+) : ExoTrackSelection.Factory {
+    override fun createTrackSelections(
+        definitions: Array<out ExoTrackSelection.Definition?>,
+        bandwidthMeter: BandwidthMeter,
+        mediaPeriodId: MediaSource.MediaPeriodId,
+        timeline: Timeline
+    ): Array<ExoTrackSelection?> {
+        val selections = delegate.createTrackSelections(definitions, bandwidthMeter, mediaPeriodId, timeline)
+        return selections.map { selection ->
+            selection?.let { SafeExoTrackSelection(it) }
+        }.toTypedArray()
+    }
+}
+
+private class SafeExoTrackSelection(
+    private val delegate: ExoTrackSelection
+) : ExoTrackSelection by delegate {
+    override fun isTrackExcluded(index: Int, nowMs: Long): Boolean {
+        if (index < 0 || index >= length()) {
+            return false
+        }
+        return delegate.isTrackExcluded(index, nowMs)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        val otherDelegate = if (other is SafeExoTrackSelection) other.delegate else other
+        return delegate == otherDelegate
+    }
+
+    override fun hashCode(): Int {
+        return delegate.hashCode()
+    }
+}

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/component/Dialog.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/component/Dialog.kt
@@ -325,6 +325,7 @@ fun TextFieldDialog(
     singleLine: Boolean = true,
     autoFocus: Boolean = true,
     maxLines: Int = if (singleLine) 1 else 10,
+    keyboardOptions: KeyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
     isInputValid: (String) -> Boolean = { it.isNotEmpty() },
     onDone: (String) -> Unit = {},
 
@@ -387,7 +388,7 @@ fun TextFieldDialog(
                         singleLine = singleLine,
                         maxLines = maxLines,
                         colors = OutlinedTextFieldDefaults.colors(),
-                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                        keyboardOptions = keyboardOptions,
                         keyboardActions = KeyboardActions(
                             onDone = {
                                 if (onDoneMultiple != null) {
@@ -410,7 +411,7 @@ fun TextFieldDialog(
                     singleLine = singleLine,
                     maxLines = maxLines,
                     colors = OutlinedTextFieldDefaults.colors(),
-                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                    keyboardOptions = keyboardOptions,
                     keyboardActions = KeyboardActions(
                         onDone = {
                             onDone(legacyFieldState.value.text)

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/component/Preference.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/component/Preference.kt
@@ -38,6 +38,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -80,6 +81,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -420,6 +423,7 @@ fun EditTextPreference(
     value: String,
     onValueChange: (String) -> Unit,
     singleLine: Boolean = true,
+    keyboardOptions: KeyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
     isInputValid: (String) -> Boolean = { it.isNotEmpty() },
     isEnabled: Boolean = true,
 ) {
@@ -429,12 +433,14 @@ fun EditTextPreference(
 
     if (showDialog) {
         TextFieldDialog(
+            title = title,
             initialTextFieldValue =
             TextFieldValue(
                 text = value,
                 selection = TextRange(value.length),
             ),
             singleLine = singleLine,
+            keyboardOptions = keyboardOptions,
             isInputValid = isInputValid,
             onDone = onValueChange,
             onDismiss = { showDialog = false },
@@ -445,6 +451,49 @@ fun EditTextPreference(
         modifier = modifier,
         title = title,
         description = value,
+        icon = icon,
+        onClick = { showDialog = true },
+        isEnabled = isEnabled,
+    )
+}
+
+@Composable
+fun NumberEditTextPreference(
+    modifier: Modifier = Modifier,
+    title: @Composable () -> Unit,
+    icon: (@Composable () -> Unit)? = null,
+    value: Int,
+    onValueChange: (Int) -> Unit,
+    isInputValid: (String) -> Boolean = { it.toIntOrNull() != null },
+    isEnabled: Boolean = true,
+) {
+    var showDialog by remember {
+        mutableStateOf(false)
+    }
+
+    if (showDialog) {
+        TextFieldDialog(
+            title = title,
+            initialTextFieldValue =
+            TextFieldValue(
+                text = value.toString(),
+                selection = TextRange(value.toString().length),
+            ),
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Number,
+                imeAction = ImeAction.Done
+            ),
+            isInputValid = isInputValid,
+            onDone = { it.toIntOrNull()?.let(onValueChange) },
+            onDismiss = { showDialog = false },
+        )
+    }
+
+    PreferenceEntry(
+        modifier = modifier,
+        title = title,
+        description = value.toString(),
         icon = icon,
         onClick = { showDialog = true },
         isEnabled = isEnabled,

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/settings/InternetSettings.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/settings/InternetSettings.kt
@@ -224,15 +224,14 @@ fun InternetSettings(
                         YouTube.proxy = Proxy(proxyType, java.net.InetSocketAddress.createUnresolved(it, proxyPort))
                     },
                 )
-                NumberPickerPreference(
+                NumberEditTextPreference(
                     title = { Text(stringResource(R.string.proxy_port)) },
                     value = proxyPort,
                     onValueChange = {
                         onProxyPortChange(it)
                         YouTube.proxy = Proxy(proxyType, java.net.InetSocketAddress.createUnresolved(proxyHost, it))
                     },
-                    minValue = 1,
-                    maxValue = 65535,
+                    isInputValid = { it.toIntOrNull() in 1..65535 },
                 )
 
                 PreferenceGroupTitle(title = stringResource(R.string.proxy_auth))

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/settings/MusicTogetherScreen.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/settings/MusicTogetherScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -92,6 +93,8 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
@@ -252,6 +255,10 @@ fun MusicTogetherScreen(
             title = { Text(text = stringResource(R.string.together_port)) },
             placeholder = { Text(text = "42117") },
             isInputValid = { it.trim().toIntOrNull() in 1..65535 },
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Number,
+                imeAction = ImeAction.Done
+            ),
             onDone = { setPort(it.trim().toInt()) },
             onDismiss = { showPortDialog = false },
         )


### PR DESCRIPTION
- Implement `SafeTrackSelectionFactory` and `SafeExoTrackSelection` to provide bounds-checking for track exclusions, preventing potential index out of bounds errors.
- Add `NumberEditTextPreference` to `Preference.kt` for a more consistent numeric input experience.
- Update `EditTextPreference` and `TextFieldDialog` to support custom `KeyboardOptions`.
- Use `NumberEditTextPreference` for proxy port settings in `InternetSettings`.
- Apply numeric keyboard type to the port selection dialog in `MusicTogetherScreen`.
- Integrate `SafeTrackSelectionFactory` into `MusicService` via `DefaultTrackSelector`.

Also this branch changed small thing for proxy port from **slidebar** to **input** because sildebar so much laggy (value issue) 