### PR TITLE
feat: add "Remove from cache" to selected songs in CachePlaylistScreen

### DIFF
--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/menu/SelectionSongsMenu.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/menu/SelectionSongsMenu.kt
@@ -87,6 +87,8 @@ fun SelectionSongMenu(
     onDismiss: () -> Unit,
     clearAction: () -> Unit,
     songPosition: List<PlaylistSongMap>? = emptyList(),
+    isFromCache: Boolean = false,
+    onRemoveFromCache: ((List<Song>) -> Unit)? = null,
 ) {
     val context = LocalContext.current
     val database = LocalDatabase.current
@@ -576,6 +578,38 @@ fun SelectionSongMenu(
                                     }
                                 }
                             }
+                        },
+                        colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+                    )
+                }
+            }
+        }
+
+        if (isFromCache && onRemoveFromCache != null) {
+            item {
+                Spacer(modifier = Modifier.height(12.dp))
+            }
+
+            item {
+                MenuSurfaceSection(modifier = Modifier.padding(vertical = 6.dp)) {
+                    ListItem(
+                        headlineContent = {
+                            Text(
+                                text = stringResource(R.string.remove_from_cache),
+                                color = MaterialTheme.colorScheme.error,
+                            )
+                        },
+                        leadingContent = {
+                            Icon(
+                                painter = painterResource(R.drawable.delete),
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.error,
+                            )
+                        },
+                        modifier = Modifier.clickable {
+                            onDismiss()
+                            onRemoveFromCache(songSelection)
+                            clearAction()
                         },
                         colors = ListItemDefaults.colors(containerColor = Color.Transparent),
                     )

--- a/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/playlist/CachePlaylistScreen.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/ui/screens/playlist/CachePlaylistScreen.kt
@@ -172,6 +172,16 @@ fun CachePlaylistScreen(
     val focusRequester = remember { FocusRequester() }
     val lazyListState = rememberLazyListState()
 
+    val selectedCount by remember(wrappedSongs) {
+        derivedStateOf { wrappedSongs.count { it.isSelected } }
+    }
+
+    LaunchedEffect(selectedCount) {
+        if (selection && selectedCount == 0) {
+            selection = false
+        }
+    }
+
     LaunchedEffect(isSearching) {
         if (isSearching) {
             focusRequester.requestFocus()
@@ -745,8 +755,21 @@ fun CachePlaylistScreen(
                 if (selection) {
                     val count = wrappedSongs.count { it.isSelected }
                     androidx.compose.material3.IconButton(onClick = {
+                        wrappedSongs.filter { it.isSelected }.forEach {
+                            viewModel.removeSongFromCache(it.item.id)
+                        }
+                        selection = false
+                    }) {
+                        Icon(
+                            painter = painterResource(R.drawable.delete),
+                            contentDescription = stringResource(R.string.remove_from_cache)
+                        )
+                    }
+
+                    androidx.compose.material3.IconButton(onClick = {
                         if (count == wrappedSongs.size) {
                             wrappedSongs.forEach { it.isSelected = false }
+                            selection = false
                         } else {
                             wrappedSongs.forEach { it.isSelected = true }
                         }
@@ -764,7 +787,11 @@ fun CachePlaylistScreen(
                             SelectionSongMenu(
                                 songSelection = wrappedSongs.filter { it.isSelected }.map { it.item },
                                 onDismiss = menuState::dismiss,
-                                clearAction = { selection = false }
+                                clearAction = { selection = false },
+                                isFromCache = true,
+                                onRemoveFromCache = { songs ->
+                                    songs.forEach { viewModel.removeSongFromCache(it.id) }
+                                }
                             )
                         }
                     }) {


### PR DESCRIPTION
- Add bulk "Remove from cache" action in selection top bar and menu.
- Auto-exit selection mode when no songs are selected.
- Explicitly exit selection mode when deselecting all songs.

## Screenshot

| Before | After |
|-----|-----|
| <img width="720" height="1600" alt="Screenshot_20260522-005243" src="https://github.com/user-attachments/assets/6b1deac8-ef04-4336-80ee-a3ae0003f397" /> | <img width="720" height="1600" alt="Screenshot_20260522-010135" src="https://github.com/user-attachments/assets/7b107c7d-4a02-449e-a04d-d00a4f35ae81" /> |

