### PR TITLE
fix(musixmatch): update duration param to 'd' per API v1.7.0 spec and improve error detection

### DIFF
--- a/paxsenix/src/main/kotlin/moe/rukamori/archivetune/paxsenix/PaxsenixLyrics.kt
+++ b/paxsenix/src/main/kotlin/moe/rukamori/archivetune/paxsenix/PaxsenixLyrics.kt
@@ -331,15 +331,16 @@ object PaxsenixLyrics {
             parameter("q", query)
             parameter("t", title)
             parameter("a", artist)
-            parameter("duration", durationSeconds.toString())
+            parameter("d", durationSeconds.toString())
             parameter("type", "word")
         }
         if (mxmWord.status == HttpStatusCode.OK) {
             val data = cleanJsonLyrics(mxmWord.body<String>())
-            if (data.isNotBlank() && !data.contains("\"error\"")) {
+            if (data.isNotBlank() && !data.contains("\"error\"") && !data.contains("\"isError\"")) {
                 System.err.println("PaxsenixLyrics: SUCCESS from Musixmatch (Word)")
                 return@runCatching data
             }
+            System.err.println("PaxsenixLyrics: Musixmatch (Word) returned server error: ${data.take(200)}")
         }
 
         // Fallback to default
@@ -347,15 +348,16 @@ object PaxsenixLyrics {
             parameter("q", query)
             parameter("t", title)
             parameter("a", artist)
-            parameter("duration", durationSeconds.toString())
+            parameter("d", durationSeconds.toString())
         }
         System.err.println("PaxsenixLyrics: Musixmatch lyrics status: ${mxmLyrics.status}")
         if (mxmLyrics.status == HttpStatusCode.OK) {
             val data = cleanJsonLyrics(mxmLyrics.body<String>())
-            if (data.isNotBlank() && !data.contains("\"error\"")) {
+            if (data.isNotBlank() && !data.contains("\"error\"") && !data.contains("\"isError\"")) {
                 System.err.println("PaxsenixLyrics: SUCCESS from Musixmatch")
                 return@runCatching data
             }
+            System.err.println("PaxsenixLyrics: Musixmatch returned server error: ${data.take(200)}")
         }
         throw IllegalStateException("Musixmatch lyrics unavailable")
     }


### PR DESCRIPTION
## Problem
The Paxsenix: Musixmatch lyrics provider is broken because the upstream API at `https://lyrics.paxsenix.org/` returned a **407 Proxy Authentication Required** error when proxying to Musixmatch (server-side issue). Additionally, the app sends the wrong query parameter name — `duration` instead of `d` as defined in the OpenAPI v1.7.0 spec.

## Changes
1. **Fixed param name**: Changed `duration` → `d` in both musixmatch requests (word-by-word and default fallback) to match the API spec
2. **Improved error detection**: Added `"isError"` check to catch server-side error responses
3. **Better debug logging**: Logs server error responses for easier troubleshooting

## Note
The upstream server's 407 error is a separate infrastructure issue on the paxsenix.org side — this PR fixes the app-side bugs that would prevent lyrics from loading even after the server is restored.