### PR TITLE
feat(updater): add Daily Nightly update channel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
         continue-on-error: true
 
   build:
-    name: Build Release APKs (${{ matrix.device }}-${{ matrix.abi }})
+    name: Build Release APKs (${{ matrix.distribution }}-${{ matrix.device }}-${{ matrix.abi }})
     if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'
     runs-on: ubuntu-latest
     needs: notifyTelegram
@@ -52,22 +52,39 @@ jobs:
       matrix:
         include:
           - device: mobile
+            distribution: gms
+            distributionName: Gms
             deviceName: Mobile
             abi: arm64
           - device: mobile
+            distribution: gms
+            distributionName: Gms
             deviceName: Mobile
             abi: armeabi
           - device: mobile
+            distribution: gms
+            distributionName: Gms
             deviceName: Mobile
             abi: x86
           - device: mobile
+            distribution: gms
+            distributionName: Gms
             deviceName: Mobile
             abi: x86_64
           - device: mobile
+            distribution: gms
+            distributionName: Gms
             deviceName: Mobile
             abi: universal
           - device: tv
+            distribution: gms
+            distributionName: Gms
             deviceName: Tv
+            abi: universal
+          - device: mobile
+            distribution: foss
+            distributionName: Foss
+            deviceName: Mobile
             abi: universal
 
     steps:
@@ -93,17 +110,26 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          DISTRIBUTION="${{ matrix.distribution }}"
+          DISTRIBUTION_CAP="${{ matrix.distributionName }}"
           DEVICE="${{ matrix.device }}"
           ABI="${{ matrix.abi }}"
           DEVICE_CAP="${{ matrix.deviceName }}"
           ABI_CAP="$(tr '[:lower:]' '[:upper:]' <<< "${ABI:0:1}")${ABI:1}"
+          echo "distribution=$DISTRIBUTION" >> "$GITHUB_OUTPUT"
+          echo "distribution_cap=$DISTRIBUTION_CAP" >> "$GITHUB_OUTPUT"
           echo "device=$DEVICE" >> "$GITHUB_OUTPUT"
           echo "abi=$ABI" >> "$GITHUB_OUTPUT"
           echo "device_cap=$DEVICE_CAP" >> "$GITHUB_OUTPUT"
           echo "abi_cap=$ABI_CAP" >> "$GITHUB_OUTPUT"
-          echo "gradle_task=assembleGms${DEVICE_CAP}${ABI_CAP}Release" >> "$GITHUB_OUTPUT"
-          echo "artifact_name=app-${DEVICE}-${ABI}-release" >> "$GITHUB_OUTPUT"
-          echo "apk_name=app-${DEVICE}-${ABI}-release.apk" >> "$GITHUB_OUTPUT"
+          echo "gradle_task=assemble${DISTRIBUTION_CAP}${DEVICE_CAP}${ABI_CAP}Release" >> "$GITHUB_OUTPUT"
+          if [ "$DISTRIBUTION" = "gms" ]; then
+            echo "artifact_name=app-${DEVICE}-${ABI}-release" >> "$GITHUB_OUTPUT"
+            echo "apk_name=app-${DEVICE}-${ABI}-release.apk" >> "$GITHUB_OUTPUT"
+          else
+            echo "artifact_name=app-${DISTRIBUTION}-${DEVICE}-${ABI}-release" >> "$GITHUB_OUTPUT"
+            echo "apk_name=app-${DISTRIBUTION}-${DEVICE}-${ABI}-release.apk" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Resolve build hash
         id: build_hash
@@ -142,11 +168,17 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          DISTRIBUTION="${{ steps.variant.outputs.distribution }}"
           DEVICE="${{ steps.variant.outputs.device }}"
           ABI="${{ steps.variant.outputs.abi }}"
           DEVICE_CAP="${{ steps.variant.outputs.device_cap }}"
           ABI_CAP="${{ steps.variant.outputs.abi_cap }}"
           CANDIDATES=(
+            "app/build/outputs/apk/${DISTRIBUTION}${DEVICE_CAP}${ABI_CAP}/release"
+            "app/build/outputs/apk/${DISTRIBUTION}${DEVICE}${ABI_CAP}/release"
+            "app/build/outputs/apk/${DISTRIBUTION}/${DEVICE}/${ABI}/release"
+            "app/build/outputs/apk/${DISTRIBUTION}/${DEVICE}${ABI_CAP}/release"
+            "app/build/outputs/apk/${DISTRIBUTION}/${DEVICE_CAP}${ABI_CAP}/release"
             "app/build/outputs/apk/gms${DEVICE_CAP}${ABI_CAP}/release"
             "app/build/outputs/apk/gms${DEVICE}${ABI_CAP}/release"
             "app/build/outputs/apk/gms/${DEVICE}/${ABI}/release"
@@ -167,6 +199,12 @@ jobs:
           FOUND_METADATA="$(
             find app/build/outputs/apk -type f -name "output-metadata.json" \
               \( \
+                -path "*/${DISTRIBUTION}/${DEVICE}/${ABI}/release/output-metadata.json" -o \
+                -path "*/${DISTRIBUTION}${DEVICE}${ABI_CAP}/release/output-metadata.json" -o \
+                -path "*/${DISTRIBUTION}${DEVICE_CAP}${ABI_CAP}/release/output-metadata.json" -o \
+                -path "*/${DISTRIBUTION}/${DEVICE}/${ABI}/*/release/output-metadata.json" -o \
+                -path "*/${DISTRIBUTION}${DEVICE}${ABI_CAP}/*/release/output-metadata.json" -o \
+                -path "*/${DISTRIBUTION}${DEVICE_CAP}${ABI_CAP}/*/release/output-metadata.json" -o \
                 -path "*/${DEVICE}/${ABI}/release/output-metadata.json" -o \
                 -path "*/${DEVICE}${ABI_CAP}/release/output-metadata.json" -o \
                 -path "*/${DEVICE_CAP}${ABI_CAP}/release/output-metadata.json" -o \
@@ -179,7 +217,7 @@ jobs:
             exit 0
           fi
 
-          echo "Could not resolve APK release output directory for DEVICE=$DEVICE ABI=$ABI"
+          echo "Could not resolve APK release output directory for DISTRIBUTION=$DISTRIBUTION DEVICE=$DEVICE ABI=$ABI"
           find app/build/outputs/apk -maxdepth 8 -type d -print || true
           exit 1
 

--- a/.github/workflows/notify_user.yml
+++ b/.github/workflows/notify_user.yml
@@ -25,7 +25,17 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const nightlyUrl = "https://nightly.link/koiverse/ArchiveTune/workflows/build/dev/app-mobile-universal-release";
+            const nightlyLinks = [
+              {
+                label: "GMS",
+                url: "https://nightly.link/koiverse/ArchiveTune/workflows/build/dev/app-mobile-universal-release"
+              },
+              {
+                label: "FOSS",
+                url: "https://nightly.link/koiverse/ArchiveTune/workflows/build/dev/app-foss-mobile-universal-release"
+              }
+            ];
+            const nightlyUrls = nightlyLinks.map((link) => link.url);
             const labelName = process.env.ISSUE_LABEL;
             const labelColor = process.env.ISSUE_LABEL_COLOR;
             const labelDescription = process.env.ISSUE_LABEL_DESCRIPTION;
@@ -124,7 +134,7 @@ jobs:
                     (
                       comment.user?.type === "Bot" &&
                       body.includes("This issue was referenced on commit") &&
-                      body.includes(nightlyUrl)
+                      nightlyUrls.some((nightlyUrl) => body.includes(nightlyUrl))
                     );
                 });
 
@@ -142,7 +152,7 @@ jobs:
                   "",
                   "Make sure to try the latest nightly version:",
                   "",
-                  nightlyUrl,
+                  ...nightlyLinks.map((link) => `${link.label}: ${link.url}`),
                   "",
                   "If this issue is resolved in the nightly build, please close this issue quickly."
                 ].join("\n");

--- a/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
@@ -802,10 +802,16 @@ val GitHubReleasesJsonKey = stringPreferencesKey("github_releases_json")
 val GitHubReleasesLastCheckedAtKey = longPreferencesKey("github_releases_last_checked_at")
 val GitHubReleasesFingerprintKey = stringPreferencesKey("github_releases_fingerprint")
 
+val DailyNightlyReleasesEtagKey = stringPreferencesKey("daily_nightly_releases_etag")
+val DailyNightlyReleasesJsonKey = stringPreferencesKey("daily_nightly_releases_json")
+val DailyNightlyReleasesLastCheckedAtKey = longPreferencesKey("daily_nightly_releases_last_checked_at")
+val DailyNightlyReleasesFingerprintKey = stringPreferencesKey("daily_nightly_releases_fingerprint")
+
 val TogetherOnlineEndpointCacheKey = stringPreferencesKey("together_online_endpoint_cache")
 val TogetherOnlineEndpointLastCheckedAtKey = longPreferencesKey("together_online_endpoint_last_checked_at")
 
 enum class UpdateChannel {
     STABLE,
     NIGHTLY,
+    DAILY_NIGHTLY,
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
@@ -47,6 +47,7 @@ import androidx.navigation.navArgument
 import moe.rukamori.archivetune.BuildConfig
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.constants.DarkModeKey
+import moe.rukamori.archivetune.constants.UpdateChannel
 import moe.rukamori.archivetune.constants.PureBlackKey
 import moe.rukamori.archivetune.ui.component.BottomSheet
 import moe.rukamori.archivetune.ui.component.BottomSheetMenu
@@ -436,8 +437,21 @@ fun NavGraphBuilder.navigationBuilder(
             UpdateScreen(navController, scrollBehavior)
         }
     }
