### PR TITLE
feat(about): update team structure, add Respecter section, extract string resources

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AboutScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AboutScreen.kt
@@ -469,7 +469,7 @@ fun AboutScreen(
 
             Row {
                 IconButton(
-                    onClick = { uriHandler.openUri(stringResource(R.string.about_repo_url)) },
+                    onClick = { uriHandler.openUri("https://github.com/ArchiveTuneApp/ArchiveTune") },
                 ) {
                     Icon(
                         painter = painterResource(R.drawable.github),
@@ -480,7 +480,7 @@ fun AboutScreen(
                 Spacer(Modifier.width(8.dp))
 
                 IconButton(
-                    onClick = { uriHandler.openUri(stringResource(R.string.about_website_url)) },
+                    onClick = { uriHandler.openUri("https://archivetune.koiiverse.cloud") },
                 ) {
                     Icon(
                         painter = painterResource(R.drawable.website),
@@ -491,7 +491,7 @@ fun AboutScreen(
                 Spacer(Modifier.width(8.dp))
 
                 IconButton(
-                    onClick = { uriHandler.openUri(stringResource(R.string.about_telegram_url)) },
+                    onClick = { uriHandler.openUri("https://t.me/ArchiveTuneGC") },
                 ) {
                     Icon(
                         painter = painterResource(R.drawable.telegram),
@@ -502,7 +502,7 @@ fun AboutScreen(
                 Spacer(Modifier.width(8.dp))
 
                 IconButton(
-                    onClick = { uriHandler.openUri(stringResource(R.string.about_donate_url)) },
+                    onClick = { uriHandler.openUri("https://sociabuzz.com/chrtrxwstia") },
                 ) {
                     Icon(
                         painter = painterResource(R.drawable.coffee),

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AboutScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AboutScreen.kt
@@ -334,7 +334,7 @@ fun AboutScreen(
     val leadDeveloper = TeamMember(
         avatarUrl = "https://avatars.githubusercontent.com/u/107134739?v=4",
         name = "rukamori「るかもり」",
-        position = "Eh?",
+        position = stringResource(R.string.about_position_lead_dev),
         profileUrl = "https://github.com/rukamori",
         github = "https://github.com/rukamori",
         website = "https://koiiverse.cloud",
@@ -345,7 +345,7 @@ fun AboutScreen(
         TeamMember(
             avatarUrl = "https://avatars.githubusercontent.com/u/93458424?v=4",
             name = "WTTexe",
-            position = "Word Synced Lyrics, Gradients and UI Changes for the better!",
+            position = stringResource(R.string.about_position_wttexe),
             profileUrl = "https://github.com/Windowstechtips",
             github = "https://github.com/Windowstechtips",
             website = null,
@@ -354,23 +354,35 @@ fun AboutScreen(
         TeamMember(
             avatarUrl = "https://avatars.githubusercontent.com/u/89002922?v=4",
             name = "Miko",
-            position = "Contributor Team",
+            position = stringResource(R.string.about_position_miko),
             profileUrl = "https://github.com/mikooochi",
             github = "https://github.com/mikooochi"
         ),
         TeamMember(
             avatarUrl = "https://avatars.githubusercontent.com/u/80249864?v=4",
             name = "sang765",
-            position = "Contributor Team",
+            position = stringResource(R.string.about_position_sang765),
             profileUrl = "https://github.com/sang765",
             github = "https://github.com/sang765"
         ),
+    )
+
+    val respecters = listOf(
         TeamMember(
             avatarUrl = "https://avatars.githubusercontent.com/u/80542861?v=4",
             name = "MO AGAMY",
-            position = "Base Framework | Metrolist",
+            position = stringResource(R.string.about_position_mo_agamy),
             profileUrl = "https://github.com/mostafaalagamy",
             github = "https://github.com/mostafaalagamy",
+            website = null,
+            discord = null
+        ),
+        TeamMember(
+            avatarUrl = "https://avatars.githubusercontent.com/u/110614797?v=4",
+            name = "Zion Huang",
+            position = stringResource(R.string.about_position_zion_huang),
+            profileUrl = "https://github.com/z-huang",
+            github = "https://github.com/z-huang",
             website = null,
             discord = null
         ),
@@ -457,44 +469,44 @@ fun AboutScreen(
 
             Row {
                 IconButton(
-                    onClick = { uriHandler.openUri("https://github.com/rukamori/archivetune") },
+                    onClick = { uriHandler.openUri(stringResource(R.string.about_repo_url)) },
                 ) {
                     Icon(
                         painter = painterResource(R.drawable.github),
-                        contentDescription = null
+                        contentDescription = stringResource(R.string.about_content_desc_github)
                     )
                 }
 
                 Spacer(Modifier.width(8.dp))
 
                 IconButton(
-                    onClick = { uriHandler.openUri("https://archivetune.koiiverse.cloud") },
+                    onClick = { uriHandler.openUri(stringResource(R.string.about_website_url)) },
                 ) {
                     Icon(
                         painter = painterResource(R.drawable.website),
-                        contentDescription = null
+                        contentDescription = stringResource(R.string.about_content_desc_website)
                     )
                 }
 
                 Spacer(Modifier.width(8.dp))
 
                 IconButton(
-                    onClick = { uriHandler.openUri("https://t.me/ArchiveTuneGC") },
+                    onClick = { uriHandler.openUri(stringResource(R.string.about_telegram_url)) },
                 ) {
                     Icon(
                         painter = painterResource(R.drawable.telegram),
-                        contentDescription = null
+                        contentDescription = stringResource(R.string.about_content_desc_telegram)
                     )
                 }
 
                 Spacer(Modifier.width(8.dp))
 
                 IconButton(
-                    onClick = { uriHandler.openUri("https://sociabuzz.com/chrtrxwstia") },
+                    onClick = { uriHandler.openUri(stringResource(R.string.about_donate_url)) },
                 ) {
                     Icon(
                         painter = painterResource(R.drawable.coffee),
-                        contentDescription = null
+                        contentDescription = stringResource(R.string.about_content_desc_donate)
                     )
                 }
             }
@@ -502,7 +514,7 @@ fun AboutScreen(
             Spacer(Modifier.height(16.dp))
 
             SectionHeader(
-                title = "Lead Developer",
+                title = stringResource(R.string.about_lead_developer),
                 modifier = Modifier.padding(horizontal = 16.dp)
             )
 
@@ -519,7 +531,7 @@ fun AboutScreen(
             Spacer(Modifier.height(24.dp))
 
             SectionHeader(
-                title = "Collaborators",
+                title = stringResource(R.string.about_archive_tune_team),
                 modifier = Modifier.padding(horizontal = 16.dp)
             )
 
@@ -542,7 +554,30 @@ fun AboutScreen(
             Spacer(Modifier.height(24.dp))
 
             SectionHeader(
-                title = "Contributors",
+                title = stringResource(R.string.about_respecter),
+                modifier = Modifier.padding(horizontal = 16.dp)
+            )
+
+            Spacer(Modifier.height(8.dp))
+
+            Column(
+                verticalArrangement = Arrangement.spacedBy(10.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+            ) {
+                respecters.forEach { member ->
+                    CollaboratorCard(
+                        member = member,
+                        onOpenUri = uriHandler::openUri,
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(24.dp))
+
+            SectionHeader(
+                title = stringResource(R.string.about_contributors),
                 modifier = Modifier.padding(horizontal = 16.dp)
             )
 
@@ -759,7 +794,7 @@ private fun LeadDeveloperCard(
                 member.github?.let { url ->
                     OutlinedIconChip(
                         iconRes = R.drawable.github,
-                        contentDescription = "GitHub",
+                        contentDescription = stringResource(R.string.about_content_desc_github),
                         onClick = { onOpenUri(url) },
                     )
                 }
@@ -767,7 +802,7 @@ private fun LeadDeveloperCard(
                 member.website?.takeIf { it.isNotBlank() }?.let { url ->
                     OutlinedIconChip(
                         iconRes = R.drawable.website,
-                        contentDescription = "Website",
+                        contentDescription = stringResource(R.string.about_content_desc_website),
                         onClick = { onOpenUri(url) },
                     )
                 }
@@ -775,7 +810,7 @@ private fun LeadDeveloperCard(
                 member.discord?.let { url ->
                     OutlinedIconChip(
                         iconRes = R.drawable.alternate_email,
-                        contentDescription = "Discord",
+                        contentDescription = stringResource(R.string.about_content_desc_discord),
                         onClick = { onOpenUri(url) },
                     )
                 }
@@ -849,7 +884,7 @@ private fun CollaboratorCard(
                 member.github?.let { url ->
                     OutlinedIconChipMembers(
                         iconRes = R.drawable.github,
-                        contentDescription = "GitHub",
+                        contentDescription = stringResource(R.string.about_content_desc_github),
                         onClick = { onOpenUri(url) },
                     )
                 }
@@ -857,7 +892,7 @@ private fun CollaboratorCard(
                 member.website?.takeIf { it.isNotBlank() }?.let { url ->
                     OutlinedIconChipMembers(
                         iconRes = R.drawable.website,
-                        contentDescription = "Website",
+                        contentDescription = stringResource(R.string.about_content_desc_website),
                         onClick = { onOpenUri(url) },
                     )
                 }
@@ -865,7 +900,7 @@ private fun CollaboratorCard(
                 member.discord?.let { url ->
                     OutlinedIconChipMembers(
                         iconRes = R.drawable.alternate_email,
-                        contentDescription = "Discord",
+                        contentDescription = stringResource(R.string.about_content_desc_discord),
                         onClick = { onOpenUri(url) },
                     )
                 }

--- a/app/src/main/res/values-ja/archivetune_strings.xml
+++ b/app/src/main/res/values-ja/archivetune_strings.xml
@@ -441,4 +441,21 @@
     <string name="ai_api_test_failed">APIテストに失敗しました</string>
     <string name="ai_translation_menu">AI翻訳</string>
     <string name="ai_translating_lyrics">歌詞を翻訳中...</string>
+
+    <!-- About Screen -->
+    <string name="about_lead_developer">リードデベロッパー</string>
+    <string name="about_archive_tune_team">ArchiveTune チーム</string>
+    <string name="about_respecter">リスペクター</string>
+    <string name="about_contributors">コントリビューター</string>
+    <string name="about_position_lead_dev">えっ？</string>
+    <string name="about_position_wttexe">歌詞同期、グラデーション、UI改善</string>
+    <string name="about_position_miko">コントリビューターチーム</string>
+    <string name="about_position_sang765">コントリビューターチーム</string>
+    <string name="about_position_mo_agamy">ベースフレームワーク | Metrolist</string>
+    <string name="about_position_zion_huang">InnerTune 製作者 · Metrolist、ArchiveTune などのフォークの基盤</string>
+    <string name="about_content_desc_github">GitHub</string>
+    <string name="about_content_desc_website">ウェブサイト</string>
+    <string name="about_content_desc_discord">Discord</string>
+    <string name="about_content_desc_telegram">Telegram</string>
+    <string name="about_content_desc_donate">寄付</string>
 </resources>

--- a/app/src/main/res/values-vi/archivetune_strings.xml
+++ b/app/src/main/res/values-vi/archivetune_strings.xml
@@ -626,4 +626,21 @@
     <string name="lyrics_share_style_clear_glass">Kính trong</string>
     <string name="lyrics_share_style_deep_blur">Mờ sâu</string>
     <string name="lyrics_share_style_vivid_glow">Phát sáng rực rỡ</string>
+
+    <!-- About Screen -->
+    <string name="about_lead_developer">Nhà phát triển chính</string>
+    <string name="about_archive_tune_team">Nhóm ArchiveTune</string>
+    <string name="about_respecter">Tôn kính</string>
+    <string name="about_contributors">Người đóng góp</string>
+    <string name="about_position_lead_dev">Hả?</string>
+    <string name="about_position_wttexe">Lời bài hát đồng bộ, Gradient và Cải thiện Giao diện</string>
+    <string name="about_position_miko">Nhóm đóng góp</string>
+    <string name="about_position_sang765">Nhóm đóng góp</string>
+    <string name="about_position_mo_agamy">Khung cơ bản | Metrolist</string>
+    <string name="about_position_zion_huang">Người tạo InnerTune · Nền tảng cho Metrolist, ArchiveTune và các fork khác</string>
+    <string name="about_content_desc_github">GitHub</string>
+    <string name="about_content_desc_website">Trang web</string>
+    <string name="about_content_desc_discord">Discord</string>
+    <string name="about_content_desc_telegram">Telegram</string>
+    <string name="about_content_desc_donate">Quyên góp</string>
 </resources>

--- a/app/src/main/res/values/archivetune_strings.xml
+++ b/app/src/main/res/values/archivetune_strings.xml
@@ -634,8 +634,4 @@
     <string name="about_content_desc_discord">Discord</string>
     <string name="about_content_desc_telegram">Telegram</string>
     <string name="about_content_desc_donate">Donate</string>
-    <string name="about_repo_url" translatable="false">https://github.com/ArchiveTuneApp/ArchiveTune</string>
-    <string name="about_website_url" translatable="false">https://archivetune.koiiverse.cloud</string>
-    <string name="about_telegram_url" translatable="false">https://t.me/ArchiveTuneGC</string>
-    <string name="about_donate_url" translatable="false">https://sociabuzz.com/chrtrxwstia</string>
 </resources>

--- a/app/src/main/res/values/archivetune_strings.xml
+++ b/app/src/main/res/values/archivetune_strings.xml
@@ -617,4 +617,25 @@
     <string name="ai_api_test_failed">API test failed</string>
     <string name="ai_translation_menu">AI Translation</string>
     <string name="ai_translating_lyrics">Translating The Lyrics...</string>
+
+    <!-- About Screen -->
+    <string name="about_lead_developer">Lead Developer</string>
+    <string name="about_archive_tune_team">ArchiveTune Team</string>
+    <string name="about_respecter">Respecter</string>
+    <string name="about_contributors">Contributors</string>
+    <string name="about_position_lead_dev">Eh?</string>
+    <string name="about_position_wttexe">Word Synced Lyrics, Gradients and UI Changes for the better!</string>
+    <string name="about_position_miko">Contributor Team</string>
+    <string name="about_position_sang765">Contributor Team</string>
+    <string name="about_position_mo_agamy">Base Framework | Metrolist</string>
+    <string name="about_position_zion_huang">Creator of InnerTune · Foundation for Metrolist, ArchiveTune, and other forks</string>
+    <string name="about_content_desc_github">GitHub</string>
+    <string name="about_content_desc_website">Website</string>
+    <string name="about_content_desc_discord">Discord</string>
+    <string name="about_content_desc_telegram">Telegram</string>
+    <string name="about_content_desc_donate">Donate</string>
+    <string name="about_repo_url" translatable="false">https://github.com/ArchiveTuneApp/ArchiveTune</string>
+    <string name="about_website_url" translatable="false">https://archivetune.koiiverse.cloud</string>
+    <string name="about_telegram_url" translatable="false">https://t.me/ArchiveTuneGC</string>
+    <string name="about_donate_url" translatable="false">https://sociabuzz.com/chrtrxwstia</string>
 </resources>


### PR DESCRIPTION
**Changes:**
- Switch repo URL from `rukamori/archivetune` → `ArchiveTuneApp/ArchiveTune`
- Rename "Collaborators" → "ArchiveTune Team", remove MO AGAMY
- Add new "Respecter" section (below ArchiveTune Team) with MO AGAMY and Zion Huang (InnerTune creator)
- Extract all hardcoded display strings to `archivetune_strings.xml`
- Add Japanese and Vietnamese translations for the new strings