### PR TITLE
Fix seek bar not updating in lyrics view after autoplay

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
@@ -252,7 +252,7 @@ fun LyricsScreen(
         gradientColorsCache[thumbnailUrl] = gradientColors
     }
 
-    LaunchedEffect(player, playbackState) {
+    LaunchedEffect(player, playbackState, mediaMetadata.id) {
         if (playbackState != STATE_READY && playbackState != STATE_BUFFERING) return@LaunchedEffect
         while (isActive) {
             positionState.longValue = player.currentPosition.coerceAtLeast(0L)


### PR DESCRIPTION
Fixes #768

## Root cause

In `LyricsScreen.kt`, the `LaunchedEffect` that updates `positionState`/`durationState` was keyed on `(player, playbackState)` only — missing `mediaMetadata.id`.

When autoplay transitions to the next song:
1. `mediaMetadata.id` changes → `remember(mediaMetadata.id)` creates **new** `MutableLongState` objects for `positionState` (0) and `durationState` (`C.TIME_UNSET`)
2. But the running `LaunchedEffect` coroutine still holds references to the **old** state objects — it keeps writing to those, while the UI reads from the new (stuck) objects

This is why manual "next" works (playbackState change causes the effect to restart and capture new references), but autoplay fails (state objects are replaced without the effect restarting).

Compare with `Player.kt` line 585 which correctly includes `mediaMetadata?.id` in its LaunchedEffect keys.

## Fix

Added `mediaMetadata.id` as a key to the `LaunchedEffect`, so the effect restarts when the song changes and captures the new state references.