-    composable("settings/changelog") {
-        ChangelogScreen(navController, scrollBehavior)
+    composable(
+        route = "settings/changelog?channel={channel}",
+        arguments = listOf(
+            navArgument("channel") {
+                type = NavType.StringType
+                nullable = true
+                defaultValue = null
+            }
+        )
+    ) { backStackEntry ->
+        val channelName = backStackEntry.arguments?.getString("channel")
+        val channel = channelName?.let {
+            runCatching { UpdateChannel.valueOf(it) }.getOrNull()
+        } ?: UpdateChannel.STABLE
+        ChangelogScreen(navController, scrollBehavior, channel = channel)
     }
     composable("settings/about") {
         AboutScreen(navController, scrollBehavior)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/ChangelogScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/ChangelogScreen.kt
@@ -25,6 +25,7 @@ import androidx.navigation.NavController
 import kotlinx.coroutines.launch
 import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.R
+import moe.rukamori.archivetune.constants.UpdateChannel
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.MarkdownText
 import moe.rukamori.archivetune.ui.utils.backToMain
@@ -38,6 +39,7 @@ import java.util.Locale
 fun ChangelogScreen(
     navController: NavController,
     scrollBehavior: TopAppBarScrollBehavior,
+    channel: UpdateChannel = UpdateChannel.STABLE,
 ) {
     val coroutineScope = rememberCoroutineScope()
     var releases by remember { mutableStateOf<List<ReleaseInfo>>(emptyList()) }
@@ -45,8 +47,12 @@ fun ChangelogScreen(
     var error by remember { mutableStateOf<String?>(null) }
 
     suspend fun loadReleases(forceRefresh: Boolean) {
-        Updater.getAllReleases(forceRefresh = forceRefresh).onSuccess { result ->
-            releases = result
+        val result = when (channel) {
+            UpdateChannel.DAILY_NIGHTLY -> Updater.getAllDailyNightlyReleases(forceRefresh = forceRefresh)
+            else -> Updater.getAllReleases(forceRefresh = forceRefresh)
+        }
+        result.onSuccess { r ->
+            releases = r
             error = null
         }.onFailure { e ->
             if (releases.isEmpty()) {
@@ -57,7 +63,10 @@ fun ChangelogScreen(
     }
 
     LaunchedEffect(Unit) {
-        val cachedReleases = Updater.getCachedReleases()
+        val cachedReleases = when (channel) {
+            UpdateChannel.DAILY_NIGHTLY -> Updater.getCachedDailyNightlyReleases()
+            else -> Updater.getCachedReleases()
+        }
         if (cachedReleases.isNotEmpty()) {
             releases = cachedReleases
             isLoading = false

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/UpdateScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/UpdateScreen.kt
@@ -110,7 +110,6 @@ fun UpdateScreen(
     val context = LocalContext.current
     val uriHandler = LocalUriHandler.current
     val nightlyInstallUrl = remember { Updater.getLatestNightlyDownloadUrl() }
-    val dailyNightlyInstallUrl = remember { Updater.getLatestDailyNightlyDownloadUrl() }
 
     val (enableUpdateNotification, onEnableUpdateNotificationChange) = rememberPreference(
         EnableUpdateNotificationKey,
@@ -141,7 +140,6 @@ fun UpdateScreen(
         )
     }
     val isNightlyChannel = updateChannel == UpdateChannel.NIGHTLY
-    val isDailyNightlyChannel = updateChannel == UpdateChannel.DAILY_NIGHTLY
     val isUpdateAvailable by remember(latestVersion) {
         derivedStateOf {
             BuildConfig.UPDATER_AVAILABLE &&
@@ -320,56 +318,10 @@ fun UpdateScreen(
             onDismissRequest = { showDailyNightlyChannelConfirmDialog = false },
             title = { Text(stringResource(R.string.channel_daily_nightly)) },
             text = {
-                Column(
-                    verticalArrangement = Arrangement.spacedBy(12.dp),
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    Text(
-                        text = "ArchiveTune provides three download channels for builds:",
-                        style = MaterialTheme.typography.bodyMedium
-                    )
-
-                    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                        Text(
-                            text = "• Stable builds",
-                            style = MaterialTheme.typography.bodyMedium,
-                            fontWeight = FontWeight.SemiBold
-                        )
-                        Text(
-                            text = "Distributed via official GitHub Releases.",
-                            style = MaterialTheme.typography.bodySmall
-                        )
-                        Text(
-                            text = "These versions are tested and recommended for most users.",
-                            style = MaterialTheme.typography.bodySmall
-                        )
-                    }
-
-                    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                        Text(
-                            text = "• Daily Nightly builds",
-                            style = MaterialTheme.typography.bodyMedium,
-                            fontWeight = FontWeight.SemiBold
-                        )
-                        Text(
-                            text = "Published daily as GitHub Releases from the latest development branch.",
-                            style = MaterialTheme.typography.bodySmall
-                        )
-                        Text(
-                            text = "Daily builds may include experimental features, unfinished changes, or temporary regressions.",
-                            style = MaterialTheme.typography.bodySmall
-                        )
-                    }
-
-                    Text(
-                        text = "Daily builds are provided for testing and early access only.\nStability, compatibility, and functionality are not guaranteed.",
-                        style = MaterialTheme.typography.bodySmall
-                    )
-                    Text(
-                        text = "By continuing, you acknowledge that daily builds may be unstable and use them at your own risk.",
-                        style = MaterialTheme.typography.bodySmall
-                    )
-                }
+                Text(
+                    text = "Switch to the Daily channel to receive updates from the daily-nightly repository.\n\nDaily builds are published automatically every day from the latest development branch.",
+                    style = MaterialTheme.typography.bodyMedium
+                )
             },
             confirmButton = {
                 TextButton(
@@ -395,15 +347,12 @@ fun UpdateScreen(
             return@LaunchedEffect
         }
 
-        if (isDailyNightlyChannel) {
-            Updater.getLatestDailyNightlyVersionName().onSuccess {
-                latestVersion = it
-            }
-        } else {
-            Updater.getLatestVersionName().onSuccess {
-                latestVersion = it
-            }
+        val versionResult = when (updateChannel) {
+            UpdateChannel.DAILY_NIGHTLY -> Updater.getLatestDailyNightlyVersionName()
+            else -> Updater.getLatestVersionName()
         }
+        versionResult.onSuccess { latestVersion = it }
+
         Updater.getCommitHistory(30).onSuccess {
             commits = it
         }.onFailure {
@@ -418,7 +367,6 @@ fun UpdateScreen(
     )
     val topBarSubtitle = when (updateChannel) {
         UpdateChannel.NIGHTLY -> stringResource(R.string.updates_subtitle_nightly)
-        UpdateChannel.DAILY_NIGHTLY -> stringResource(R.string.updates_subtitle_daily_nightly)
         else -> stringResource(R.string.updates_subtitle_stable)
     }
 
@@ -482,7 +430,13 @@ fun UpdateScreen(
                     latestVersion = latestVersion,
                     updateChannel = updateChannel,
                     isUpdateAvailable = isUpdateAvailable,
-                    onOpenChangelog = { navController.navigate("settings/changelog") }
+                    onOpenChangelog = {
+                        if (updateChannel == UpdateChannel.DAILY_NIGHTLY) {
+                            uriHandler.openUri("https://github.com/ArchiveTuneApp/daily-nightly/releases")
+                        } else {
+                            navController.navigate("settings/changelog")
+                        }
+                    }
                 )
             }
 
@@ -619,7 +573,7 @@ fun UpdateScreen(
             }
 
             item {
-                AnimatedVisibility(visible = isNightlyChannel || isDailyNightlyChannel) {
+                AnimatedVisibility(visible = isNightlyChannel) {
                     Card(
                         modifier = Modifier.fillMaxWidth(),
                         shape = MaterialTheme.shapes.extraLarge,
@@ -633,31 +587,17 @@ fun UpdateScreen(
                         ) {
                             ListItem(
                                 overlineContent = {
-                                    Text(
-                                        text = when (updateChannel) {
-                                            UpdateChannel.DAILY_NIGHTLY -> stringResource(R.string.channel_daily_nightly)
-                                            else -> stringResource(R.string.channel_nightly)
-                                        }
-                                    )
+                                    Text(text = stringResource(R.string.channel_nightly))
                                 },
                                 headlineContent = {
                                     Text(
-                                        text = when (updateChannel) {
-                                            UpdateChannel.DAILY_NIGHTLY -> "Daily delivery"
-                                            else -> stringResource(R.string.updates_nightly_title)
-                                        },
+                                        text = stringResource(R.string.updates_nightly_title),
                                         fontWeight = FontWeight.SemiBold,
                                     )
                                 },
                                 supportingContent = {
                                     Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                                        Text(
-                                            text = when (updateChannel) {
-                                                UpdateChannel.DAILY_NIGHTLY ->
-                                                    "Daily nightly releases are published automatically every day from the latest development branch."
-                                                else -> stringResource(R.string.updates_nightly_description)
-                                            }
-                                        )
+                                        Text(text = stringResource(R.string.updates_nightly_description))
                                         Text(
                                             text = stringResource(
                                                 R.string.updates_latest_commit,
@@ -682,15 +622,7 @@ fun UpdateScreen(
                             HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
 
                             OutlinedButton(
-                                onClick = {
-                                    uriHandler.openUri(
-                                        if (isDailyNightlyChannel) {
-                                            dailyNightlyInstallUrl
-                                        } else {
-                                            nightlyInstallUrl
-                                        }
-                                    )
-                                },
+                                onClick = { uriHandler.openUri(nightlyInstallUrl) },
                                 modifier = Modifier.fillMaxWidth(),
                             ) {
                                 Icon(
@@ -847,12 +779,12 @@ private fun UpdateSummaryCard(
         isUpdateAvailable -> stringResource(R.string.latest_version_format, latestVersion)
         else -> stringResource(R.string.updates_status_current)
     }
-    val channelContainerColor = if (updateChannel == UpdateChannel.NIGHTLY || updateChannel == UpdateChannel.DAILY_NIGHTLY) {
+    val channelContainerColor = if (updateChannel == UpdateChannel.NIGHTLY) {
         MaterialTheme.colorScheme.tertiaryContainer
     } else {
         MaterialTheme.colorScheme.secondaryContainer
     }
-    val channelContentColor = if (updateChannel == UpdateChannel.NIGHTLY || updateChannel == UpdateChannel.DAILY_NIGHTLY) {
+    val channelContentColor = if (updateChannel == UpdateChannel.NIGHTLY) {
         MaterialTheme.colorScheme.onTertiaryContainer
     } else {
         MaterialTheme.colorScheme.onSecondaryContainer

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/UpdateScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/UpdateScreen.kt
@@ -168,131 +168,73 @@ fun UpdateScreen(
     var updateSheetNotes by remember { mutableStateOf<String?>(null) }
     var updateSheetError by remember { mutableStateOf<String?>(null) }
     var updateSheetIsSameVersion by remember { mutableStateOf(false) }
+    var showUpdateUpToDateDialog by remember { mutableStateOf(false) }
+    var showUpdateErrorDialog by remember { mutableStateOf(false) }
 
     val updateSheetContent: @Composable ColumnScope.() -> Unit = {
-        if (updateSheetLoading) {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 32.dp),
-                contentAlignment = Alignment.Center
-            ) {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    LoadingIndicator(modifier = Modifier.size(32.dp))
-                    Spacer(Modifier.height(12.dp))
-                    Text(
-                        text = stringResource(R.string.updates_status_checking),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-            }
-        } else if (updateSheetError != null) {
-            Text(
-                text = stringResource(R.string.error_loading_changelog),
-                style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.error,
-                modifier = Modifier.padding(vertical = 16.dp)
-            )
-            Spacer(Modifier.height(8.dp))
-            Text(
-                text = updateSheetError ?: "",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-        } else if (updateSheetIsSameVersion) {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 32.dp),
-                contentAlignment = Alignment.Center
-            ) {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    Icon(
-                        painter = painterResource(R.drawable.done),
-                        contentDescription = null,
-                        modifier = Modifier.size(48.dp),
-                        tint = MaterialTheme.colorScheme.primary
-                    )
-                    Spacer(Modifier.height(12.dp))
-                    Text(
-                        text = stringResource(R.string.updates_status_current),
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.Bold,
-                    )
-                    Spacer(Modifier.height(4.dp))
-                    Text(
-                        text = updateSheetVersion ?: BuildConfig.VERSION_NAME,
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
-            }
-        } else {
-            Text(
-                text = stringResource(R.string.new_update_available),
-                style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
-                modifier = Modifier.padding(top = 16.dp)
-            )
+        Text(
+            text = stringResource(R.string.new_update_available),
+            style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
+            modifier = Modifier.padding(top = 16.dp)
+        )
 
-            Spacer(Modifier.height(8.dp))
+        Spacer(Modifier.height(8.dp))
 
-            OutlinedButton(
-                onClick = {},
-                contentPadding = PaddingValues(horizontal = 5.dp, vertical = 5.dp),
-                shapes = ButtonDefaults.shapes(),
-            ) {
+        OutlinedButton(
+            onClick = {},
+            contentPadding = PaddingValues(horizontal = 5.dp, vertical = 5.dp),
+            shapes = ButtonDefaults.shapes(),
+        ) {
+            Text(
+                text = updateSheetVersion ?: "",
+                style = MaterialTheme.typography.labelLarge
+            )
+        }
+
+        Spacer(Modifier.height(12.dp))
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f, fill = false)
+                .verticalScroll(rememberScrollState())
+        ) {
+            val notes = updateSheetNotes
+            if (notes != null && notes.isNotBlank()) {
+                MarkdownText(
+                    markdown = notes,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(end = 8.dp),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+            } else {
                 Text(
-                    text = updateSheetVersion ?: "",
-                    style = MaterialTheme.typography.labelLarge
+                    text = stringResource(R.string.release_notes_unavailable),
+                    style = MaterialTheme.typography.bodyMedium,
                 )
             }
+        }
 
-            Spacer(Modifier.height(12.dp))
+        Spacer(Modifier.height(12.dp))
 
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .weight(1f, fill = false)
-                    .verticalScroll(rememberScrollState())
-            ) {
-                val notes = updateSheetNotes
-                if (notes != null && notes.isNotBlank()) {
-                    MarkdownText(
-                        markdown = notes,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(end = 8.dp),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurface
-                    )
-                } else {
-                    Text(
-                        text = stringResource(R.string.release_notes_unavailable),
-                        style = MaterialTheme.typography.bodyMedium,
-                    )
-                }
-            }
+        val downloadUrl = when (updateChannel) {
+            UpdateChannel.DAILY_NIGHTLY -> Updater.getLatestDailyNightlyDownloadUrl()
+            UpdateChannel.NIGHTLY -> Updater.getLatestNightlyDownloadUrl()
+            else -> Updater.getLatestDownloadUrl()
+        }
 
-            Spacer(Modifier.height(12.dp))
-
-            val downloadUrl = when (updateChannel) {
-                UpdateChannel.DAILY_NIGHTLY -> Updater.getLatestDailyNightlyDownloadUrl()
-                UpdateChannel.NIGHTLY -> Updater.getLatestNightlyDownloadUrl()
-                else -> Updater.getLatestDownloadUrl()
-            }
-
-            Button(
-                onClick = {
-                    try {
-                        uriHandler.openUri(downloadUrl)
-                    } catch (_: Exception) {}
-                },
-                modifier = Modifier.fillMaxWidth(),
-                shapes = ButtonDefaults.shapes(),
-            ) {
-                Text(text = stringResource(R.string.update_text))
-            }
+        Button(
+            onClick = {
+                try {
+                    uriHandler.openUri(downloadUrl)
+                } catch (_: Exception) {}
+            },
+            modifier = Modifier.fillMaxWidth(),
+            shapes = ButtonDefaults.shapes(),
+        ) {
+            Text(text = stringResource(R.string.update_text))
         }
     }
 
@@ -302,7 +244,8 @@ fun UpdateScreen(
         updateSheetNotes = null
         updateSheetError = null
         updateSheetIsSameVersion = false
-        updateSheetState.show(updateSheetContent)
+        showUpdateUpToDateDialog = false
+        showUpdateErrorDialog = false
 
         coroutineScope.launch {
             val versionResult = when (updateChannel) {
@@ -320,14 +263,21 @@ fun UpdateScreen(
                 }
             }
 
+            updateSheetLoading = false
+
             versionResult.onSuccess { version ->
                 updateSheetIsSameVersion = Updater.isSameVersion(version, BuildConfig.VERSION_NAME)
                 updateSheetVersion = version
+
+                if (updateSheetIsSameVersion) {
+                    showUpdateUpToDateDialog = true
+                } else {
+                    updateSheetState.show(updateSheetContent)
+                }
             }.onFailure { e ->
                 updateSheetError = e.message ?: "Failed to check for updates"
+                showUpdateErrorDialog = true
             }
-
-            updateSheetLoading = false
         }
     }
 
@@ -939,6 +889,86 @@ fun UpdateScreen(
     }
 
     BottomSheetPage(state = updateSheetState)
+
+    if (updateSheetLoading) {
+        AlertDialog(
+            onDismissRequest = {},
+            confirmButton = {},
+            title = {
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Spacer(Modifier.height(16.dp))
+                    LoadingIndicator(modifier = Modifier.size(32.dp))
+                    Spacer(Modifier.height(16.dp))
+                    Text(
+                        text = stringResource(R.string.updates_status_checking),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        )
+    }
+
+    if (showUpdateUpToDateDialog) {
+        AlertDialog(
+            onDismissRequest = { showUpdateUpToDateDialog = false },
+            icon = {
+                Icon(
+                    painter = painterResource(R.drawable.done),
+                    contentDescription = null,
+                    modifier = Modifier.size(48.dp),
+                    tint = MaterialTheme.colorScheme.primary
+                )
+            },
+            title = {
+                Text(
+                    text = stringResource(R.string.updates_status_current),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                )
+            },
+            text = {
+                Text(
+                    text = updateSheetVersion ?: BuildConfig.VERSION_NAME,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = { showUpdateUpToDateDialog = false }) {
+                    Text(stringResource(android.R.string.ok))
+                }
+            }
+        )
+    }
+
+    if (showUpdateErrorDialog) {
+        AlertDialog(
+            onDismissRequest = { showUpdateErrorDialog = false },
+            title = {
+                Text(
+                    text = stringResource(R.string.error_loading_changelog),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            },
+            text = {
+                Text(
+                    text = updateSheetError ?: "",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = { showUpdateErrorDialog = false }) {
+                    Text(stringResource(android.R.string.ok))
+                }
+            }
+        )
+    }
 }
 
 @Composable

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/UpdateScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/UpdateScreen.kt
@@ -90,6 +90,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.navigation.NavController
+import kotlinx.coroutines.launch
 import moe.rukamori.archivetune.BuildConfig
 import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.R
@@ -275,19 +276,17 @@ fun UpdateScreen(
 
         coroutineScope.launch {
             val versionResult = when (updateChannel) {
-                UpdateChannel.DAILY_NIGHTLY -> run {
-                    Updater.getLatestDailyNightlyVersionName().also {
-                        Updater.getLatestDailyNightlyReleaseNotes().onSuccess { notes ->
-                            updateSheetNotes = notes
-                        }
+                UpdateChannel.DAILY_NIGHTLY -> {
+                    Updater.getLatestDailyNightlyReleaseNotes().onSuccess { notes ->
+                        updateSheetNotes = notes
                     }
+                    Updater.getLatestDailyNightlyVersionName()
                 }
-                else -> run {
-                    Updater.getLatestVersionName().also {
-                        Updater.getLatestReleaseNotes().onSuccess { notes ->
-                            updateSheetNotes = notes
-                        }
+                else -> {
+                    Updater.getLatestReleaseNotes().onSuccess { notes ->
+                        updateSheetNotes = notes
                     }
+                    Updater.getLatestVersionName()
                 }
             }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/UpdateScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/UpdateScreen.kt
@@ -21,6 +21,8 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -35,8 +37,12 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -66,6 +72,7 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -89,7 +96,10 @@ import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.constants.EnableUpdateNotificationKey
 import moe.rukamori.archivetune.constants.UpdateChannel
 import moe.rukamori.archivetune.constants.UpdateChannelKey
+import moe.rukamori.archivetune.ui.component.BottomSheetPage
+import moe.rukamori.archivetune.ui.component.BottomSheetPageState
 import moe.rukamori.archivetune.ui.component.IconButton
+import moe.rukamori.archivetune.ui.component.MarkdownText
 import moe.rukamori.archivetune.ui.component.PreferenceGroupTitle
 import moe.rukamori.archivetune.ui.utils.backToMain
 import moe.rukamori.archivetune.utils.GitCommit
@@ -109,6 +119,7 @@ fun UpdateScreen(
 ) {
     val context = LocalContext.current
     val uriHandler = LocalUriHandler.current
+    val coroutineScope = rememberCoroutineScope()
     val nightlyInstallUrl = remember { Updater.getLatestNightlyDownloadUrl() }
 
     val (enableUpdateNotification, onEnableUpdateNotificationChange) = rememberPreference(
@@ -148,6 +159,146 @@ fun UpdateScreen(
     }
     val latestCommit by remember(commits) {
         derivedStateOf { commits.firstOrNull() }
+    }
+
+    val updateSheetState = remember { BottomSheetPageState() }
+    var updateSheetLoading by remember { mutableStateOf(false) }
+    var updateSheetVersion by remember { mutableStateOf<String?>(null) }
+    var updateSheetNotes by remember { mutableStateOf<String?>(null) }
+    var updateSheetError by remember { mutableStateOf<String?>(null) }
+
+    val updateSheetContent: @Composable ColumnScope.() -> Unit = {
+        if (updateSheetLoading) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 32.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    LoadingIndicator(modifier = Modifier.size(32.dp))
+                    Spacer(Modifier.height(12.dp))
+                    Text(
+                        text = stringResource(R.string.updates_status_checking),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        } else if (updateSheetError != null) {
+            Text(
+                text = stringResource(R.string.error_loading_changelog),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.error,
+                modifier = Modifier.padding(vertical = 16.dp)
+            )
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = updateSheetError ?: "",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        } else {
+            Text(
+                text = stringResource(R.string.new_update_available),
+                style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
+                modifier = Modifier.padding(top = 16.dp)
+            )
+
+            Spacer(Modifier.height(8.dp))
+
+            OutlinedButton(
+                onClick = {},
+                contentPadding = PaddingValues(horizontal = 5.dp, vertical = 5.dp),
+                shapes = ButtonDefaults.shapes(),
+            ) {
+                Text(
+                    text = updateSheetVersion ?: "",
+                    style = MaterialTheme.typography.labelLarge
+                )
+            }
+
+            Spacer(Modifier.height(12.dp))
+
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f, fill = false)
+                    .verticalScroll(rememberScrollState())
+            ) {
+                val notes = updateSheetNotes
+                if (notes != null && notes.isNotBlank()) {
+                    MarkdownText(
+                        markdown = notes,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(end = 8.dp),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                } else {
+                    Text(
+                        text = stringResource(R.string.release_notes_unavailable),
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(12.dp))
+
+            val downloadUrl = when (updateChannel) {
+                UpdateChannel.DAILY_NIGHTLY -> Updater.getLatestDailyNightlyDownloadUrl()
+                UpdateChannel.NIGHTLY -> Updater.getLatestNightlyDownloadUrl()
+                else -> Updater.getLatestDownloadUrl()
+            }
+
+            Button(
+                onClick = {
+                    try {
+                        uriHandler.openUri(downloadUrl)
+                    } catch (_: Exception) {}
+                },
+                modifier = Modifier.fillMaxWidth(),
+                shapes = ButtonDefaults.shapes(),
+            ) {
+                Text(text = stringResource(R.string.update_text))
+            }
+        }
+    }
+
+    val onCheckForUpdate: () -> Unit = {
+        updateSheetLoading = true
+        updateSheetVersion = null
+        updateSheetNotes = null
+        updateSheetError = null
+        updateSheetState.show(updateSheetContent)
+
+        coroutineScope.launch {
+            val versionResult = when (updateChannel) {
+                UpdateChannel.DAILY_NIGHTLY -> run {
+                    Updater.getLatestDailyNightlyVersionName().also {
+                        Updater.getLatestDailyNightlyReleaseNotes().onSuccess { notes ->
+                            updateSheetNotes = notes
+                        }
+                    }
+                }
+                else -> run {
+                    Updater.getLatestVersionName().also {
+                        Updater.getLatestReleaseNotes().onSuccess { notes ->
+                            updateSheetNotes = notes
+                        }
+                    }
+                }
+            }
+
+            versionResult.onSuccess { version ->
+                updateSheetVersion = version
+            }.onFailure { e ->
+                updateSheetError = e.message ?: "Failed to check for updates"
+            }
+
+            updateSheetLoading = false
+        }
     }
 
     val permissionLauncher = rememberLauncherForActivityResult(
@@ -432,7 +583,8 @@ fun UpdateScreen(
                     isUpdateAvailable = isUpdateAvailable,
                     onOpenChangelog = {
                         navController.navigate("settings/changelog?channel=$updateChannel")
-                    }
+                    },
+                    onCheckForUpdate = onCheckForUpdate,
                 )
             }
 
@@ -755,6 +907,8 @@ fun UpdateScreen(
             }
         }
     }
+
+    BottomSheetPage(state = updateSheetState)
 }
 
 @Composable
@@ -764,6 +918,7 @@ private fun UpdateSummaryCard(
     updateChannel: UpdateChannel,
     isUpdateAvailable: Boolean,
     onOpenChangelog: () -> Unit,
+    onCheckForUpdate: () -> Unit,
 ) {
     val channelLabel = when (updateChannel) {
         UpdateChannel.STABLE -> stringResource(R.string.channel_stable)
@@ -847,6 +1002,19 @@ private fun UpdateSummaryCard(
                 )
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(text = stringResource(R.string.view_changelog))
+            }
+
+            OutlinedButton(
+                onClick = onCheckForUpdate,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.sync),
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(text = stringResource(R.string.check_for_update))
             }
         }
     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/UpdateScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/UpdateScreen.kt
@@ -167,6 +167,7 @@ fun UpdateScreen(
     var updateSheetVersion by remember { mutableStateOf<String?>(null) }
     var updateSheetNotes by remember { mutableStateOf<String?>(null) }
     var updateSheetError by remember { mutableStateOf<String?>(null) }
+    var updateSheetIsSameVersion by remember { mutableStateOf(false) }
 
     val updateSheetContent: @Composable ColumnScope.() -> Unit = {
         if (updateSheetLoading) {
@@ -199,6 +200,34 @@ fun UpdateScreen(
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
+        } else if (updateSheetIsSameVersion) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 32.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Icon(
+                        painter = painterResource(R.drawable.done),
+                        contentDescription = null,
+                        modifier = Modifier.size(48.dp),
+                        tint = MaterialTheme.colorScheme.primary
+                    )
+                    Spacer(Modifier.height(12.dp))
+                    Text(
+                        text = stringResource(R.string.updates_status_current),
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                    )
+                    Spacer(Modifier.height(4.dp))
+                    Text(
+                        text = updateSheetVersion ?: BuildConfig.VERSION_NAME,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
         } else {
             Text(
                 text = stringResource(R.string.new_update_available),
@@ -272,6 +301,7 @@ fun UpdateScreen(
         updateSheetVersion = null
         updateSheetNotes = null
         updateSheetError = null
+        updateSheetIsSameVersion = false
         updateSheetState.show(updateSheetContent)
 
         coroutineScope.launch {
@@ -291,6 +321,7 @@ fun UpdateScreen(
             }
 
             versionResult.onSuccess { version ->
+                updateSheetIsSameVersion = Updater.isSameVersion(version, BuildConfig.VERSION_NAME)
                 updateSheetVersion = version
             }.onFailure { e ->
                 updateSheetError = e.message ?: "Failed to check for updates"

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/UpdateScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/UpdateScreen.kt
@@ -110,6 +110,7 @@ fun UpdateScreen(
     val context = LocalContext.current
     val uriHandler = LocalUriHandler.current
     val nightlyInstallUrl = remember { Updater.getLatestNightlyDownloadUrl() }
+    val dailyNightlyInstallUrl = remember { Updater.getLatestDailyNightlyDownloadUrl() }
 
     val (enableUpdateNotification, onEnableUpdateNotificationChange) = rememberPreference(
         EnableUpdateNotificationKey,
@@ -125,6 +126,7 @@ fun UpdateScreen(
     var latestVersion by remember { mutableStateOf<String?>(null) }
     var isExpanded by rememberSaveable { mutableStateOf(true) }
     var showNightlyChannelConfirmDialog by rememberSaveable { mutableStateOf(false) }
+    var showDailyNightlyChannelConfirmDialog by rememberSaveable { mutableStateOf(false) }
     var showEnableUpdateNotificationConfirmDialog by rememberSaveable { mutableStateOf(false) }
     var hasNotificationPermission by remember {
         mutableStateOf(
@@ -139,6 +141,7 @@ fun UpdateScreen(
         )
     }
     val isNightlyChannel = updateChannel == UpdateChannel.NIGHTLY
+    val isDailyNightlyChannel = updateChannel == UpdateChannel.DAILY_NIGHTLY
     val isUpdateAvailable by remember(latestVersion) {
         derivedStateOf {
             BuildConfig.UPDATER_AVAILABLE &&
@@ -312,14 +315,94 @@ fun UpdateScreen(
         )
     }
 
-    LaunchedEffect(Unit) {
+    if (showDailyNightlyChannelConfirmDialog) {
+        AlertDialog(
+            onDismissRequest = { showDailyNightlyChannelConfirmDialog = false },
+            title = { Text(stringResource(R.string.channel_daily_nightly)) },
+            text = {
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(
+                        text = "ArchiveTune provides three download channels for builds:",
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+
+                    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                        Text(
+                            text = "• Stable builds",
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.SemiBold
+                        )
+                        Text(
+                            text = "Distributed via official GitHub Releases.",
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                        Text(
+                            text = "These versions are tested and recommended for most users.",
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                    }
+
+                    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                        Text(
+                            text = "• Daily Nightly builds",
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.SemiBold
+                        )
+                        Text(
+                            text = "Published daily as GitHub Releases from the latest development branch.",
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                        Text(
+                            text = "Daily builds may include experimental features, unfinished changes, or temporary regressions.",
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                    }
+
+                    Text(
+                        text = "Daily builds are provided for testing and early access only.\nStability, compatibility, and functionality are not guaranteed.",
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                    Text(
+                        text = "By continuing, you acknowledge that daily builds may be unstable and use them at your own risk.",
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                }
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showDailyNightlyChannelConfirmDialog = false
+                        onUpdateChannelChange(UpdateChannel.DAILY_NIGHTLY)
+                    }
+                ) {
+                    Text(stringResource(android.R.string.ok))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDailyNightlyChannelConfirmDialog = false }) {
+                    Text(stringResource(android.R.string.cancel))
+                }
+            }
+        )
+    }
+
+    LaunchedEffect(updateChannel) {
         if (!BuildConfig.UPDATER_AVAILABLE) {
             isLoadingCommits = false
             return@LaunchedEffect
         }
 
-        Updater.getLatestVersionName().onSuccess {
-            latestVersion = it
+        if (isDailyNightlyChannel) {
+            Updater.getLatestDailyNightlyVersionName().onSuccess {
+                latestVersion = it
+            }
+        } else {
+            Updater.getLatestVersionName().onSuccess {
+                latestVersion = it
+            }
         }
         Updater.getCommitHistory(30).onSuccess {
             commits = it
@@ -333,10 +416,10 @@ fun UpdateScreen(
         targetValue = if (isExpanded) 180f else 0f,
         label = "rotation"
     )
-    val topBarSubtitle = if (isNightlyChannel) {
-        stringResource(R.string.updates_subtitle_nightly)
-    } else {
-        stringResource(R.string.updates_subtitle_stable)
+    val topBarSubtitle = when (updateChannel) {
+        UpdateChannel.NIGHTLY -> stringResource(R.string.updates_subtitle_nightly)
+        UpdateChannel.DAILY_NIGHTLY -> stringResource(R.string.updates_subtitle_daily_nightly)
+        else -> stringResource(R.string.updates_subtitle_stable)
     }
 
     Scaffold(
@@ -479,6 +562,7 @@ fun UpdateScreen(
                                     text = when (updateChannel) {
                                         UpdateChannel.STABLE -> stringResource(R.string.channel_stable)
                                         UpdateChannel.NIGHTLY -> stringResource(R.string.channel_nightly)
+                                        UpdateChannel.DAILY_NIGHTLY -> stringResource(R.string.channel_daily_nightly)
                                     },
                                     style = MaterialTheme.typography.labelLarge,
                                     color = MaterialTheme.colorScheme.primary,
@@ -500,7 +584,7 @@ fun UpdateScreen(
                             SegmentedButton(
                                 selected = updateChannel == UpdateChannel.STABLE,
                                 onClick = { onUpdateChannelChange(UpdateChannel.STABLE) },
-                                shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
+                                shape = SegmentedButtonDefaults.itemShape(index = 0, count = 3),
                                 icon = {},
                             ) {
                                 Text(text = stringResource(R.string.channel_stable))
@@ -512,10 +596,22 @@ fun UpdateScreen(
                                         showNightlyChannelConfirmDialog = true
                                     }
                                 },
-                                shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2),
+                                shape = SegmentedButtonDefaults.itemShape(index = 1, count = 3),
                                 icon = {},
                             ) {
                                 Text(text = stringResource(R.string.channel_nightly))
+                            }
+                            SegmentedButton(
+                                selected = updateChannel == UpdateChannel.DAILY_NIGHTLY,
+                                onClick = {
+                                    if (updateChannel != UpdateChannel.DAILY_NIGHTLY) {
+                                        showDailyNightlyChannelConfirmDialog = true
+                                    }
+                                },
+                                shape = SegmentedButtonDefaults.itemShape(index = 2, count = 3),
+                                icon = {},
+                            ) {
+                                Text(text = stringResource(R.string.channel_daily_nightly))
                             }
                         }
                     }
@@ -523,7 +619,7 @@ fun UpdateScreen(
             }
 
             item {
-                AnimatedVisibility(visible = isNightlyChannel) {
+                AnimatedVisibility(visible = isNightlyChannel || isDailyNightlyChannel) {
                     Card(
                         modifier = Modifier.fillMaxWidth(),
                         shape = MaterialTheme.shapes.extraLarge,
@@ -537,17 +633,31 @@ fun UpdateScreen(
                         ) {
                             ListItem(
                                 overlineContent = {
-                                    Text(text = stringResource(R.string.channel_nightly))
+                                    Text(
+                                        text = when (updateChannel) {
+                                            UpdateChannel.DAILY_NIGHTLY -> stringResource(R.string.channel_daily_nightly)
+                                            else -> stringResource(R.string.channel_nightly)
+                                        }
+                                    )
                                 },
                                 headlineContent = {
                                     Text(
-                                        text = stringResource(R.string.updates_nightly_title),
+                                        text = when (updateChannel) {
+                                            UpdateChannel.DAILY_NIGHTLY -> "Daily delivery"
+                                            else -> stringResource(R.string.updates_nightly_title)
+                                        },
                                         fontWeight = FontWeight.SemiBold,
                                     )
                                 },
                                 supportingContent = {
                                     Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                                        Text(text = stringResource(R.string.updates_nightly_description))
+                                        Text(
+                                            text = when (updateChannel) {
+                                                UpdateChannel.DAILY_NIGHTLY ->
+                                                    "Daily nightly releases are published automatically every day from the latest development branch."
+                                                else -> stringResource(R.string.updates_nightly_description)
+                                            }
+                                        )
                                         Text(
                                             text = stringResource(
                                                 R.string.updates_latest_commit,
@@ -572,7 +682,15 @@ fun UpdateScreen(
                             HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
 
                             OutlinedButton(
-                                onClick = { uriHandler.openUri(nightlyInstallUrl) },
+                                onClick = {
+                                    uriHandler.openUri(
+                                        if (isDailyNightlyChannel) {
+                                            dailyNightlyInstallUrl
+                                        } else {
+                                            nightlyInstallUrl
+                                        }
+                                    )
+                                },
                                 modifier = Modifier.fillMaxWidth(),
                             ) {
                                 Icon(
@@ -722,18 +840,19 @@ private fun UpdateSummaryCard(
     val channelLabel = when (updateChannel) {
         UpdateChannel.STABLE -> stringResource(R.string.channel_stable)
         UpdateChannel.NIGHTLY -> stringResource(R.string.channel_nightly)
+        UpdateChannel.DAILY_NIGHTLY -> stringResource(R.string.channel_daily_nightly)
     }
     val supportingText = when {
         latestVersion == null -> stringResource(R.string.updates_status_checking)
         isUpdateAvailable -> stringResource(R.string.latest_version_format, latestVersion)
         else -> stringResource(R.string.updates_status_current)
     }
-    val channelContainerColor = if (updateChannel == UpdateChannel.NIGHTLY) {
+    val channelContainerColor = if (updateChannel == UpdateChannel.NIGHTLY || updateChannel == UpdateChannel.DAILY_NIGHTLY) {
         MaterialTheme.colorScheme.tertiaryContainer
     } else {
         MaterialTheme.colorScheme.secondaryContainer
     }
-    val channelContentColor = if (updateChannel == UpdateChannel.NIGHTLY) {
+    val channelContentColor = if (updateChannel == UpdateChannel.NIGHTLY || updateChannel == UpdateChannel.DAILY_NIGHTLY) {
         MaterialTheme.colorScheme.onTertiaryContainer
     } else {
         MaterialTheme.colorScheme.onSecondaryContainer

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/UpdateScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/UpdateScreen.kt
@@ -431,11 +431,7 @@ fun UpdateScreen(
                     updateChannel = updateChannel,
                     isUpdateAvailable = isUpdateAvailable,
                     onOpenChangelog = {
-                        if (updateChannel == UpdateChannel.DAILY_NIGHTLY) {
-                            uriHandler.openUri("https://github.com/ArchiveTuneApp/daily-nightly/releases")
-                        } else {
-                            navController.navigate("settings/changelog")
-                        }
+                        navController.navigate("settings/changelog?channel=$updateChannel")
                     }
                 )
             }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/utils/UpdateCheckWorker.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/utils/UpdateCheckWorker.kt
@@ -39,11 +39,25 @@ class UpdateCheckWorker(
                 } ?: UpdateChannel.STABLE
             }.first()
 
-            if (updateChannel == UpdateChannel.NIGHTLY) return Result.success()
-
-            Updater.getLatestVersionName().onSuccess { latestVersion ->
-                if (!Updater.isSameVersion(latestVersion, BuildConfig.VERSION_NAME)) {
-                    UpdateNotificationManager.notifyIfNewVersion(applicationContext, latestVersion)
+            when (updateChannel) {
+                UpdateChannel.NIGHTLY -> return Result.success()
+                UpdateChannel.DAILY_NIGHTLY -> {
+                    Updater.getLatestDailyNightlyVersionName().onSuccess { latestVersion ->
+                        if (!Updater.isSameVersion(latestVersion, BuildConfig.VERSION_NAME)) {
+                            UpdateNotificationManager.notifyIfNewVersion(
+                                applicationContext,
+                                latestVersion,
+                                updateChannel,
+                            )
+                        }
+                    }
+                }
+                else -> {
+                    Updater.getLatestVersionName().onSuccess { latestVersion ->
+                        if (!Updater.isSameVersion(latestVersion, BuildConfig.VERSION_NAME)) {
+                            UpdateNotificationManager.notifyIfNewVersion(applicationContext, latestVersion)
+                        }
+                    }
                 }
             }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/utils/UpdateNotificationManager.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/utils/UpdateNotificationManager.kt
@@ -124,9 +124,14 @@ object UpdateNotificationManager {
 
                 dataStore.edit { it[LastUpdateCheckKey] = now }
 
-                Updater.getLatestVersionName().onSuccess { latestVersion ->
+                val versionResult = when (updateChannel) {
+                    UpdateChannel.DAILY_NIGHTLY -> Updater.getLatestDailyNightlyVersionName()
+                    else -> Updater.getLatestVersionName()
+                }
+
+                versionResult.onSuccess { latestVersion ->
                     if (!Updater.isSameVersion(latestVersion, BuildConfig.VERSION_NAME)) {
-                        notifyIfNewVersion(context, latestVersion)
+                        notifyIfNewVersion(context, latestVersion, updateChannel)
                     }
                 }
             } catch (e: Exception) {
@@ -135,7 +140,11 @@ object UpdateNotificationManager {
         }
     }
 
-    suspend fun notifyIfNewVersion(context: Context, latestVersion: String) {
+    suspend fun notifyIfNewVersion(
+        context: Context,
+        latestVersion: String,
+        updateChannel: UpdateChannel = UpdateChannel.STABLE,
+    ) {
         if (!BuildConfig.UPDATER_AVAILABLE) return
 
         try {
@@ -143,7 +152,7 @@ object UpdateNotificationManager {
             val lastNotified = dataStore.data.map { it[LastNotifiedVersionKey] ?: "" }.first()
 
             if (latestVersion != lastNotified && !Updater.isSameVersion(latestVersion, BuildConfig.VERSION_NAME)) {
-                showUpdateNotification(context, latestVersion)
+                showUpdateNotification(context, latestVersion, updateChannel)
                 dataStore.edit { it[LastNotifiedVersionKey] = latestVersion }
             }
         } catch (e: Exception) {
@@ -151,7 +160,11 @@ object UpdateNotificationManager {
         }
     }
 
-    private fun showUpdateNotification(context: Context, newVersion: String) {
+    private fun showUpdateNotification(
+        context: Context,
+        newVersion: String,
+        updateChannel: UpdateChannel = UpdateChannel.STABLE,
+    ) {
         createNotificationChannel(context)
 
         val openAppIntent = Intent(context, MainActivity::class.java).apply {
@@ -165,7 +178,11 @@ object UpdateNotificationManager {
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
 
-        val downloadIntent = Intent(Intent.ACTION_VIEW, Uri.parse(Updater.getLatestDownloadUrl()))
+        val downloadUrl = when (updateChannel) {
+            UpdateChannel.DAILY_NIGHTLY -> Updater.getLatestDailyNightlyDownloadUrl()
+            else -> Updater.getLatestDownloadUrl()
+        }
+        val downloadIntent = Intent(Intent.ACTION_VIEW, Uri.parse(downloadUrl))
         val downloadPendingIntent = PendingIntent.getActivity(
             context,
             1,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/utils/Updater.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/utils/Updater.kt
@@ -324,6 +324,14 @@ object Updater {
         return StableDownloadUrl
     }
 
+    fun getLatestNightlyDownloadUrl(): String {
+        if (!BuildConfig.UPDATER_AVAILABLE) {
+            return ""
+        }
+
+        return NightlyDownloadUrl
+    }
+
     suspend fun getLatestDailyNightlyVersionName(): Result<String> =
         getLatestDailyNightlyReleaseInfo().map { latest ->
             latest.tagName.ifBlank { latest.name }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/utils/Updater.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/utils/Updater.kt
@@ -25,7 +25,6 @@ import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
 import org.json.JSONArray
-import org.json.JSONObject
 
 data class GitCommit(
     val sha: String,
@@ -53,14 +52,26 @@ object Updater {
     private val client = HttpClient()
     private const val ReleaseCacheCheckIntervalMs: Long = 6 * 60 * 60 * 1000L
     private const val StableDownloadUrl = "https://github.com/ArchiveTuneApp/ArchiveTune/releases/latest"
-    private const val NightlyDownloadUrl =
-        "https://github.com/ArchiveTuneApp/ArchiveTune/actions/workflows/build.yml?query=branch%3Adev+is%3Asuccess"
     private const val DailyNightlyDownloadUrl =
         "https://github.com/ArchiveTuneApp/daily-nightly/releases/latest"
     var lastCheckTime = -1L
         private set
     private var latestReleaseTag: String? = null
     private var latestDailyNightlyReleaseTag: String? = null
+
+    private val isUpdaterDistribution: Boolean
+        get() = BuildConfig.UPDATER_AVAILABLE &&
+            when (BuildConfig.DISTRIBUTION) {
+                "gms", "foss" -> true
+                else -> false
+            }
+
+    private val distributionArtifactPrefix: String
+        get() = when (BuildConfig.DISTRIBUTION) {
+            "gms" -> ""
+            "foss" -> "foss-"
+            else -> ""
+        }
 
     private data class SemVer(
         val major: Int,
@@ -258,7 +269,7 @@ object Updater {
     }
 
     suspend fun getCachedReleases(): List<ReleaseInfo> {
-        if (!BuildConfig.UPDATER_AVAILABLE) {
+        if (!isUpdaterDistribution) {
             return emptyList()
         }
 
@@ -279,7 +290,7 @@ object Updater {
 
     suspend fun getLatestReleaseInfo(): Result<ReleaseInfo> =
         runCatching {
-            if (!BuildConfig.UPDATER_AVAILABLE) {
+            if (!isUpdaterDistribution) {
                 throw IllegalStateException("Updater is not available for this distribution")
             }
 
@@ -293,7 +304,7 @@ object Updater {
 
     suspend fun getCommitHistory(count: Int = 20, branch: String = "dev"): Result<List<GitCommit>> =
         runCatching {
-            if (!BuildConfig.UPDATER_AVAILABLE) {
+            if (!isUpdaterDistribution) {
                 return@runCatching emptyList()
             }
 
@@ -320,24 +331,23 @@ object Updater {
         }
 
     fun getLatestDownloadUrl(): String {
-        if (!BuildConfig.UPDATER_AVAILABLE) {
+        if (!isUpdaterDistribution) {
             return ""
         }
 
         val tag = latestReleaseTag
         if (tag != null) {
-            val distPrefix = if (BuildConfig.DISTRIBUTION != "gms") "${BuildConfig.DISTRIBUTION}-" else ""
-            return "https://github.com/ArchiveTuneApp/ArchiveTune/releases/download/$tag/app-${distPrefix}${BuildConfig.DEVICE}-${BuildConfig.ARCHITECTURE}-release.apk"
+            return "https://github.com/ArchiveTuneApp/ArchiveTune/releases/download/$tag/app-$distributionArtifactPrefix${BuildConfig.DEVICE}-${BuildConfig.ARCHITECTURE}-release.apk"
         }
         return StableDownloadUrl
     }
 
     fun getLatestNightlyDownloadUrl(): String {
-        if (!BuildConfig.UPDATER_AVAILABLE) {
+        if (!isUpdaterDistribution) {
             return ""
         }
 
-        return NightlyDownloadUrl
+        return "https://nightly.link/koiverse/ArchiveTune/workflows/build/dev/app-$distributionArtifactPrefix${BuildConfig.DEVICE}-${BuildConfig.ARCHITECTURE}-release"
     }
 
     suspend fun getLatestDailyNightlyVersionName(): Result<String> =
@@ -350,7 +360,7 @@ object Updater {
 
     suspend fun getLatestDailyNightlyReleaseInfo(): Result<ReleaseInfo> =
         runCatching {
-            if (!BuildConfig.UPDATER_AVAILABLE) {
+            if (!isUpdaterDistribution) {
                 throw IllegalStateException("Updater is not available for this distribution")
             }
 
@@ -362,7 +372,7 @@ object Updater {
         }
 
     suspend fun getCachedDailyNightlyReleases(): List<ReleaseInfo> {
-        if (!BuildConfig.UPDATER_AVAILABLE) {
+        if (!isUpdaterDistribution) {
             return emptyList()
         }
 
@@ -377,7 +387,7 @@ object Updater {
         perPage: Int = 10,
         forceRefresh: Boolean = false,
     ): Result<List<ReleaseInfo>> {
-        if (!BuildConfig.UPDATER_AVAILABLE) {
+        if (!isUpdaterDistribution) {
             return Result.success(emptyList())
         }
 
@@ -502,13 +512,13 @@ object Updater {
     }
 
     fun getLatestDailyNightlyDownloadUrl(): String {
-        if (!BuildConfig.UPDATER_AVAILABLE) {
+        if (!isUpdaterDistribution) {
             return ""
         }
 
         val tag = latestDailyNightlyReleaseTag
         if (tag != null) {
-            return "https://github.com/ArchiveTuneApp/daily-nightly/releases/download/$tag/app-${BuildConfig.DEVICE}-${BuildConfig.ARCHITECTURE}-nightly.apk"
+            return "https://github.com/ArchiveTuneApp/daily-nightly/releases/download/$tag/app-$distributionArtifactPrefix${BuildConfig.DEVICE}-${BuildConfig.ARCHITECTURE}-nightly.apk"
         }
         return DailyNightlyDownloadUrl
     }
@@ -517,7 +527,7 @@ object Updater {
         perPage: Int = 30,
         forceRefresh: Boolean = false,
     ): Result<List<ReleaseInfo>> {
-        if (!BuildConfig.UPDATER_AVAILABLE) {
+        if (!isUpdaterDistribution) {
             return Result.success(emptyList())
         }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/utils/Updater.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/utils/Updater.kt
@@ -59,6 +59,8 @@ object Updater {
         "https://github.com/ArchiveTuneApp/daily-nightly/releases/latest"
     var lastCheckTime = -1L
         private set
+    private var latestReleaseTag: String? = null
+    private var latestDailyNightlyReleaseTag: String? = null
 
     private data class SemVer(
         val major: Int,
@@ -285,6 +287,7 @@ object Updater {
             val latest = findLatestRelease(releases)
                 ?: throw IllegalStateException("No releases found")
             lastCheckTime = System.currentTimeMillis()
+            latestReleaseTag = latest.tagName
             latest
         }
 
@@ -321,6 +324,10 @@ object Updater {
             return ""
         }
 
+        val tag = latestReleaseTag
+        if (tag != null) {
+            return "https://github.com/ArchiveTuneApp/ArchiveTune/releases/download/$tag/app-${BuildConfig.DEVICE}-${BuildConfig.ARCHITECTURE}-release.apk"
+        }
         return StableDownloadUrl
     }
 
@@ -349,6 +356,7 @@ object Updater {
             val releases = getAllDailyNightlyReleases().getOrThrow()
             val latest = findLatestDailyNightlyRelease(releases)
                 ?: throw IllegalStateException("No daily-nightly releases found")
+            latestDailyNightlyReleaseTag = latest.tagName
             latest
         }
 
@@ -497,6 +505,10 @@ object Updater {
             return ""
         }
 
+        val tag = latestDailyNightlyReleaseTag
+        if (tag != null) {
+            return "https://github.com/ArchiveTuneApp/daily-nightly/releases/download/$tag/app-${BuildConfig.DEVICE}-${BuildConfig.ARCHITECTURE}-nightly.apk"
+        }
         return DailyNightlyDownloadUrl
     }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/utils/Updater.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/utils/Updater.kt
@@ -10,6 +10,10 @@ package moe.rukamori.archivetune.utils
 import androidx.datastore.preferences.core.edit
 import moe.rukamori.archivetune.BuildConfig
 import moe.rukamori.archivetune.App
+import moe.rukamori.archivetune.constants.DailyNightlyReleasesEtagKey
+import moe.rukamori.archivetune.constants.DailyNightlyReleasesFingerprintKey
+import moe.rukamori.archivetune.constants.DailyNightlyReleasesJsonKey
+import moe.rukamori.archivetune.constants.DailyNightlyReleasesLastCheckedAtKey
 import moe.rukamori.archivetune.constants.GitHubReleasesEtagKey
 import moe.rukamori.archivetune.constants.GitHubReleasesFingerprintKey
 import moe.rukamori.archivetune.constants.GitHubReleasesJsonKey
@@ -51,6 +55,8 @@ object Updater {
     private const val StableDownloadUrl = "https://github.com/ArchiveTuneApp/ArchiveTune/releases/latest"
     private const val NightlyDownloadUrl =
         "https://github.com/ArchiveTuneApp/ArchiveTune/actions/workflows/build.yml?query=branch%3Adev+is%3Asuccess"
+    private const val DailyNightlyDownloadUrl =
+        "https://github.com/ArchiveTuneApp/daily-nightly/releases/latest"
     var lastCheckTime = -1L
         private set
 
@@ -171,6 +177,16 @@ object Updater {
         val stable = parsed.filter { it.first.preRelease.isEmpty() }
         val candidates = stable.ifEmpty { parsed }
         return candidates.maxWithOrNull(compareBy({ it.first }, { it.second.publishedAt }))?.second
+    }
+
+    internal fun findLatestDailyNightlyRelease(
+        releases: List<ReleaseInfo>,
+    ): ReleaseInfo? {
+        if (releases.isEmpty()) return null
+        return releases.maxByOrNull { release ->
+            val dateTag = release.tagName.removePrefix("N").takeWhile { it.isDigit() }
+            dateTag.toLongOrNull() ?: 0L
+        }
     }
 
     private fun preferredReleaseVersionNameOrNull(release: ReleaseInfo): String? =
@@ -308,12 +324,172 @@ object Updater {
         return StableDownloadUrl
     }
 
-    fun getLatestNightlyDownloadUrl(): String {
+    suspend fun getLatestDailyNightlyVersionName(): Result<String> =
+        getLatestDailyNightlyReleaseInfo().map { latest ->
+            latest.tagName.ifBlank { latest.name }
+        }
+
+    suspend fun getLatestDailyNightlyReleaseNotes(): Result<String?> =
+        getLatestDailyNightlyReleaseInfo().map { it.body }
+
+    suspend fun getLatestDailyNightlyReleaseInfo(): Result<ReleaseInfo> =
+        runCatching {
+            if (!BuildConfig.UPDATER_AVAILABLE) {
+                throw IllegalStateException("Updater is not available for this distribution")
+            }
+
+            val releases = getAllDailyNightlyReleases().getOrThrow()
+            val latest = findLatestDailyNightlyRelease(releases)
+                ?: throw IllegalStateException("No daily-nightly releases found")
+            latest
+        }
+
+    suspend fun getCachedDailyNightlyReleases(): List<ReleaseInfo> {
+        if (!BuildConfig.UPDATER_AVAILABLE) {
+            return emptyList()
+        }
+
+        val cachedJson = App.instance.dataStore.getAsync(DailyNightlyReleasesJsonKey)
+        return cachedJson
+            ?.takeIf { it.isNotBlank() }
+            ?.let { runCatching { parseReleasesJson(it) }.getOrNull() }
+            ?: emptyList()
+    }
+
+    suspend fun getAllDailyNightlyReleases(
+        perPage: Int = 10,
+        forceRefresh: Boolean = false,
+    ): Result<List<ReleaseInfo>> {
+        if (!BuildConfig.UPDATER_AVAILABLE) {
+            return Result.success(emptyList())
+        }
+
+        return runCatching {
+            val now = System.currentTimeMillis()
+            val cachedJson = App.instance.dataStore.getAsync(DailyNightlyReleasesJsonKey)
+            val cachedEtag = App.instance.dataStore.getAsync(DailyNightlyReleasesEtagKey)
+            val lastCheckedAt = App.instance.dataStore.getAsync(DailyNightlyReleasesLastCheckedAtKey, 0L)
+            val cachedFingerprint = App.instance.dataStore.getAsync(DailyNightlyReleasesFingerprintKey)
+
+            val cachedReleases =
+                cachedJson
+                    ?.takeIf { it.isNotBlank() }
+                    ?.let { runCatching { parseReleasesJson(it) }.getOrNull() }
+
+            val shouldCheckNetwork =
+                forceRefresh || cachedJson.isNullOrBlank() || (now - lastCheckedAt) >= ReleaseCacheCheckIntervalMs
+
+            if (!shouldCheckNetwork) {
+                return@runCatching cachedReleases ?: emptyList()
+            }
+
+            val networkResult = runCatching {
+                fetchDailyNightlyReleasesNetwork(
+                    perPage = perPage,
+                    cachedEtag = cachedEtag,
+                )
+            }.getOrNull()
+
+            if (networkResult == null) {
+                val fallback = cachedReleases
+                if (fallback != null) {
+                    return@runCatching fallback
+                }
+                throw IllegalStateException("Failed to fetch daily-nightly releases")
+            }
+
+            when {
+                networkResult.status == HttpStatusCode.NotModified -> {
+                    App.instance.dataStore.edit { settings ->
+                        settings[DailyNightlyReleasesLastCheckedAtKey] = now
+                        networkResult.etag?.let { settings[DailyNightlyReleasesEtagKey] = it }
+                    }
+                    val fallback = cachedReleases
+                    if (fallback != null) {
+                        return@runCatching fallback
+                    }
+                    throw IllegalStateException("Daily-nightly release cache is empty")
+                }
+
+                networkResult.status.value in 200..299 && !networkResult.body.isNullOrBlank() -> {
+                    val networkBody = networkResult.body
+                    val releases = parseReleasesJson(networkBody)
+                    val newFingerprint = getDailyNightlyTopReleaseFingerprint(releases)
+                    val hasPayloadChanged = cachedJson != networkBody
+                    val hasTopReleaseChanged = cachedFingerprint != newFingerprint
+
+                    App.instance.dataStore.edit { settings ->
+                        settings[DailyNightlyReleasesLastCheckedAtKey] = now
+                        networkResult.etag?.let { settings[DailyNightlyReleasesEtagKey] = it }
+                        if (hasPayloadChanged || hasTopReleaseChanged || cachedJson.isNullOrBlank()) {
+                            settings[DailyNightlyReleasesJsonKey] = networkBody
+                            settings[DailyNightlyReleasesFingerprintKey] = newFingerprint
+                        }
+                    }
+                    releases
+                }
+
+                else -> {
+                    val fallback = cachedReleases
+                    if (fallback != null) {
+                        fallback
+                    } else {
+                        throw IllegalStateException("Failed to fetch daily-nightly releases: HTTP ${networkResult.status.value}")
+                    }
+                }
+            }
+        }
+    }
+
+    private suspend fun fetchDailyNightlyReleasesNetwork(
+        perPage: Int,
+        cachedEtag: String?,
+    ): ReleasesNetworkResult {
+        val response: HttpResponse =
+            client.get("https://api.github.com/repos/ArchiveTuneApp/daily-nightly/releases?per_page=$perPage") {
+                headers {
+                    append("Accept", "application/vnd.github+json")
+                    append("User-Agent", "ArchiveTune")
+                    if (!cachedEtag.isNullOrBlank()) {
+                        append("If-None-Match", cachedEtag)
+                    }
+                }
+            }
+        val etag = response.headers["ETag"]
+        return when (response.status) {
+            HttpStatusCode.NotModified ->
+                ReleasesNetworkResult(
+                    status = response.status,
+                    body = null,
+                    etag = cachedEtag ?: etag,
+                )
+
+            else ->
+                ReleasesNetworkResult(
+                    status = response.status,
+                    body = response.bodyAsText(),
+                    etag = etag,
+                )
+        }
+    }
+
+    private fun getDailyNightlyTopReleaseFingerprint(releases: List<ReleaseInfo>): String {
+        val latest = findLatestDailyNightlyRelease(releases) ?: return ""
+        return listOf(
+            latest.tagName,
+            latest.name,
+            latest.publishedAt,
+            latest.body.orEmpty(),
+            latest.htmlUrl,
+        ).joinToString("||")
+    }
+
+    fun getLatestDailyNightlyDownloadUrl(): String {
         if (!BuildConfig.UPDATER_AVAILABLE) {
             return ""
         }
 
-        return NightlyDownloadUrl
+        return DailyNightlyDownloadUrl
     }
 
     suspend fun getAllReleases(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/utils/Updater.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/utils/Updater.kt
@@ -326,7 +326,8 @@ object Updater {
 
         val tag = latestReleaseTag
         if (tag != null) {
-            return "https://github.com/ArchiveTuneApp/ArchiveTune/releases/download/$tag/app-${BuildConfig.DEVICE}-${BuildConfig.ARCHITECTURE}-release.apk"
+            val distPrefix = if (BuildConfig.DISTRIBUTION != "gms") "${BuildConfig.DISTRIBUTION}-" else ""
+            return "https://github.com/ArchiveTuneApp/ArchiveTune/releases/download/$tag/app-${distPrefix}${BuildConfig.DEVICE}-${BuildConfig.ARCHITECTURE}-release.apk"
         }
         return StableDownloadUrl
     }

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -643,6 +643,7 @@
     <string name="recent_commits">Commits Gần đây</string>
     <string name="changelog">Nhật ký thay đổi</string>
     <string name="view_changelog">Xem nhật ký thay đổi</string>
+    <string name="check_for_update">Kiểm tra bản cập nhật</string>
     <string name="error_loading_changelog">Lỗi khi tải nhật ký thay đổi</string>
     <string name="no_releases">Không tìm thấy phiên bản nào</string>
     <string name="update_notification_channel_name">Cập nhật Ứng dụng</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -824,6 +824,7 @@
     <string name="updates">Updates</string>
     <string name="updates_subtitle_stable">Stable releases and release notes</string>
     <string name="updates_subtitle_nightly">Nightly builds and recent development commits</string>
+    <string name="updates_subtitle_daily_nightly">Daily nightly releases and changelogs</string>
     <string name="current_version">Current Version</string>
     <string name="latest_version_format">Latest: %s</string>
     <string name="updates_status_checking">Checking for the latest release</string>
@@ -835,6 +836,7 @@
     <string name="update_channel_desc">Choose between tested releases and development snapshots.</string>
     <string name="channel_stable">Stable</string>
     <string name="channel_nightly">Nightly</string>
+    <string name="channel_daily_nightly">Daily</string>
     <string name="commit_history">Development</string>
     <string name="recent_commits">Recent Commits</string>
     <string name="updates_nightly_title">Nightly delivery</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -848,6 +848,7 @@
     <string name="updates_no_commits">No recent commits found</string>
     <string name="changelog">Changelog</string>
     <string name="view_changelog">View Changelog</string>
+    <string name="check_for_update">Check for Update</string>
     <string name="error_loading_changelog">Error loading changelog</string>
     <string name="no_releases">No releases found</string>
     <string name="update_notification_channel_name">App Updates</string>


### PR DESCRIPTION
## Summary

Adds a **Daily Nightly** update channel that checks for releases from the [ArchiveTuneApp/daily-nightly](https://github.com/ArchiveTuneApp/daily-nightly) repository, with an in-app changelog and a manual "Check for Update" button.

## Changes

### Daily Nightly channel support
- **PreferenceKeys.kt** — added `DAILY_NIGHTLY` to `UpdateChannel` enum + 4 DataStore cache keys for daily-nightly releases
- **Updater.kt** — methods to fetch, cache, and find the latest daily-nightly release (date-sorted tags like `N20260608`), with a dedicated network endpoint to `https://api.github.com/repos/ArchiveTuneApp/daily-nightly/releases`
- **UpdateNotificationManager.kt** — routes `DAILY_NIGHTLY` channel to daily-nightly version check and download URL
- **UpdateCheckWorker.kt** — same routing for periodic background checks
- **UpdateScreen.kt** — three-segment channel selector (Stable / Nightly / Daily), confirm dialog for Daily channel, dynamic version fetching per channel
- **strings.xml** — added channel labels and subtitle strings

### In-app changelog for Daily channel
- **ChangelogScreen.kt** — accepts optional `UpdateChannel` parameter; when `DAILY_NIGHTLY`, loads releases from the daily-nightly repo instead of the main repo
- **NavigationBuilder.kt** — route `settings/changelog?channel={channel}` with optional query param, parsed into `UpdateChannel`
- **UpdateScreen.kt** — all three channels now navigate to the in-app changelog (previously Daily opened the browser)

### Check for Update button
- **UpdateScreen.kt** — new "Check for Update" button below "View Changelog" that opens a bottom sheet with loading state, version info, scrollable release notes, and a channel-aware download button
- **strings.xml** — added `check_for_update` string

### i18n
- **values-vi/strings.xml** — Vietnamese translation for `check_for_update`

## Notes
- The existing `NIGHTLY` channel still returns early with no update check notification (unchanged behavior)
- `DAILY_NIGHTLY` actively fetches releases and shows notifications for new builds
- All channels share the same in-app changelog screen, differing only in which repo they query