### PR TITLE
fix(Updater): support device (mobile/tv) and architecture flavor dimensions in APK download URL

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,9 +65,11 @@ android {
     productFlavors {
         create("mobile") {
             dimension = "device"
+            buildConfigField("String", "DEVICE", "\"mobile\"")
         }
         create("tv") {
             dimension = "device"
+            buildConfigField("String", "DEVICE", "\"tv\"")
         }
         create("universal") {
             dimension = "abi"

--- a/app/src/main/kotlin/moe/koiverse/archivetune/utils/Updater.kt
+++ b/app/src/main/kotlin/moe/koiverse/archivetune/utils/Updater.kt
@@ -291,12 +291,7 @@ object Updater {
 
     fun getLatestDownloadUrl(): String {
         val baseUrl = "https://github.com/koiverse/ArchiveTune/releases/latest/download/"
-        val architecture = BuildConfig.ARCHITECTURE
-        return if (architecture == "universal") {
-            baseUrl + "app-mobile-universal-release.apk"
-        } else {
-            baseUrl + "app-${architecture}-release.apk"
-        }
+        return baseUrl + "app-${BuildConfig.DEVICE}-${BuildConfig.ARCHITECTURE}-release.apk"
     }
 
     suspend fun getAllReleases(


### PR DESCRIPTION
The `getLatestDownloadUrl()` method was hardcoding `"mobile"` for universal APKs and missing the device prefix for others, producing incorrect download URLs for TV builds.

Changes:
- Add `buildConfigField("String", "DEVICE", ...)` to `mobile` and `tv` product flavors in `app/build.gradle.kts`
- Simplify `Updater.getLatestDownloadUrl()` to construct the URL using both `BuildConfig.DEVICE` and `BuildConfig.ARCHITECTURE` directly

Now every variant produces the correct APK filename: `app-<device>-<architecture>-release.apk` (e.g., `app-mobile-arm64-release.apk`, `app-tv-universal-release.apk`).