### PR TITLE
feat(Webview): automatic exit from LoginScreen after successful login

### DIFF
--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/LoginScreen.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/LoginScreen.kt
@@ -17,6 +17,7 @@ import android.webkit.CookieManager
 import android.webkit.JavascriptInterface
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.windowInsetsPadding
@@ -26,6 +27,8 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -84,6 +87,8 @@ fun LoginScreen(
     var accountEmail by rememberPreference(AccountEmailKey, "")
     var accountChannelHandle by rememberPreference(AccountChannelHandleKey, "")
 
+    var hasNavigated by remember { mutableStateOf(false) }
+
     var webView: WebView? = null
 
     AndroidView(
@@ -110,6 +115,12 @@ fun LoginScreen(
                                     accountName = it.name
                                     accountEmail = it.email.orEmpty()
                                     accountChannelHandle = it.channelHandle.orEmpty()
+
+                                    if (!hasNavigated) {
+                                        hasNavigated = true
+                                        Toast.makeText(context, R.string.login_success, Toast.LENGTH_SHORT).show()
+                                        navController.navigateUp()
+                                    }
                                 }.onFailure {
                                     reportException(it)
                                 }

--- a/app/src/main/res/values-vi/archivetune_strings.xml
+++ b/app/src/main/res/values-vi/archivetune_strings.xml
@@ -367,4 +367,5 @@
     <string name="backup_category_settings_desc">Giao diện, phát lại &amp; tùy chọn</string>
     <string name="backup_category_account">Chi tiết tài khoản</string>
     <string name="backup_category_account_desc">Thông tin đăng nhập YouTube, Last.fm, Discord và proxy</string>
+    <string name="login_success">Đăng nhập thành công</string>
 </resources>

--- a/app/src/main/res/values/archivetune_strings.xml
+++ b/app/src/main/res/values/archivetune_strings.xml
@@ -384,4 +384,5 @@
     <string name="backup_category_settings_desc">Appearance, playback &amp; preferences</string>
     <string name="backup_category_account">Account Details</string>
     <string name="backup_category_account_desc">YouTube, Last.fm, Discord &amp; proxy credentials</string>
+    <string name="login_success">Logged in successfully</string>
 </resources>


### PR DESCRIPTION
This PR implements an automatic exit from the `LoginScreen` after a successful Google login, improving the user experience by providing immediate feedback and returning to the previous screen.

### Changes:
- **String Resources**: Added `login_success` ("Logged in successfully") to both the default and Vietnamese (`vi`) string resources.
- **Login Logic**:
    - Introduced a `hasNavigated` state in `LoginScreen` to prevent redundant navigation or multiple toast notifications.
    - Updated the `onPageFinished` logic to trigger a check for account information via `YouTube.accountInfo()`.
    - On a successful account info retrieval, a toast notification is displayed, and the `navController` navigates back.
- **Safety**: Verified that these changes do not affect `PoTokenExtractionActivity`, as it uses its own WebView client logic.

### Video

https://github.com/user-attachments/assets/da0874e5-f90c-4d41-b4ad-2b9004dfe157


