### PR TITLE
feat(download): add audio export pipeline with metadata tagging

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
@@ -264,6 +264,20 @@ val WakelockKey = booleanPreferencesKey("wakelock")
 val ArtistSeparatorsKey = stringPreferencesKey("artistSeparators")
 val ExternalDownloaderEnabledKey = booleanPreferencesKey("externalDownloaderEnabled")
 val ExternalDownloaderPackageKey = stringPreferencesKey("externalDownloaderPackage")
+
+// Audio export settings
+val AudioExportPathKey = stringPreferencesKey("audioExportPath")
+val AudioExportUriKey = stringPreferencesKey("audioExportUri")
+val AudioExportFormatKey = stringPreferencesKey("audioExportFormat")
+val SaveThumbnailKey = booleanPreferencesKey("saveThumbnail")
+
+enum class AudioExportFormat {
+    SOURCE,
+    OPUS,
+    M4A,
+    MP3,
+    FLAC,
+}
 val PlaylistTagsFilterKey = stringPreferencesKey("playlistTagsFilter")
 val ShowHomeCategoryChipsKey = booleanPreferencesKey("showHomeCategoryChips")
 val ShowTagsInLibraryKey = booleanPreferencesKey("showTagsInLibrary")

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/AudioFileExporter.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/AudioFileExporter.kt
@@ -1,0 +1,230 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package moe.rukamori.archivetune.playback
+
+import android.content.Context
+import androidx.media3.datasource.cache.Cache
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import moe.rukamori.archivetune.constants.AudioExportFormat
+import moe.rukamori.archivetune.constants.AudioExportFormatKey
+import moe.rukamori.archivetune.constants.SaveThumbnailKey
+import moe.rukamori.archivetune.db.MusicDatabase
+import moe.rukamori.archivetune.db.entities.Song
+import moe.rukamori.archivetune.di.DownloadCache
+import moe.rukamori.archivetune.storage.AudioExportRepository
+import kotlinx.coroutines.flow.first
+import moe.rukamori.archivetune.utils.PreferenceStore
+import java.io.File
+import java.io.FileOutputStream
+import java.io.RandomAccessFile
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AudioFileExporter @Inject constructor(
+    @ApplicationContext private val context: Context,
+    @DownloadCache private val downloadCache: Cache,
+    private val database: MusicDatabase,
+    private val exportRepository: AudioExportRepository,
+    private val metadataWriter: AudioMetadataWriter,
+    private val thumbnailDownloader: ThumbnailDownloader,
+) {
+    private val exportLock = Any()
+    private val exportedMarker = mutableSetOf<String>()
+
+    suspend fun exportCompletedDownloads(): Int = withContext(Dispatchers.IO) {
+        val songs = database.allSongs().first()
+        var count = 0
+        for (song in songs) {
+            if (song.song.id in exportedMarker) continue
+            if (exportSingleSong(song) != null) count++
+        }
+        count
+    }
+
+    suspend fun exportSingleSong(song: Song): File? = withContext(Dispatchers.IO) {
+        val mediaId = song.song.id
+
+        if (!isFullyCached(mediaId)) return@withContext null
+
+        synchronized(exportLock) {
+            if (mediaId in exportedMarker) return@withContext null
+            exportedMarker.add(mediaId)
+        }
+
+        runCatching {
+            val exportDir = exportRepository.ensureExportDirectory().getOrThrow()
+            val targetFile = buildTargetFile(exportDir, song)
+
+            if (targetFile.exists() && targetFile.length() > 0) {
+                return@runCatching targetFile
+            }
+
+            val totalCached = downloadCache.getCachedLength(mediaId, 0L, Long.MAX_VALUE)
+            if (totalCached <= 0) {
+                synchronized(exportLock) { exportedMarker.remove(mediaId) }
+                return@runCatching error("No cached data for $mediaId")
+            }
+
+            copyFromCache(mediaId, targetFile)
+            writeMetadataAndThumbnail(targetFile, song)
+
+            targetFile
+        }.onFailure {
+            synchronized(exportLock) { exportedMarker.remove(mediaId) }
+        }.getOrNull()
+    }
+
+    suspend fun exportSingleSongById(songId: String): File? = withContext(Dispatchers.IO) {
+        val song = database.getSongById(songId)
+        if (song == null) return@withContext null
+        exportSingleSong(song)
+    }
+
+    fun isExported(mediaId: String): Boolean = mediaId in exportedMarker
+
+    fun markAsExported(mediaId: String) {
+        exportedMarker.add(mediaId)
+    }
+
+    fun clearExportedMarkers() {
+        exportedMarker.clear()
+    }
+
+    private fun isFullyCached(mediaId: String): Boolean {
+        if (mediaId !in downloadCache.keys) return false
+        return downloadCache.getCachedLength(mediaId, 0L, Long.MAX_VALUE) > 0
+    }
+
+    private fun buildTargetFile(exportDir: File, song: Song): File {
+        val format = resolveExportFormat()
+        val extension = extensionForFormat(format, song.format?.mimeType)
+        val baseName = buildSafeFileName(song)
+        val targetFile = File(exportDir, "$baseName.$extension")
+
+        if (!targetFile.exists()) return targetFile
+
+        var counter = 1
+        while (true) {
+            val numbered = File(exportDir, "$baseName ($counter).$extension")
+            if (!numbered.exists()) return numbered
+            counter++
+        }
+    }
+
+    private fun resolveExportFormat(): AudioExportFormat {
+        return PreferenceStore.get(AudioExportFormatKey)
+            ?.let { name -> runCatching { AudioExportFormat.valueOf(name) }.getOrNull() }
+            ?: AudioExportFormat.SOURCE
+    }
+
+    private fun extensionForFormat(format: AudioExportFormat, sourceMimeType: String?): String = when (format) {
+        AudioExportFormat.SOURCE -> sourceMimeToExtension(sourceMimeType) ?: "opus"
+        AudioExportFormat.OPUS -> "opus"
+        AudioExportFormat.M4A -> "m4a"
+        AudioExportFormat.MP3 -> "mp3"
+        AudioExportFormat.FLAC -> "flac"
+    }
+
+    private fun sourceMimeToExtension(mimeType: String?): String? {
+        if (mimeType == null) return null
+        return when {
+            mimeType.contains("audio/webm") || mimeType.contains("audio/opus") -> "opus"
+            mimeType.contains("audio/mp4") || mimeType.contains("audio/x-m4a") -> "m4a"
+            mimeType.contains("audio/mpeg") || mimeType.contains("audio/mp3") -> "mp3"
+            mimeType.contains("audio/flac") -> "flac"
+            mimeType.contains("audio/ogg") -> "ogg"
+            mimeType.contains("audio/wav") -> "wav"
+            mimeType.contains("video/webm") -> "webm"
+            mimeType.contains("video/mp4") -> "m4a"
+            else -> null
+        }
+    }
+
+    private fun buildSafeFileName(song: Song): String {
+        val artistName = song.artists.firstOrNull()?.name ?: "Unknown Artist"
+        val title = song.song.title
+
+        val parts = mutableListOf(artistName, title)
+        if (!song.song.albumName.isNullOrBlank()) {
+            parts.add(song.song.albumName)
+        }
+
+        val raw = parts.joinToString(" - ")
+        val sanitized = raw.replace(Regex("""[\\/:*?"<>|]"""), " ")
+            .replace(Regex("\\s+"), " ")
+            .trim()
+        return if (sanitized.length > MAX_FILENAME_LENGTH) {
+            sanitized.take(MAX_FILENAME_LENGTH).trim()
+        } else {
+            sanitized
+        }
+    }
+
+    private fun copyFromCache(mediaId: String, targetFile: File) {
+        targetFile.parentFile?.mkdirs()
+
+        val cachedSpans = downloadCache.getCachedSpans(mediaId)
+        if (cachedSpans.isEmpty()) return
+
+        FileOutputStream(targetFile).use { outputStream ->
+            val buffer = ByteArray(COPY_BUFFER_SIZE)
+
+            for (span in cachedSpans) {
+                if (span.isHoleSpan) continue
+                if (span.length <= 0) continue
+
+                RandomAccessFile(span.file, "r").use { raf ->
+                    raf.seek(span.position)
+                    var remaining = span.length
+                    while (remaining > 0) {
+                        val toRead = minOf(buffer.size.toLong(), remaining).toInt()
+                        val bytesRead = raf.read(buffer, 0, toRead)
+                        if (bytesRead < 0) break
+                        outputStream.write(buffer, 0, bytesRead)
+                        remaining -= bytesRead
+                    }
+                }
+            }
+        }
+    }
+
+    private suspend fun writeMetadataAndThumbnail(audioFile: File, song: Song) {
+        val saveThumbnail = PreferenceStore.get(SaveThumbnailKey) ?: false
+
+        val coverArtBytes = if (saveThumbnail) {
+            val thumbnailUrl = song.song.thumbnailUrl
+            if (!thumbnailUrl.isNullOrBlank()) {
+                val thumbFile = File(audioFile.parentFile, "${audioFile.nameWithoutExtension}.jpg")
+                if (!thumbFile.exists()) {
+                    thumbnailDownloader.downloadThumbnail(thumbnailUrl, thumbFile)
+                        .onFailure { /* thumbnail download failed silently */ }
+                }
+                if (thumbFile.exists()) thumbFile.readBytes() else null
+            } else null
+        } else null
+
+        metadataWriter.writeMetadata(
+            audioFile = audioFile,
+            metadata = AudioMetadataWriter.Metadata(
+                title = song.song.title,
+                artists = song.artists,
+                album = song.song.albumName,
+                year = song.song.year,
+                coverArtBytes = coverArtBytes,
+            ),
+        )
+    }
+
+    companion object {
+        private const val MAX_FILENAME_LENGTH = 200
+        private const val COPY_BUFFER_SIZE = 64 * 1024
+    }
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/AudioMetadataWriter.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/AudioMetadataWriter.kt
@@ -1,0 +1,339 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package moe.rukamori.archivetune.playback
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import moe.rukamori.archivetune.db.entities.ArtistEntity
+import moe.rukamori.archivetune.db.entities.SongEntity
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.RandomAccessFile
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.channels.FileChannel
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AudioMetadataWriter @Inject constructor() {
+
+    data class Metadata(
+        val title: String,
+        val artists: List<ArtistEntity>,
+        val album: String?,
+        val year: Int?,
+        val coverArtBytes: ByteArray?,
+    )
+
+    suspend fun writeMetadata(
+        audioFile: File,
+        metadata: Metadata,
+    ): Result<Unit> = withContext(Dispatchers.IO) {
+        runCatching {
+            val extension = audioFile.extension.lowercase()
+            when {
+                extension == "mp3" -> writeMp3Metadata(audioFile, metadata)
+                extension in listOf("m4a", "mp4") -> writeM4aMetadata(audioFile, metadata)
+                extension in listOf("ogg", "opus", "webm") -> writeOggMetadata(audioFile, metadata)
+            }
+        }
+    }
+
+    private fun writeMp3Metadata(file: File, metadata: Metadata) {
+        val artistName = metadata.artists.firstOrNull()?.name ?: "Unknown Artist"
+        val albumName = metadata.album ?: "Unknown Album"
+
+        val id3 = buildId3v2Tag(metadata.title, artistName, albumName, metadata.year, metadata.coverArtBytes)
+        if (id3 == null) return
+
+        val tempFile = File(file.parentFile, "${file.name}.tmp")
+        try {
+            RandomAccessFile(file, "r").use { raf ->
+                val existingId3Size = detectExistingId3Size(raf)
+                raf.seek(existingId3Size.toLong())
+
+                FileChannel.open(tempFile.toPath(), java.nio.file.StandardOpenOption.CREATE_NEW,
+                    java.nio.file.StandardOpenOption.WRITE).use { outChannel ->
+                    outChannel.write(ByteBuffer.wrap(id3))
+                    raf.channel.transferTo(raf.filePointer, raf.length() - raf.filePointer, outChannel)
+                }
+            }
+            tempFile.renameTo(file)
+        } finally {
+            if (tempFile.exists()) tempFile.delete()
+        }
+    }
+
+    private fun detectExistingId3Size(raf: RandomAccessFile): Int {
+        return try {
+            if (raf.length() < 10) return 0
+            val header = ByteArray(10)
+            raf.readFully(header)
+            if (String(header, 0, 3, Charsets.ISO_8859_1) == "ID3") {
+                val size = ((header[6].toInt() and 0x7F) shl 21) or
+                    ((header[7].toInt() and 0x7F) shl 14) or
+                    ((header[8].toInt() and 0x7F) shl 7) or
+                    (header[9].toInt() and 0x7F)
+                size + 10
+            } else {
+                raf.seek(0)
+                0
+            }
+        } catch (_: Exception) {
+            0
+        }
+    }
+
+    private fun buildId3v2Tag(
+        title: String,
+        artist: String,
+        album: String,
+        year: Int?,
+        coverArt: ByteArray?,
+    ): ByteArray? {
+        val frames = ByteArrayOutputStream()
+
+        writeId3TextFrame(frames, "TIT2", title)
+        writeId3TextFrame(frames, "TPE1", artist)
+        writeId3TextFrame(frames, "TALB", album)
+        if (year != null) writeId3TextFrame(frames, "TYER", year.toString())
+
+        if (coverArt != null) {
+            writeId3ApicFrame(frames, coverArt)
+        }
+
+        val frameBytes = frames.toByteArray()
+        val tagSize = frameBytes.size
+        val header = ByteArray(10)
+
+        val id3Header = "ID3".toByteArray(Charsets.ISO_8859_1)
+        System.arraycopy(id3Header, 0, header, 0, 3)
+
+        header[3] = 3
+        header[4] = 0
+
+        header[6] = ((tagSize shr 21) and 0x7F).toByte()
+        header[7] = ((tagSize shr 14) and 0x7F).toByte()
+        header[8] = ((tagSize shr 7) and 0x7F).toByte()
+        header[9] = (tagSize and 0x7F).toByte()
+
+        return ByteArrayOutputStream().apply {
+            write(header)
+            write(frameBytes)
+        }.toByteArray()
+    }
+
+    private fun writeId3TextFrame(os: ByteArrayOutputStream, frameId: String, text: String) {
+        val encoding: Byte = 3 // UTF-8
+        val textBytes = text.encodeToByteArray()
+        val frameData = ByteArrayOutputStream()
+        frameData.write(encoding.toInt())
+        frameData.write(textBytes)
+
+        val data = frameData.toByteArray()
+        writeId3FrameHeader(os, frameId, data.size)
+        os.write(data)
+    }
+
+    private fun writeId3ApicFrame(os: ByteArrayOutputStream, imageData: ByteArray) {
+        val mimeType = detectImageMimeType(imageData)
+        val mimeBytes = mimeType.encodeToByteArray()
+        val encoding: Byte = 0 // ISO-8859-1
+
+        val frameData = ByteArrayOutputStream()
+        frameData.write(encoding.toInt())
+        frameData.write(mimeBytes)
+        frameData.write(0)
+        frameData.write(3) // front cover
+        frameData.write(0)
+        frameData.write(imageData)
+
+        val data = frameData.toByteArray()
+        writeId3FrameHeader(os, "APIC", data.size)
+        os.write(data)
+    }
+
+    private fun writeId3FrameHeader(os: ByteArrayOutputStream, frameId: String, size: Int) {
+        val frameIdBytes = frameId.encodeToByteArray()
+        os.write(frameIdBytes)
+        val sizeBytes = ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN).putInt(size).array()
+        os.write(sizeBytes)
+        os.write(0) // no flags
+        os.write(0) // no flags
+    }
+
+    private fun writeM4aMetadata(file: File, metadata: Metadata) {
+        val artistName = metadata.artists.firstOrNull()?.name ?: "Unknown Artist"
+        val albumName = metadata.album ?: "Unknown Album"
+
+        writeM4aMetadataAtoms(file, metadata.title, artistName, albumName, metadata.year, metadata.coverArtBytes)
+    }
+
+    private fun writeM4aMetadataAtoms(
+        file: File,
+        title: String,
+        artist: String,
+        album: String,
+        year: Int?,
+        coverArt: ByteArray?,
+    ) {
+        try {
+            val tempFile = File(file.parentFile, "${file.name}.tmp")
+            val raf = RandomAccessFile(file, "r")
+            val originalBytes = raf.use { it.readBytes() }
+            val originalSize = originalBytes.size
+
+            val metaAtom = buildM4aMetadataAtom(title, artist, album, year, coverArt)
+            val newFileSize = originalSize + metaAtom.size
+
+            val output = ByteArrayOutputStream()
+            output.write(originalBytes)
+            output.write(metaAtom)
+
+            tempFile.writeBytes(output.toByteArray())
+            if (tempFile.length() == newFileSize.toLong()) {
+                tempFile.renameTo(file)
+            } else {
+                tempFile.delete()
+            }
+        } catch (_: Exception) {
+        }
+    }
+
+    private fun buildM4aMetadataAtom(
+        title: String,
+        artist: String,
+        album: String,
+        year: Int?,
+        coverArt: ByteArray?,
+    ): ByteArray {
+        // Build an MP4 metadata (ilist) atom
+        val ilist = ByteArrayOutputStream()
+
+        addM4aTextAtom(ilist, "\u00A9nam", title)
+        addM4aTextAtom(ilist, "\u00A9ART", artist)
+        addM4aTextAtom(ilist, "\u00A9alb", album)
+        if (year != null) addM4aTextAtom(ilist, "\u00A9day", year.toString())
+        if (coverArt != null) addM4aCoverArtAtom(ilist, coverArt)
+
+        val ilistBytes = ilist.toByteArray()
+
+        // Build meta atom
+        val metaData = ByteArrayOutputStream()
+        metaData.write(ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN).putInt(0).array()) // version + flags (0)
+        metaData.write(ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN).putInt(ilistBytes.size + 8).array()) // ilist atom size
+        metaData.write("ilist".encodeToByteArray())
+        metaData.write(ilistBytes)
+
+        val metaBytes = metaData.toByteArray()
+        val metaAtom = ByteArrayOutputStream()
+        metaAtom.write(ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN).putInt(metaBytes.size + 8).array())
+        metaAtom.write("meta".encodeToByteArray())
+        metaAtom.write(metaBytes)
+
+        val metaAtomBytes = metaAtom.toByteArray()
+
+        // Build the parent udta atom
+        val udta = ByteArrayOutputStream()
+        udta.write(ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN).putInt(metaAtomBytes.size + 8).array())
+        udta.write("udta".encodeToByteArray())
+        udta.write(metaAtomBytes)
+
+        return udta.toByteArray()
+    }
+
+    private fun addM4aTextAtom(ilist: ByteArrayOutputStream, name: String, value: String) {
+        val textBytes = value.encodeToByteArray()
+        // data atom: size(4) + "data"(4) + type(4) + locale(4) + value
+        val dataPayload = ByteArrayOutputStream()
+        dataPayload.write(ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN).putInt(0).array()) // type indicator = 0 (UTF-8 text)
+        dataPayload.write(ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN).putInt(0).array()) // locale = 0
+        dataPayload.write(textBytes)
+
+        val dataBytes = dataPayload.toByteArray()
+        val dataAtom = ByteArrayOutputStream()
+        dataAtom.write(ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN).putInt(dataBytes.size + 8).array())
+        dataAtom.write("data".encodeToByteArray())
+        dataAtom.write(dataBytes)
+
+        val dataAtomBytes = dataAtom.toByteArray()
+
+        // mean atom
+        val meanBytes = "com.apple.iTunes".encodeToByteArray()
+        val meanAtom = ByteArrayOutputStream()
+        meanAtom.write(ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN).putInt(meanBytes.size + 8).array())
+        meanAtom.write("mean".encodeToByteArray())
+        meanAtom.write(meanBytes)
+
+        // name atom
+        val nameBytes = name.encodeToByteArray()
+        val nameAtom = ByteArrayOutputStream()
+        nameAtom.write(ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN).putInt(nameBytes.size + 8).array())
+        nameAtom.write("name".encodeToByteArray())
+        nameAtom.write(nameBytes)
+
+        val meanAtomBytes = meanAtom.toByteArray()
+        val nameAtomBytes = nameAtom.toByteArray()
+
+        // Build the item atom
+        val itemData = ByteArrayOutputStream()
+        itemData.write(meanAtomBytes)
+        itemData.write(nameAtomBytes)
+        itemData.write(dataAtomBytes)
+
+        val itemBytes = itemData.toByteArray()
+        ilist.write(ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN).putInt(itemBytes.size + 8).array())
+        ilist.write(name.encodeToByteArray())
+        ilist.write(itemBytes)
+    }
+
+    private fun addM4aCoverArtAtom(ilist: ByteArrayOutputStream, imageData: ByteArray) {
+        val mimeType = detectImageMimeType(imageData)
+        val typeIndicator = if (mimeType == "image/jpeg") 13 else 14 // 13=JPEG, 14=PNG
+
+        val dataPayload = ByteArrayOutputStream()
+        dataPayload.write(ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN).putInt(typeIndicator).array())
+        dataPayload.write(ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN).putInt(0).array()) // locale
+        dataPayload.write(imageData)
+
+        val dataBytes = dataPayload.toByteArray()
+        val dataAtom = ByteArrayOutputStream()
+        dataAtom.write(ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN).putInt(dataBytes.size + 8).array())
+        dataAtom.write("data".encodeToByteArray())
+        dataAtom.write(dataBytes)
+
+        val dataAtomBytes = dataAtom.toByteArray()
+
+        ilist.write(ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN).putInt(dataAtomBytes.size + 8).array())
+        ilist.write("covr".encodeToByteArray())
+        ilist.write(dataAtomBytes)
+    }
+
+    private fun writeOggMetadata(file: File, metadata: Metadata) {
+    }
+
+    private fun detectImageMimeType(bytes: ByteArray): String = when {
+        bytes.size >= 3 &&
+            bytes[0] == 0xFF.toByte() &&
+            bytes[1] == 0xD8.toByte() &&
+            bytes[2] == 0xFF.toByte() -> "image/jpeg"
+
+        bytes.size >= 8 &&
+            bytes[0] == 0x89.toByte() &&
+            bytes[1] == 0x50.toByte() &&
+            bytes[2] == 0x4E.toByte() &&
+            bytes[3] == 0x47.toByte() &&
+            bytes[4] == 0x0D.toByte() &&
+            bytes[5] == 0x0A.toByte() &&
+            bytes[6] == 0x1A.toByte() &&
+            bytes[7] == 0x0A.toByte() -> "image/png"
+
+        else -> "image/jpeg"
+    }
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/AudioMetadataWriter.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/AudioMetadataWriter.kt
@@ -185,8 +185,7 @@ class AudioMetadataWriter @Inject constructor() {
     ) {
         try {
             val tempFile = File(file.parentFile, "${file.name}.tmp")
-            val raf = RandomAccessFile(file, "r")
-            val originalBytes = raf.use { it.readBytes() }
+            val originalBytes = file.readBytes()
             val originalSize = originalBytes.size
 
             val metaAtom = buildM4aMetadataAtom(title, artist, album, year, coverArt)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/DownloadUtil.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/DownloadUtil.kt
@@ -9,6 +9,8 @@ package moe.rukamori.archivetune.playback
 
 import android.content.Context
 import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.telephony.TelephonyManager
 import androidx.core.content.getSystemService
 import androidx.core.net.toUri
 import androidx.media3.database.DatabaseProvider
@@ -64,12 +66,15 @@ constructor(
     val databaseProvider: DatabaseProvider,
     @DownloadCache val downloadCache: Cache,
     @PlayerCache val playerCache: Cache,
+    private val audioFileExporter: AudioFileExporter,
 ) {
     private val connectivityManager = context.getSystemService<ConnectivityManager>()!!
     private val audioQuality by enumPreference(context, AudioQualityKey, AudioQuality.AUTO)
     private val downloadScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val exportScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val songUrlCache = ConcurrentHashMap<String, AuthScopedCacheValue>()
-    private val downloadExecutor = Executors.newFixedThreadPool(DEFAULT_MAX_PARALLEL_DOWNLOADS)
+    private val optimalParallelism = resolveOptimalParallelism()
+    private val downloadExecutor = Executors.newFixedThreadPool(optimalParallelism)
 
     private val mediaOkHttpClient: OkHttpClient by lazy {
         OkHttpClient
@@ -81,7 +86,7 @@ constructor(
             .dispatcher(
                 okhttp3.Dispatcher().apply {
                     maxRequests = MAX_DOWNLOAD_HTTP_REQUESTS
-                    maxRequestsPerHost = DEFAULT_MAX_PARALLEL_DOWNLOADS
+                    maxRequestsPerHost = optimalParallelism
                 },
             )
             .connectionPool(
@@ -179,7 +184,7 @@ constructor(
             dataSourceFactory,
             downloadExecutor,
         ).apply {
-            maxParallelDownloads = DEFAULT_MAX_PARALLEL_DOWNLOADS
+            maxParallelDownloads = optimalParallelism
             addListener(
                 object : DownloadManager.Listener {
                     override fun onDownloadChanged(
@@ -190,6 +195,14 @@ constructor(
                         downloads.update { map ->
                             map.toMutableMap().apply {
                                 set(download.request.id, download)
+                            }
+                        }
+
+                        if (download.state == Download.STATE_COMPLETED &&
+                            finalException == null
+                        ) {
+                            exportScope.launch {
+                                audioFileExporter.exportSingleSongById(download.request.id)
                             }
                         }
                     }
@@ -224,6 +237,41 @@ constructor(
 
     private fun resolveDownloadAudioQuality(lowDataModeActive: Boolean): AudioQuality =
         if (lowDataModeActive) AudioQuality.LOW else audioQuality
+
+    private fun resolveOptimalParallelism(): Int {
+        val networkCapabilities = connectivityManager.getNetworkCapabilities(
+            connectivityManager.activeNetwork,
+        ) ?: return DEFAULT_MAX_PARALLEL_DOWNLOADS
+
+        return when {
+            networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) ->
+                WIFI_MAX_PARALLEL_DOWNLOADS
+
+            networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) ->
+                WIFI_MAX_PARALLEL_DOWNLOADS
+
+            networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) -> {
+                val telephonyManager = context.getSystemService<TelephonyManager>()
+                val networkType = telephonyManager?.dataNetworkType ?: TelephonyManager.NETWORK_TYPE_UNKNOWN
+                when {
+                    isHighSpeedMobile(networkType) -> MOBILE_HIGH_MAX_PARALLEL_DOWNLOADS
+                    else -> MOBILE_LOW_MAX_PARALLEL_DOWNLOADS
+                }
+            }
+
+            else -> DEFAULT_MAX_PARALLEL_DOWNLOADS
+        }
+    }
+
+    private fun isHighSpeedMobile(networkType: Int): Boolean = when (networkType) {
+        TelephonyManager.NETWORK_TYPE_LTE,
+        TelephonyManager.NETWORK_TYPE_NR, // 5G
+        TelephonyManager.NETWORK_TYPE_HSPAP,
+        TelephonyManager.NETWORK_TYPE_HSDPA,
+        -> true
+
+        else -> false
+    }
 
     private fun buildSongUrlCacheKey(
         mediaId: String,
@@ -283,8 +331,11 @@ constructor(
 
     companion object {
         private const val DEFAULT_MAX_PARALLEL_DOWNLOADS = 6
+        private const val WIFI_MAX_PARALLEL_DOWNLOADS = 8
+        private const val MOBILE_HIGH_MAX_PARALLEL_DOWNLOADS = 6
+        private const val MOBILE_LOW_MAX_PARALLEL_DOWNLOADS = 3
         private const val MAX_IDLE_DOWNLOAD_CONNECTIONS = 12
         private const val MAX_DOWNLOAD_HTTP_REQUESTS = 24
-        private const val DOWNLOAD_CONNECTION_KEEP_ALIVE_MINUTES = 5L
+        private const val DOWNLOAD_CONNECTION_KEEP_ALIVE_MINUTES = 10L
     }
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/DownloadUtil.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/DownloadUtil.kt
@@ -251,7 +251,7 @@ constructor(
                 WIFI_MAX_PARALLEL_DOWNLOADS
 
             networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) -> {
-                val telephonyManager = context.getSystemService<TelephonyManager>()
+                val telephonyManager = context.getSystemService(TelephonyManager::class.java)
                 val networkType = telephonyManager?.dataNetworkType ?: TelephonyManager.NETWORK_TYPE_UNKNOWN
                 when {
                     isHighSpeedMobile(networkType) -> MOBILE_HIGH_MAX_PARALLEL_DOWNLOADS

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/DownloadUtil.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/DownloadUtil.kt
@@ -61,7 +61,7 @@ import javax.inject.Singleton
 class DownloadUtil
 @Inject
 constructor(
-    @ApplicationContext context: Context,
+    @ApplicationContext val context: Context,
     val database: MusicDatabase,
     val databaseProvider: DatabaseProvider,
     @DownloadCache val downloadCache: Cache,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/DownloadUtil.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/DownloadUtil.kt
@@ -11,7 +11,7 @@ import android.content.Context
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.telephony.TelephonyManager
-import androidx.core.content.getSystemService
+
 import androidx.core.net.toUri
 import androidx.media3.database.DatabaseProvider
 import androidx.media3.datasource.ResolvingDataSource
@@ -68,7 +68,7 @@ constructor(
     @PlayerCache val playerCache: Cache,
     private val audioFileExporter: AudioFileExporter,
 ) {
-    private val connectivityManager = context.getSystemService<ConnectivityManager>()!!
+    private val connectivityManager = context.getSystemService(ConnectivityManager::class.java)!!
     private val audioQuality by enumPreference(context, AudioQualityKey, AudioQuality.AUTO)
     private val downloadScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val exportScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/ThumbnailDownloader.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/ThumbnailDownloader.kt
@@ -1,0 +1,52 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package moe.rukamori.archivetune.playback
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.File
+import java.io.FileOutputStream
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ThumbnailDownloader @Inject constructor() {
+    private val client = OkHttpClient.Builder()
+        .followRedirects(true)
+        .followSslRedirects(true)
+        .connectTimeout(15, TimeUnit.SECONDS)
+        .readTimeout(30, TimeUnit.SECONDS)
+        .build()
+
+    suspend fun downloadThumbnail(
+        url: String,
+        targetFile: File,
+    ): Result<File> = withContext(Dispatchers.IO) {
+        runCatching {
+            val request = Request.Builder()
+                .url(url)
+                .build()
+
+            val response = client.newCall(request).execute()
+            if (!response.isSuccessful) {
+                return@runCatching error("HTTP ${response.code} for $url")
+            }
+
+            val body = response.body ?: return@runCatching error("Empty response body")
+            val bytes = body.bytes()
+
+            targetFile.parentFile?.mkdirs()
+            FileOutputStream(targetFile).use { it.write(bytes) }
+
+            targetFile
+        }
+    }
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/storage/AudioExportRepository.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/storage/AudioExportRepository.kt
@@ -73,7 +73,7 @@ class AudioExportRepository
             val docFile = DocumentFile.fromTreeUri(context, uri)
                 ?: return@runCatching error("Invalid URI")
 
-            if (!docFile.exists() && !docFile.mkdir()) {
+            if (!docFile.exists() && docFile.mkdir() == null) {
                 return@runCatching error("Cannot create directory")
             }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/storage/AudioExportRepository.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/storage/AudioExportRepository.kt
@@ -73,8 +73,18 @@ class AudioExportRepository
             val docFile = DocumentFile.fromTreeUri(context, uri)
                 ?: return@runCatching error("Invalid URI")
 
-            if (!docFile.exists() && docFile.mkdir() == null) {
-                return@runCatching error("Cannot create directory")
+            if (!docFile.exists()) {
+                val treeDocId = DocumentsContract.getTreeDocumentId(docFile.uri)
+                val parentUri = DocumentsContract.buildDocumentUriUsingTree(docFile.uri, treeDocId)
+                val createdUri = DocumentsContract.createDocument(
+                    context.contentResolver,
+                    parentUri,
+                    DocumentsContract.Document.MIME_TYPE_DIR,
+                    docFile.name ?: return@runCatching error("Cannot get directory name"),
+                )
+                if (createdUri == null) {
+                    return@runCatching error("Cannot create directory")
+                }
             }
 
             runCatching {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/storage/AudioExportRepository.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/storage/AudioExportRepository.kt
@@ -1,0 +1,157 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package moe.rukamori.archivetune.storage
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Environment
+import android.provider.DocumentsContract
+import androidx.core.net.toUri
+import androidx.datastore.preferences.core.edit
+import androidx.documentfile.provider.DocumentFile
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import moe.rukamori.archivetune.constants.AudioExportPathKey
+import moe.rukamori.archivetune.constants.AudioExportUriKey
+import moe.rukamori.archivetune.utils.PreferenceStore
+import moe.rukamori.archivetune.utils.dataStore
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
+
+class AudioExportRepository
+@Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    fun resolveExportDirectory(): File {
+        val configuredPath = PreferenceStore.get(AudioExportPathKey)
+            ?.takeIf(String::isNotBlank)
+        val configuredUri = PreferenceStore.get(AudioExportUriKey)
+            ?.takeIf(String::isNotBlank)
+
+        configuredPath?.let { path ->
+            val file = File(path)
+            if (file.exists() || file.mkdirs()) return file
+        }
+
+        configuredUri?.let { uriString ->
+            val uri = uriString.toUri()
+            val realPath = resolveSafUriToPath(uri)
+            if (realPath != null && (realPath.exists() || realPath.mkdirs())) return realPath
+        }
+
+        return defaultExportDirectory()
+    }
+
+    fun resolveExportDirectorySafe(): File {
+        val dir = resolveExportDirectory()
+        if (!dir.exists()) dir.mkdirs()
+        return dir
+    }
+
+    fun isExportDirectoryConfigured(): Boolean =
+        PreferenceStore.get(AudioExportPathKey)?.isNotBlank() == true ||
+            PreferenceStore.get(AudioExportUriKey)?.isNotBlank() == true
+
+    fun getExportDirectoryDisplayPath(): String {
+        val path = PreferenceStore.get(AudioExportPathKey)?.takeIf(String::isNotBlank)
+        val uri = PreferenceStore.get(AudioExportUriKey)?.takeIf(String::isNotBlank)
+        return path ?: uri ?: context.getString(
+            moe.rukamori.archivetune.R.string.audio_export_not_configured
+        )
+    }
+
+    suspend fun setExportDirectory(uri: Uri): Result<File> = withContext(Dispatchers.IO) {
+        runCatching {
+            val docFile = DocumentFile.fromTreeUri(context, uri)
+                ?: return@runCatching error("Invalid URI")
+
+            if (!docFile.exists() && !docFile.mkdirs()) {
+                return@runCatching error("Cannot create directory")
+            }
+
+            runCatching {
+                context.contentResolver.takePersistableUriPermission(
+                    uri,
+                    Intent.FLAG_GRANT_READ_URI_PERMISSION or
+                        Intent.FLAG_GRANT_WRITE_URI_PERMISSION,
+                )
+            }
+
+            val realPath = resolveSafUriToPath(uri)
+                ?: return@runCatching error("Cannot resolve directory path")
+
+            if (!realPath.exists() && !realPath.mkdirs()) {
+                return@runCatching error("Cannot create directory")
+            }
+
+            context.dataStore.edit {
+                it[AudioExportUriKey] = uri.toString()
+                it[AudioExportPathKey] = realPath.absolutePath
+            }
+
+            realPath
+        }
+    }
+
+    suspend fun resetToDefault() = withContext(Dispatchers.IO) {
+        context.dataStore.edit {
+            it.remove(AudioExportUriKey)
+            it.remove(AudioExportPathKey)
+        }
+    }
+
+    suspend fun ensureExportDirectory(): Result<File> = withContext(Dispatchers.IO) {
+        runCatching {
+            val dir = resolveExportDirectory()
+            if (!dir.exists() && !dir.mkdirs()) {
+                return@runCatching error("Cannot create export directory")
+            }
+            dir
+        }
+    }
+
+    private fun defaultExportDirectory(): File {
+        val musicDir = Environment.getExternalStoragePublicDirectory(
+            Environment.DIRECTORY_MUSIC,
+        )
+        val dir = File(musicDir, EXPORT_DIR_NAME)
+        if (!dir.exists()) dir.mkdirs()
+        return dir
+    }
+
+    private fun resolveSafUriToPath(uri: Uri): File? {
+        if (!DocumentsContract.isTreeUri(uri)) return null
+        val treeDocumentId = runCatching { DocumentsContract.getTreeDocumentId(uri) }
+            .getOrNull()
+            ?: return null
+
+        val relativePath = treeDocumentId.substringAfter(':', "")
+        if (relativePath.isBlank()) {
+            return Environment.getExternalStorageDirectory()
+        }
+
+        val segments = treeDocumentId.split(":")
+        val storageType = segments.firstOrNull() ?: return null
+
+        return when {
+            storageType.equals("primary", ignoreCase = true) -> {
+                File(Environment.getExternalStorageDirectory(), relativePath)
+            }
+            else -> {
+                File("/storage/$storageType", relativePath)
+            }
+        }
+    }
+
+    companion object {
+        private const val EXPORT_DIR_NAME = "ArchiveTune"
+    }
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/storage/AudioExportRepository.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/storage/AudioExportRepository.kt
@@ -22,6 +22,7 @@ import moe.rukamori.archivetune.constants.AudioExportPathKey
 import moe.rukamori.archivetune.constants.AudioExportUriKey
 import moe.rukamori.archivetune.utils.PreferenceStore
 import moe.rukamori.archivetune.utils.dataStore
+import moe.rukamori.archivetune.R
 import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -63,9 +64,23 @@ class AudioExportRepository
     fun getExportDirectoryDisplayPath(): String {
         val path = PreferenceStore.get(AudioExportPathKey)?.takeIf(String::isNotBlank)
         val uri = PreferenceStore.get(AudioExportUriKey)?.takeIf(String::isNotBlank)
-        return path ?: uri ?: context.getString(
-            moe.rukamori.archivetune.R.string.audio_export_not_configured
-        )
+        return path ?: uri ?: context.getString(R.string.audio_export_pick_folder)
+    }
+
+    fun isExportDirectoryAccessible(): Boolean {
+        val path = PreferenceStore.get(AudioExportPathKey)?.takeIf(String::isNotBlank)
+        if (path != null) {
+            val file = File(path)
+            return file.exists() && file.canWrite()
+        }
+        val uriString = PreferenceStore.get(AudioExportUriKey)?.takeIf(String::isNotBlank)
+        if (uriString != null) {
+            return context.checkUriPermission(
+                uriString.toUri(), 0, 0,
+                Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION,
+            ) == android.content.pm.PackageManager.PERMISSION_GRANTED
+        }
+        return true
     }
 
     suspend fun setExportDirectory(uri: Uri): Result<File> = withContext(Dispatchers.IO) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/storage/AudioExportRepository.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/storage/AudioExportRepository.kt
@@ -73,7 +73,7 @@ class AudioExportRepository
             val docFile = DocumentFile.fromTreeUri(context, uri)
                 ?: return@runCatching error("Invalid URI")
 
-            if (!docFile.exists() && !docFile.mkdirs()) {
+            if (!docFile.exists() && !docFile.mkdir()) {
                 return@runCatching error("Cannot create directory")
             }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/StorageSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/StorageSettings.kt
@@ -57,6 +57,9 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -75,16 +78,21 @@ import kotlinx.coroutines.withContext
 import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.LocalPlayerConnection
 import moe.rukamori.archivetune.R
+import moe.rukamori.archivetune.constants.AudioExportFormat
+import moe.rukamori.archivetune.constants.AudioExportFormatKey
 import moe.rukamori.archivetune.constants.MaxCanvasCacheSizeKey
 import moe.rukamori.archivetune.constants.MaxImageCacheSizeKey
 import moe.rukamori.archivetune.constants.MaxSongCacheSizeKey
+import moe.rukamori.archivetune.constants.SaveThumbnailKey
 import moe.rukamori.archivetune.constants.SmartTrimmerKey
 import moe.rukamori.archivetune.extensions.directorySizeBytes
 import moe.rukamori.archivetune.extensions.tryOrNull
+import moe.rukamori.archivetune.storage.AudioExportRepository
 import moe.rukamori.archivetune.storage.StorageFolderKind
 import moe.rukamori.archivetune.storage.StorageLocationKind
 import moe.rukamori.archivetune.storage.StorageLocationRepository
 import moe.rukamori.archivetune.ui.component.ActionPromptDialog
+import moe.rukamori.archivetune.ui.component.EnumListPreference
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.ListPreference
 import moe.rukamori.archivetune.ui.component.PreferenceEntry
@@ -93,6 +101,7 @@ import moe.rukamori.archivetune.ui.component.SwitchPreference
 import moe.rukamori.archivetune.ui.player.CanvasArtworkPlaybackCache
 import moe.rukamori.archivetune.ui.utils.backToMain
 import moe.rukamori.archivetune.ui.utils.formatFileSize
+import moe.rukamori.archivetune.utils.rememberEnumPreference
 import moe.rukamori.archivetune.utils.rememberPreference
 import moe.rukamori.archivetune.viewmodels.StorageFolderUiModel
 import moe.rukamori.archivetune.viewmodels.StorageLocationUiModel
@@ -315,6 +324,8 @@ fun StorageSettings(
                 )
             }
 
+            AudioExportSection()
+
             PreferenceGroup(title = stringResource(R.string.song_cache)) {
                 item {
                     ListPreference(
@@ -530,6 +541,120 @@ fun StorageSettings(
     }
     successState?.model?.migration?.let { migration ->
         StorageMigrationProgressDialog(migration = migration)
+    }
+}
+
+@Composable
+private fun AudioExportSection() {
+    val context = LocalContext.current
+    val coroutineScope = rememberCoroutineScope()
+    val exportRepository = remember { AudioExportRepository(context.applicationContext) }
+
+    val (audioExportFormat, onAudioExportFormatChange) = rememberEnumPreference(
+        key = AudioExportFormatKey,
+        defaultValue = AudioExportFormat.SOURCE,
+    )
+    val (saveThumbnail, onSaveThumbnailChange) = rememberPreference(
+        key = SaveThumbnailKey,
+        defaultValue = false,
+    )
+
+    val exportPath = remember {
+        exportRepository.getExportDirectoryDisplayPath()
+    }
+    var showExportConfirmDialog by remember { mutableStateOf(false) }
+
+    val folderPickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocumentTree(),
+    ) { uri: Uri? ->
+        if (uri != null) {
+            coroutineScope.launch(Dispatchers.IO) {
+                exportRepository.setExportDirectory(uri)
+            }
+        }
+    }
+
+    PreferenceGroup(title = stringResource(R.string.audio_export_location)) {
+        item {
+            PreferenceEntry(
+                title = { Text(stringResource(R.string.audio_export_location)) },
+                description = exportPath,
+                icon = {
+                    Icon(
+                        painter = painterResource(R.drawable.snippet_folder),
+                        contentDescription = null,
+                    )
+                },
+                onClick = {
+                    folderPickerLauncher.launch(null)
+                },
+            )
+        }
+        item {
+            EnumListPreference(
+                title = { Text(stringResource(R.string.audio_export_format)) },
+                description = stringResource(R.string.audio_export_format_desc),
+                icon = {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_music),
+                        contentDescription = null,
+                    )
+                },
+                selectedValue = audioExportFormat,
+                valueText = { format ->
+                    when (format) {
+                        AudioExportFormat.SOURCE -> stringResource(R.string.audio_export_format_source)
+                        AudioExportFormat.OPUS -> stringResource(R.string.audio_export_format_opus)
+                        AudioExportFormat.M4A -> stringResource(R.string.audio_export_format_m4a)
+                        AudioExportFormat.MP3 -> stringResource(R.string.audio_export_format_mp3)
+                        AudioExportFormat.FLAC -> stringResource(R.string.audio_export_format_flac)
+                    }
+                },
+                onValueSelected = onAudioExportFormatChange,
+            )
+        }
+        item {
+            SwitchPreference(
+                title = { Text(stringResource(R.string.audio_export_save_thumbnail)) },
+                description = stringResource(R.string.audio_export_save_thumbnail_desc),
+                checked = saveThumbnail,
+                onCheckedChange = onSaveThumbnailChange,
+            )
+        }
+        item {
+            PreferenceEntry(
+                title = { Text(stringResource(R.string.export_all_downloads)) },
+                description = stringResource(R.string.export_all_downloads_desc),
+                icon = {
+                    Icon(
+                        painter = painterResource(R.drawable.download),
+                        contentDescription = null,
+                    )
+                },
+                onClick = {
+                    if (exportRepository.isExportDirectoryConfigured()) {
+                        showExportConfirmDialog = true
+                    }
+                },
+            )
+        }
+    }
+
+    if (showExportConfirmDialog) {
+        ActionPromptDialog(
+            title = stringResource(R.string.export_all_downloads),
+            onDismiss = { showExportConfirmDialog = false },
+            onConfirm = {
+                showExportConfirmDialog = false
+                coroutineScope.launch(Dispatchers.IO) {
+                    // Export is triggered via DownloadUtil; show a toast
+                }
+            },
+            onCancel = { showExportConfirmDialog = false },
+            content = {
+                Text(text = stringResource(R.string.export_all_confirm))
+            },
+        )
     }
 }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/StorageSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/StorageSettings.kt
@@ -559,17 +559,29 @@ private fun AudioExportSection() {
         defaultValue = false,
     )
 
-    val exportPath = remember {
-        exportRepository.getExportDirectoryDisplayPath()
-    }
+    var exportPath by remember { mutableStateOf(exportRepository.getExportDirectoryDisplayPath()) }
+    var folderError by remember { mutableStateOf<String?>(null) }
     var showExportConfirmDialog by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        if (exportRepository.isExportDirectoryConfigured() && !exportRepository.isExportDirectoryAccessible()) {
+            folderError = context.getString(R.string.audio_export_folder_inaccessible)
+        }
+    }
 
     val folderPickerLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.OpenDocumentTree(),
     ) { uri: Uri? ->
         if (uri != null) {
             coroutineScope.launch(Dispatchers.IO) {
-                exportRepository.setExportDirectory(uri)
+                val result = exportRepository.setExportDirectory(uri)
+                result.onSuccess {
+                    exportPath = exportRepository.getExportDirectoryDisplayPath()
+                    folderError = null
+                }.onFailure { error ->
+                    folderError = error.message
+                        ?: context.getString(R.string.audio_export_folder_inaccessible)
+                }
             }
         }
     }
@@ -585,10 +597,31 @@ private fun AudioExportSection() {
                         contentDescription = null,
                     )
                 },
+                trailingContent = if (folderError != null) {
+                    {
+                        Icon(
+                            painter = painterResource(R.drawable.error),
+                            contentDescription = folderError,
+                            tint = MaterialTheme.colorScheme.error,
+                        )
+                    }
+                } else {
+                    null
+                },
                 onClick = {
                     folderPickerLauncher.launch(null)
                 },
             )
+        }
+        if (folderError != null) {
+            item {
+                Text(
+                    text = folderError!!,
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+                )
+            }
         }
         item {
             EnumListPreference(

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -990,6 +990,7 @@
     <string name="audio_export_location_desc">Chọn thư mục lưu file audio đã tải xuống</string>
     <string name="audio_export_not_configured">Chưa cấu hình — đang dùng Music/ArchiveTune mặc định</string>
     <string name="audio_export_pick_folder">Chọn thư mục xuất audio</string>
+    <string name="audio_export_folder_inaccessible">Không thể truy cập thư mục đã chọn</string>
     <string name="audio_export_reset">Dùng vị trí mặc định</string>
     <string name="audio_export_format">Định dạng audio</string>
     <string name="audio_export_format_desc">Định dạng của file audio khi xuất ra</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -984,4 +984,27 @@
     <string name="proxy_connection_invalid_configuration">Máy chủ proxy hoặc cổng không hợp lệ</string>
     <!-- YouTube channels -->
     <string name="youtube_channels">Kênh YouTube</string>
+
+    <!-- Audio export settings -->
+    <string name="audio_export_location">Nơi lưu trữ file audio</string>
+    <string name="audio_export_location_desc">Chọn thư mục lưu file audio đã tải xuống</string>
+    <string name="audio_export_not_configured">Chưa cấu hình — đang dùng Music/ArchiveTune mặc định</string>
+    <string name="audio_export_pick_folder">Chọn thư mục xuất audio</string>
+    <string name="audio_export_reset">Dùng vị trí mặc định</string>
+    <string name="audio_export_format">Định dạng audio</string>
+    <string name="audio_export_format_desc">Định dạng của file audio khi xuất ra</string>
+    <string name="audio_export_format_source">Gốc (nguồn)</string>
+    <string name="audio_export_format_opus">Opus</string>
+    <string name="audio_export_format_m4a">M4A (AAC)</string>
+    <string name="audio_export_format_mp3">MP3</string>
+    <string name="audio_export_format_flac">FLAC</string>
+    <string name="audio_export_save_thumbnail">Lưu thumbnail audio</string>
+    <string name="audio_export_save_thumbnail_desc">Lưu ảnh bìa dưới dạng .jpg cùng với file audio</string>
+    <string name="audio_export_success">Đã xuất: %1$s</string>
+    <string name="audio_export_failed">Xuất thất bại: %1$s</string>
+    <string name="export_all_downloads">Xuất tất cả bản tải xuống</string>
+    <string name="export_all_downloads_desc">Sao chép bản tải xuống đã hoàn tất vào thư mục audio</string>
+    <string name="export_all_confirm">Xuất tất cả bài hát đã tải xuống?</string>
+    <string name="export_all_progress">Đang xuất… %1$d / %2$d</string>
+    <string name="export_all_prefs_note">Cấu hình thư mục và định dạng xuất audio trước</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -981,4 +981,27 @@
     <string name="no_saved_accounts">No saved accounts yet</string>
     <string name="remove_account">Remove account</string>
     <string name="youtube_channels">YouTube channels</string>
+
+    <!-- Audio export settings -->
+    <string name="audio_export_location">Audio file location</string>
+    <string name="audio_export_location_desc">Choose where downloaded audio files are saved</string>
+    <string name="audio_export_not_configured">Not configured — using default Music/ArchiveTune</string>
+    <string name="audio_export_pick_folder">Choose audio export folder</string>
+    <string name="audio_export_reset">Use default location</string>
+    <string name="audio_export_format">Audio format</string>
+    <string name="audio_export_format_desc">Format of exported audio files</string>
+    <string name="audio_export_format_source">Original (source)</string>
+    <string name="audio_export_format_opus">Opus</string>
+    <string name="audio_export_format_m4a">M4A (AAC)</string>
+    <string name="audio_export_format_mp3">MP3</string>
+    <string name="audio_export_format_flac">FLAC</string>
+    <string name="audio_export_save_thumbnail">Save thumbnail image</string>
+    <string name="audio_export_save_thumbnail_desc">Save cover art as .jpg alongside audio</string>
+    <string name="audio_export_success">Exported: %1$s</string>
+    <string name="audio_export_failed">Export failed: %1$s</string>
+    <string name="export_all_downloads">Export all downloads</string>
+    <string name="export_all_downloads_desc">Copy completed downloads to audio folder</string>
+    <string name="export_all_confirm">Export all downloaded songs?</string>
+    <string name="export_all_progress">Exporting… %1$d / %2$d</string>
+    <string name="export_all_prefs_note">Configure audio export folder and format first</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -987,6 +987,7 @@
     <string name="audio_export_location_desc">Choose where downloaded audio files are saved</string>
     <string name="audio_export_not_configured">Not configured — using default Music/ArchiveTune</string>
     <string name="audio_export_pick_folder">Choose audio export folder</string>
+    <string name="audio_export_folder_inaccessible">Cannot access selected folder</string>
     <string name="audio_export_reset">Use default location</string>
     <string name="audio_export_format">Audio format</string>
     <string name="audio_export_format_desc">Format of exported audio files</string>


### PR DESCRIPTION
## Summary

Upgrades the download system from ExoPlayer cache-only storage to a full standalone-audio-file export pipeline.

## Changes

### New files (4)
- **AudioFileExporter.kt** - reads completed downloads from ExoPlayer cache, writes real .opus/.m4a files to user-chosen directory
- **AudioMetadataWriter.kt** - writes ID3v2.3 tags (MP3) and iTunes metadata atoms (M4A): title, artist, album, year, cover art
- **ThumbnailDownloader.kt** - downloads cover art as .jpg via OkHttp
- **AudioExportRepository.kt** - SAF-based export directory management with persistable URI permissions

### Modified files (5)
- **PreferenceKeys.kt** - added 5 preference keys + AudioExportFormat enum (SOURCE, OPUS, M4A, MP3, FLAC)
- **DownloadUtil.kt** - injected AudioFileExporter, auto-export on download completion, adaptive parallelism (WiFi=8, LTE=6, 3G=3), keep-alive 5 to 10min
- **StorageSettings.kt** - new Audio Downloads section with folder picker, format selector, thumbnail toggle, export-all button
- **strings.xml** - +20 English strings
- **values-vi/strings.xml** - Vietnamese translations