### PR TITLE
Fix Bluetooth A2DP crash on Android 15 during local media playback

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
@@ -1339,6 +1339,9 @@ class MusicService :
 
     private fun onAudioOutputDeviceChanged() {
         if (!::player.isInitialized) return
+        val now = android.os.SystemClock.elapsedRealtime()
+        if (now - lastAudioRouteRecoveryRealtimeMs < AUDIO_ROUTE_RECOVERY_MIN_INTERVAL_MS) return
+        lastAudioRouteRecoveryRealtimeMs = now
         val outputSignature = currentAudioOutputDeviceSignature()
         if (outputSignature == lastAudioOutputDeviceSignature) return
         lastAudioOutputDeviceSignature = outputSignature
@@ -1358,10 +1361,6 @@ class MusicService :
         rebindAudioEffectsAfterRouteChange()
 
         if (!shouldRebuildPlaybackForAudioRouteChange()) return
-
-        val now = android.os.SystemClock.elapsedRealtime()
-        if (now - lastAudioRouteRecoveryRealtimeMs < AUDIO_ROUTE_RECOVERY_MIN_INTERVAL_MS) return
-        lastAudioRouteRecoveryRealtimeMs = now
 
         val mediaItemIndex = player.currentMediaItemIndex.takeIf { it != C.INDEX_UNSET } ?: return
         val playbackPosition = player.currentPosition.coerceAtLeast(0L)
@@ -1430,6 +1429,17 @@ class MusicService :
             .setContentType(C.AUDIO_CONTENT_TYPE_MUSIC)
             .setAllowedCapturePolicy(C.ALLOW_CAPTURE_BY_ALL)
             .build()
+
+    private fun isBluetoothA2dpActive(): Boolean {
+        return runCatching {
+            audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS).any { device ->
+                device.type == AudioDeviceInfo.TYPE_BLUETOOTH_A2DP ||
+                    device.type == AudioDeviceInfo.TYPE_BLUETOOTH_SCO ||
+                    device.type == AudioDeviceInfo.TYPE_BLE_HEADSET ||
+                    device.type == AudioDeviceInfo.TYPE_BLE_SPEAKER
+            }
+        }.getOrDefault(false)
+    }
 
     private fun calculateEffectivePlayerVolume(
         playerVolume: Float,
@@ -1576,6 +1586,8 @@ class MusicService :
         if (!crossfadeEnabled || crossfadeDurationMs <= 0L) return null
         if (player.mediaItemCount == 0 || player.currentTimeline.isEmpty) return null
         if (player.playbackState == Player.STATE_IDLE || player.playbackState == Player.STATE_ENDED) return null
+
+        if (isBluetoothA2dpActive()) return null
 
         val currentIndex = player.currentMediaItemIndex
         if (currentIndex !in 0 until player.mediaItemCount) return null


### PR DESCRIPTION
## Summary

Fixes a system-level Bluetooth service crash that occurs when playing local media files through Bluetooth A2DP headphones on Android 15. The crash was heavily triggered during track transitions (skipping/changing songs) and happened randomly mid-song.

## Root Cause

The crossfade system creates a secondary `ExoPlayer` instance that outputs audio through a separate `AudioTrack` simultaneously with the primary player. On Android 15's updated audio HAL, dual-`AudioTrack` output over Bluetooth A2DP crashes the Bluetooth service.

For local files the crash window is maximized because `shouldBypassPlayerCache()` returns `true` for `content://`/`file://` URIs, causing `hasBufferedForSmoothStart()` and `canHandoffWithoutRebuffer()` to return immediately — so the secondary player starts the moment it reaches `STATE_READY` (near-instant for local files). Streaming content avoids this because network buffering delays the secondary player's readiness, often past the point where the primary has already faded out.

## Changes

### `MusicService.kt`

| Change | Description |
|--------|-------------|
| `isBluetoothA2dpActive()` | Detects A2DP/SCO/BLE headset/speaker audio routes |
| `resolveCrossfadeTarget()` | Returns `null` (skips crossfade) when Bluetooth is active |
| `onAudioOutputDeviceChanged()` | Rate-limited with `AUDIO_ROUTE_RECOVERY_MIN_INTERVAL_MS` (1500ms) to prevent Bluetooth reconnection flaps from cascading into repeated `AudioTrack` recreation + full route recovery |
| `recoverAudioRouteAfterDeviceChange()` | Removed duplicate rate gate (now handled at the caller)