### PR TITLE
feat: add APP_UPDATE_PAT for GitHub API rate limit bypass

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,6 +123,7 @@ jobs:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           LASTFM_API_KEY: ${{ secrets.LASTFM_API_KEY }}
           LASTFM_SECRET: ${{ secrets.LASTFM_SECRET }}
+          APP_UPDATE_PAT: ${{ secrets.APP_UPDATE_PAT }}
           TOGETHER_BEARER_TOKEN: ${{ secrets.TOGETHER_BEARER_TOKEN }}
           CANVAS_BEARER_TOKEN: ${{ secrets.CANVAS_BEARER_TOKEN }}
           NIGHTLY_BUILD_HASH: ${{ steps.build_hash.outputs.value }}
@@ -281,6 +282,7 @@ jobs:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           LASTFM_API_KEY: ${{ secrets.LASTFM_API_KEY }}
           LASTFM_SECRET: ${{ secrets.LASTFM_SECRET }}
+          APP_UPDATE_PAT: ${{ secrets.APP_UPDATE_PAT }}
           TOGETHER_BEARER_TOKEN: ${{ secrets.TOGETHER_BEARER_TOKEN }}
           CANVAS_BEARER_TOKEN: ${{ secrets.CANVAS_BEARER_TOKEN }}
           NIGHTLY_BUILD_HASH: ${{ steps.build_hash.outputs.value }}

--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -49,6 +49,7 @@ jobs:
           PULL_REQUEST: "true"
           LASTFM_API_KEY: ${{ secrets.LASTFM_API_KEY }}
           LASTFM_SECRET: ${{ secrets.LASTFM_SECRET }}
+          APP_UPDATE_PAT: ${{ secrets.APP_UPDATE_PAT }}
           CANVAS_BEARER_TOKEN: ${{ secrets.CANVAS_BEARER_TOKEN }}
 
       - name: Upload APK

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,7 @@ jobs:
         env:
           LASTFM_API_KEY: ${{ secrets.LASTFM_API_KEY }}
           LASTFM_SECRET: ${{ secrets.LASTFM_SECRET }}
+          APP_UPDATE_PAT: ${{ secrets.APP_UPDATE_PAT }}
           TOGETHER_BEARER_TOKEN: ${{ secrets.TOGETHER_BEARER_TOKEN }}
           CANVAS_BEARER_TOKEN: ${{ secrets.CANVAS_BEARER_TOKEN }}
         run: |
@@ -234,6 +235,7 @@ jobs:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           LASTFM_API_KEY: ${{ secrets.LASTFM_API_KEY }}
           LASTFM_SECRET: ${{ secrets.LASTFM_SECRET }}
+          APP_UPDATE_PAT: ${{ secrets.APP_UPDATE_PAT }}
           TOGETHER_BEARER_TOKEN: ${{ secrets.TOGETHER_BEARER_TOKEN }}
           CANVAS_BEARER_TOKEN: ${{ secrets.CANVAS_BEARER_TOKEN }}
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,6 +40,12 @@ android {
         buildConfigField("String", "LASTFM_API_KEY", "\"$lastfmApiKey\"")
         buildConfigField("String", "LASTFM_SECRET", "\"$lastfmSecret\"")
 
+        val appUpdatePat =
+            localProperties.getProperty("APP_UPDATE_PAT")
+                ?: System.getenv("APP_UPDATE_PAT")
+                ?: ""
+        buildConfigField("String", "APP_UPDATE_PAT", "\"$appUpdatePat\"")
+
         val togetherBearerToken =
             localProperties.getProperty("TOGETHER_BEARER_TOKEN")
                 ?: System.getenv("TOGETHER_BEARER_TOKEN")

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/settings/AboutScreen.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/settings/AboutScreen.kt
@@ -152,6 +152,9 @@ private suspend fun fetchRepoContributorsNetwork(
             headers {
                 append("Accept", "application/vnd.github+json")
                 append("User-Agent", "ArchiveTune")
+                if (BuildConfig.APP_UPDATE_PAT.isNotBlank()) {
+                    append("Authorization", "Bearer ${BuildConfig.APP_UPDATE_PAT}")
+                }
                 if (!cachedEtag.isNullOrBlank()) {
                     append("If-None-Match", cachedEtag)
                 }

--- a/app/src/main/kotlin/moe/koiverse/archivetune/utils/Updater.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/utils/Updater.kt
@@ -217,6 +217,9 @@ object Updater {
                 headers {
                     append("Accept", "application/vnd.github+json")
                     append("User-Agent", "ArchiveTune")
+                    if (BuildConfig.APP_UPDATE_PAT.isNotBlank()) {
+                        append("Authorization", "Bearer ${BuildConfig.APP_UPDATE_PAT}")
+                    }
                     if (!cachedEtag.isNullOrBlank()) {
                         append("If-None-Match", cachedEtag)
                     }
@@ -268,8 +271,15 @@ object Updater {
     suspend fun getCommitHistory(count: Int = 20, branch: String = "dev"): Result<List<GitCommit>> =
         runCatching {
             val response =
-                client.get("https://api.github.com/repos/koiverse/ArchiveTune/commits?sha=$branch&per_page=$count")
-                    .bodyAsText()
+                client.get("https://api.github.com/repos/koiverse/ArchiveTune/commits?sha=$branch&per_page=$count") {
+                    headers {
+                        append("Accept", "application/vnd.github+json")
+                        append("User-Agent", "ArchiveTune")
+                        if (BuildConfig.APP_UPDATE_PAT.isNotBlank()) {
+                            append("Authorization", "Bearer ${BuildConfig.APP_UPDATE_PAT}")
+                        }
+                    }
+                }.bodyAsText()
             val jsonArray = JSONArray(response)
             val commits = mutableListOf<GitCommit>()
             for (i in 0 until jsonArray.length()) {


### PR DESCRIPTION
This PR adds support for using a GitHub Personal Access Token (`APP_UPDATE_PAT`) in the app to increase GitHub API rate limits for features like update checking and contributor list fetching.

### Technical Changes
- **Build Configuration**: Added `APP_UPDATE_PAT` to `app/build.gradle.kts`, reading from `local.properties` or environment variables and exposing it via `BuildConfig`.
- **API Authentication**:
    - Updated `moe.koiverse.archivetune.utils.Updater` to include a `Bearer` token in the `Authorization` header for fetching releases and commit history.
    - Updated `moe.koiverse.archivetune.ui.screens.settings.AboutScreen` to include the same header when fetching repository contributors.
- **CI/CD**: Modified GitHub Actions workflows (`build.yml`, `release.yml`, and `build_pull_request.yml`) to inject the `APP_UPDATE_PAT` secret into the build environment.

### Fallback
The implementation checks if the token is non-blank before adding the header, ensuring the app falls back to unauthenticated requests if no token is provided during build.