### PR TITLE
feat(Lyrics): add clear all lyrics cache functionality with confirmation dialog

### DIFF
--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/menu/LyricsMenu.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/menu/LyricsMenu.kt
@@ -118,6 +118,7 @@ fun LyricsMenu(
 
     var showTranslateDialog by rememberSaveable { mutableStateOf(false) }
     var showLyricsSyncOffsetDialog by rememberSaveable { mutableStateOf(false) }
+    var showClearLyricsCacheDialog by rememberSaveable { mutableStateOf(false) }
     val coroutineScope = rememberCoroutineScope()
 
     if (showEditDialog) {
@@ -707,6 +708,47 @@ fun LyricsMenu(
         }
 
 
+    if (showClearLyricsCacheDialog) {
+        DefaultDialog(
+            onDismiss = { showClearLyricsCacheDialog = false },
+            icon = {
+                Icon(
+                    painter = painterResource(R.drawable.delete),
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.error,
+                )
+            },
+            title = { Text(stringResource(R.string.clear_lyrics_cache)) },
+            buttons = {
+                TextButton(
+                    onClick = { showClearLyricsCacheDialog = false },
+                    shapes = ButtonDefaults.shapes(),
+                ) {
+                    Text(stringResource(android.R.string.cancel))
+                }
+                TextButton(
+                    onClick = {
+                        viewModel.clearAllLyricsCache()
+                        showClearLyricsCacheDialog = false
+                        onDismiss()
+                    },
+                    shapes = ButtonDefaults.shapes(),
+                    colors = ButtonDefaults.textButtonColors(
+                        contentColor = MaterialTheme.colorScheme.error,
+                    ),
+                ) {
+                    Text(stringResource(R.string.clear))
+                }
+            }
+        ) {
+            Text(
+                text = stringResource(R.string.clear_lyrics_cache_confirm),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+
     LazyColumn(
         userScrollEnabled = !isPortrait,
         contentPadding = PaddingValues(
@@ -782,6 +824,19 @@ fun LyricsMenu(
                             },
                             text = stringResource(R.string.search),
                             onClick = { showSearchDialog = true }
+                        ),
+                        NewAction(
+                            icon = {
+                                Icon(
+                                    painter = painterResource(R.drawable.delete),
+                                    contentDescription = null,
+                                    modifier = Modifier.size(28.dp),
+                                    tint = MaterialTheme.colorScheme.error
+                                )
+                            },
+                            text = stringResource(R.string.clear_lyrics_cache),
+                            onClick = { showClearLyricsCacheDialog = true },
+                            contentColor = MaterialTheme.colorScheme.error,
                         )
                     ),
                     modifier = Modifier.padding(horizontal = 12.dp, vertical = 12.dp)

--- a/app/src/main/kotlin/moe/koiverse/archivetune/viewmodels/LyricsMenuViewModel.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/viewmodels/LyricsMenuViewModel.kt
@@ -110,4 +110,12 @@ constructor(
             }
         }
     }
+
+    fun clearAllLyricsCache() {
+        viewModelScope.launch(Dispatchers.IO) {
+            database.query {
+                clearAllLyrics()
+            }
+        }
+    }
 }


### PR DESCRIPTION
Add ability to clear all cached lyrics through the lyrics menu with a confirmation dialog. Implements clearAllLyricsCache method in LyricsMenuViewModel to remove all lyrics from database, and adds a new action button with error styling to trigger the clear operation.

Request by: https://t.me/ArchiveTuneGC/1/18458