### PR TITLE
fix(updater): respect saved update channel on startup check

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -231,6 +231,8 @@ import androidx.compose.ui.hapticfeedback.HapticFeedback
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import moe.rukamori.archivetune.constants.EnableHapticFeedbackKey
+import moe.rukamori.archivetune.constants.UpdateChannel
+import moe.rukamori.archivetune.constants.UpdateChannelKey
 import moe.rukamori.archivetune.utils.rememberPreference
 import moe.rukamori.archivetune.playback.PlayerConnection
 import moe.rukamori.archivetune.playback.queues.LocalAlbumRadio
@@ -506,6 +508,8 @@ class MainActivity : ComponentActivity() {
                     }
                 }
 
+            val updateChannel by rememberEnumPreference(UpdateChannelKey, defaultValue = UpdateChannel.STABLE)
+
             LaunchedEffect(Unit) {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
                     ContextCompat.checkSelfPermission(
@@ -520,8 +524,14 @@ class MainActivity : ComponentActivity() {
                     BuildConfig.UPDATER_AVAILABLE &&
                     System.currentTimeMillis() - Updater.lastCheckTime > 1.days.inWholeMilliseconds
                 ) {
-                    Updater.getLatestVersionName().onSuccess {
-                        latestVersionName = it
+                    if (updateChannel != UpdateChannel.NIGHTLY) {
+                        val versionResult = when (updateChannel) {
+                            UpdateChannel.DAILY_NIGHTLY -> Updater.getLatestDailyNightlyVersionName()
+                            else -> Updater.getLatestVersionName()
+                        }
+                        versionResult.onSuccess {
+                            latestVersionName = it
+                        }
                     }
                 }
                 moe.rukamori.archivetune.utils.UpdateNotificationManager.checkForUpdates(this@MainActivity)
@@ -584,7 +594,12 @@ class MainActivity : ComponentActivity() {
                         androidx.compose.material3.Button(
                             onClick = {
                                 try {
-                                    uriHandler.openUri(Updater.getLatestDownloadUrl())
+                                    val downloadUrl = when (updateChannel) {
+                                        UpdateChannel.DAILY_NIGHTLY -> Updater.getLatestDailyNightlyDownloadUrl()
+                                        UpdateChannel.NIGHTLY -> Updater.getLatestNightlyDownloadUrl()
+                                        UpdateChannel.STABLE -> Updater.getLatestDownloadUrl()
+                                    }
+                                    uriHandler.openUri(downloadUrl)
                                 } catch (_: Exception) {}
                             },
                             modifier = Modifier.fillMaxWidth(),
@@ -600,7 +615,11 @@ class MainActivity : ComponentActivity() {
                             BuildConfig.UPDATER_AVAILABLE &&
                             !Updater.isSameVersion(latestVersionName, BuildConfig.VERSION_NAME)
                         ) {
-                            Updater.getLatestReleaseNotes().onSuccess {
+                            val releaseNotesResult = when (updateChannel) {
+                                UpdateChannel.DAILY_NIGHTLY -> Updater.getLatestDailyNightlyReleaseNotes()
+                                else -> Updater.getLatestReleaseNotes()
+                            }
+                            releaseNotesResult.onSuccess {
                                 releaseNotesState.value = it
                             }.onFailure {
                                 releaseNotesState.value = null


### PR DESCRIPTION
## Description

The startup update check in `MainActivity.kt` always called `Updater.getLatestVersionName()` (STABLE channel) regardless of the user's selected update channel preference.

## Root Cause

In `MainActivity.kt`, the `LaunchedEffect(Unit)` block at startup hardcoded `Updater.getLatestVersionName()` without reading the user's saved `UpdateChannel` preference from DataStore.

## Fix

1. Read the `updateChannel` preference via `rememberEnumPreference(UpdateChannelKey)` in the composable scope
2. Dispatch the startup version check to the correct channel method:
   - `DAILY_NIGHTLY` → `Updater.getLatestDailyNightlyVersionName()`
   - `NIGHTLY` → skip (no version-based check for nightly)
   - `STABLE` → `Updater.getLatestVersionName()`
3. Channel-specific release notes fetch in the update bottom sheet (`LaunchedEffect(latestVersionName)`)
4. Channel-specific download URL in the update bottom sheet button

## Related

Previously only `UpdateNotificationManager.checkForUpdates()` and `UpdateCheckWorker.doWork()` properly read the channel preference.