### PR TITLE
Feat/history auto refresh

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
@@ -4465,6 +4465,8 @@ class MusicService :
                     "Failed to register remote playback history for %s",
                     mediaId,
                 )
+            }.onSuccess {
+                YouTube.notifyHistorySynced()
             }.isSuccess
         }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/HistoryScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/HistoryScreen.kt
@@ -90,6 +90,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import kotlinx.coroutines.delay
+import moe.rukamori.archivetune.innertube.YouTube
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import moe.rukamori.archivetune.LocalAnimationsDisabled
@@ -266,8 +268,18 @@ fun HistoryScreen(
                 if (newSource == historySource) return@HistoryOverviewCard
 
                 viewModel.historySource.value = newSource
-                if (newSource == HistorySource.REMOTE && remoteHistoryState is RemoteHistoryUiState.Error) {
-                    viewModel.fetchRemoteHistory()
+                if (newSource == HistorySource.REMOTE) {
+                    when (remoteHistoryState) {
+                        is RemoteHistoryUiState.Error -> {
+                            viewModel.fetchRemoteHistory()  // error: fetch with loading (user expects feedback)
+                        }
+                        is RemoteHistoryUiState.Empty -> {
+                            viewModel.enqueueSilentFetch()  // empty: try silent fetch
+                        }
+                        else -> {
+                            // Already has data: no fetch needed
+                        }
+                    }
                 }
             },
             modifier = Modifier
@@ -389,6 +401,29 @@ fun HistoryScreen(
     LaunchedEffect(localVisibleEventIds) {
         if (selectedEventIds.any { it !in localVisibleEventIdSet }) {
             selectedEventIds = selectedEventIds.filter(localVisibleEventIdSet::contains)
+        }
+    }
+
+    // A. When screen opens + user is logged in → fetch remote history in background
+    LaunchedEffect(isLoggedIn) {
+        if (!isLoggedIn) return@LaunchedEffect
+        if (remoteHistoryState is RemoteHistoryUiState.Success) return@LaunchedEffect
+        delay(1_000)  // wait for screen
+
+        viewModel.fetchRemoteHistorySilent()
+    }
+
+    // B. When playback sync happens → retry with backoff
+    LaunchedEffect(isLoggedIn) {
+        YouTube.historySyncEvent.collect {
+            if (!isLoggedIn) return@collect
+
+            // Retry 3 times with increasing delay (handles slow internet)
+            repeat(3) { attempt ->
+                delay(3000L * (attempt + 1))  // 3s, 6s, 9s
+                viewModel.fetchRemoteHistorySilent()
+                if (remoteHistoryState is RemoteHistoryUiState.Success) return@collect
+            }
         }
     }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/HistoryScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/HistoryScreen.kt
@@ -405,7 +405,7 @@ fun HistoryScreen(
     }
 
     // A. When screen opens + user is logged in → fetch remote history in background
-    LaunchedEffect(isLoggedIn) {
+    LaunchedEffect("prefetch", isLoggedIn) {
         if (!isLoggedIn) return@LaunchedEffect
         if (remoteHistoryState is RemoteHistoryUiState.Success) return@LaunchedEffect
         delay(1_000)  // wait for screen
@@ -414,7 +414,7 @@ fun HistoryScreen(
     }
 
     // B. When playback sync happens → retry with backoff
-    LaunchedEffect(isLoggedIn) {
+    LaunchedEffect("sync", isLoggedIn) {
         YouTube.historySyncEvent.collect {
             if (!isLoggedIn) return@collect
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/HistoryViewModel.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/HistoryViewModel.kt
@@ -76,7 +76,7 @@ constructor(
             }.stateIn(viewModelScope, SharingStarted.Lazily, emptyMap())
 
     init {
-        viewModelScope.launch(Dispatchers.IO) {
+        viewModelScope.launch {
             fetchRemoteHistorySilent()
         }
     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/HistoryViewModel.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/HistoryViewModel.kt
@@ -17,6 +17,7 @@ import moe.rukamori.archivetune.utils.reportException
 import moe.rukamori.archivetune.db.MusicDatabase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -28,6 +29,7 @@ import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
 import javax.inject.Inject
+import timber.log.Timber
 
 @HiltViewModel
 class HistoryViewModel
@@ -42,8 +44,6 @@ constructor(
     private val today = LocalDate.now()
     private val thisMonday = today.with(DayOfWeek.MONDAY)
     private val lastMonday = thisMonday.minusDays(7)
-
-    val historyPage = mutableStateOf<HistoryPage?>(null)
 
     val events =
         database
@@ -76,24 +76,73 @@ constructor(
             }.stateIn(viewModelScope, SharingStarted.Lazily, emptyMap())
 
     init {
-        fetchRemoteHistory()
+        viewModelScope.launch(Dispatchers.IO) {
+            fetchRemoteHistorySilent()
+        }
     }
 
     fun fetchRemoteHistory() {
         _remoteHistoryState.value = RemoteHistoryUiState.Loading
         viewModelScope.launch(Dispatchers.IO) {
             YouTube.musicHistory().onSuccess {
-                historyPage.value = it
-                _remoteHistoryState.value =
-                    if (it.sections?.any { section -> section.songs.isNotEmpty() } == true) {
-                        RemoteHistoryUiState.Success(it)
-                    } else {
-                        RemoteHistoryUiState.Empty
-                    }
+                _remoteHistoryState.value = it.toRemoteUiState()
             }.onFailure {
                 _remoteHistoryState.value = RemoteHistoryUiState.Error
                 reportException(it)
             }
+        }
+    }
+
+    /**
+     * Fetches remote history without transitioning the UI to a Loading state.
+     *
+     * - [RemoteHistoryUiState.Error]   → delegates to [fetchRemoteHistory] (user sees spinner)
+     * - [RemoteHistoryUiState.Loading] → fetches silently; transitions to Error on failure
+     * - [RemoteHistoryUiState.Empty]   → fetches silently; transitions to Error on failure
+     * - [RemoteHistoryUiState.Success] → fetches silently; keeps cached data + logs warning on failure
+     *
+     * Call from a coroutine context (e.g. LaunchedEffect or viewModelScope.launch).
+     */
+    suspend fun fetchRemoteHistorySilent() {
+        val snapshot = _remoteHistoryState.value
+
+        if (snapshot is RemoteHistoryUiState.Error) {
+            fetchRemoteHistory()
+            return
+        }
+
+        withContext(Dispatchers.IO) {
+            try {
+                val page = YouTube.musicHistory().getOrThrow()
+                _remoteHistoryState.value = page.toRemoteUiState()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Timber.tag("History").w(e, "Silent remote history fetch failed")
+                when (snapshot) {
+                    is RemoteHistoryUiState.Success -> {
+                        // Keep cached data; don't disrupt the user
+                    }
+                    is RemoteHistoryUiState.Loading,
+                    is RemoteHistoryUiState.Empty -> {
+                        _remoteHistoryState.value = RemoteHistoryUiState.Error
+                    }
+                }
+            }
+        }
+    }
+
+    private fun HistoryPage.toRemoteUiState(): RemoteHistoryUiState =
+        if (sections?.any { it.songs.isNotEmpty() } == true) RemoteHistoryUiState.Success(this)
+        else RemoteHistoryUiState.Empty
+
+    /**
+     * Non-suspend wrapper for call sites that are not already in a coroutine
+     * (e.g. click handlers in Compose).
+     */
+    fun enqueueSilentFetch() {
+        viewModelScope.launch(Dispatchers.IO) {
+            fetchRemoteHistorySilent()
         }
     }
 

--- a/innertube/src/main/kotlin/moe/rukamori/archivetune/innertube/YouTube.kt
+++ b/innertube/src/main/kotlin/moe/rukamori/archivetune/innertube/YouTube.kt
@@ -76,8 +76,11 @@ import io.ktor.client.plugins.ClientRequestException
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.encodeToString
@@ -109,6 +112,13 @@ object YouTube {
     private val mutableAuthState = MutableStateFlow(PlaybackAuthState.EMPTY)
 
     val authStateFlow: StateFlow<PlaybackAuthState> = mutableAuthState.asStateFlow()
+
+    private val _historySyncEvent = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    val historySyncEvent: SharedFlow<Unit> = _historySyncEvent.asSharedFlow()
+
+    fun notifyHistorySynced() {
+        _historySyncEvent.tryEmit(Unit)
+    }
 
     var authState: PlaybackAuthState
         get() = mutableAuthState.value


### PR DESCRIPTION
# Pull Request

## Summary

Silently auto-refreshes YouTube remote history when the user opens the History screen or after a track is registered to YouTube's playback tracking. Avoids flashing a loading spinner on subsequent fetches by using a dedicated `suspend fun fetchRemoteHistorySilent()` that updates UI state in-place. A `SharedFlow` event bus from `MusicService` through `YouTube` signals the History screen to retry up to 3 times with exponential backoff, handling YouTube's server-side indexing lag.

## Linked Work

- Closes: —

- Related: #780 (playback history sync fix that this builds on)

## Change Type

- [x] Feature

- [ ] Bug fix

- [ ] UI / UX

- [ ] Performance / memory

- [ ] Playback / Media3

- [ ] Lyrics / provider integration

- [x] Search / YouTube / network data

- [ ] Local library / Room database

- [ ] Widgets / notification / shortcuts

- [ ] Settings / preferences / DataStore

- [ ] Discord / Last.fm / ListenBrainz / external integration

- [ ] Localization / strings / fastlane metadata

- [ ] Build / Gradle / CI / release packaging

- [ ] Dependency update

- [ ] Documentation only

## Affected Surfaces

- [x] `:app`

- [x] `:innertube`

- [ ] `:betterlyrics`

- [ ] `:kugou`

- [ ] `:lrclib`

- [ ] `:lastfm`

- [ ] `:simpmusic`

- [ ] `:paxsenix`

- [ ] `:unison`

- [ ] `:canvas`

- [ ] `:shazamkit`

- [ ] `:spotifycore`

- [ ] `server`

- [ ] `fastlane`

- [ ] `.github`

- [ ] Other:

## Screenshots / Recordings

No visual changes — the history screen UI is unchanged. The behavior change is invisible: remote history now stays up-to-date without the user needing to manually retry or switch tabs.

| Before | After |
| --- | --- |
| Remote history only refreshed on explicit retry or source-switch to Error state | Remote history silently pre-fetched on screen open, and auto-refreshed after each playback sync event |

## Behavior Notes

1. **Screen open**: When the user opens History while logged in, remote history is silently fetched in the background (1s delay to let the enter animation settle). Skipped if data already exists from a prior successful fetch.
2. **Playback sync**: After `MusicService` successfully registers a track to YouTube's remote playback tracking, the History screen silently re-fetches. Retries up to 3 times (3s / 6s / 9s backoff) to handle YouTube indexing lag.
3. **Source switching**: Tapping the REMOTE tab now triggers a silent fetch on `Empty` state (previously only handled `Error`). `Error` still uses the full fetch with loading spinner. `Success` is a no-op.
4. **Logout safety**: If the user logs out while on the History screen, all remote-fetch coroutines cancel and the sync listener stops. Re-logging in restarts them.
5. **Error handling**: Silent fetch failures while in `Loading` or `Empty` state transition to `Error`. Failures while in `Success` are logged with Timber and cached data is preserved.
6. **No visual regression**: All existing UI — search, multi-select, shuffle FAB, song menus, sticky headers — is untouched.

## Architecture Checklist

- [x] The change preserves UDF flow: UI -> ViewModel -> UseCase/domain -> Repository/data.
- [x] Screen state is represented structurally with `Loading`, `Success`, `Empty`, and `Error` where this PR introduces or changes screen state.
- [x] Composables receive immutable, UI-specific domain models instead of raw Room, network, or service entities.
- [x] Business work is not triggered directly from composition.
- [x] Exceptions are surfaced through explicit state or result types instead of being swallowed.
- [x] No `runBlocking` is introduced in app execution paths.

## Compose / Material Checklist

- [x] UI state is hoisted out of composable layout code.
- [x] Reactive state is collected with `collectAsStateWithLifecycle()`.
- [ ] New UI models are annotated with `@Immutable` or `@Stable`. — No new UI models.
- [ ] Lazy layouts use stable `key` values and explicit `contentType`. — No change to lazy layouts.
- [ ] Non-primitive constants, structural lambdas, and allocation-heavy objects in hot paths are remembered. — No new allocations in hot paths.
- [ ] Rapidly changing inputs such as scroll, gesture, animation, or playback progress use `derivedStateOf` where appropriate. — No change to rapidly-changing inputs.
- [ ] UI strings come from `stringResource()` and duplicated visible strings on the same screen are avoided. — No new strings.
- [ ] Interactive elements keep a minimum 48dp touch target. — No new interactive elements.
- [ ] Material 3 / Material 3 Expressive tokens are used for color, typography, shape, and motion instead of hardcoded UI values. — No new UI.
- [ ] Edge-to-edge layouts handle and consume `WindowInsets` correctly when this PR changes screen layout. — No layout changes.

## Concurrency / Performance Checklist

- [x] Business coroutines are scoped to `viewModelScope` or an existing lifecycle-owned application/service scope.
- [x] Disk, database, network, parsing, and heavy mapping work is dispatched to `Dispatchers.IO` or `Dispatchers.Default`.
- [x] Cancellation is handled explicitly where long-running work, playback, downloads, sync, lyrics fetching, or recognition is involved.
- [x] The change avoids blocking the main thread.
- [x] The change avoids unnecessary allocations in recomposition loops, playback loops, polling loops, and provider parsing paths.
- [ ] Large lists, images, lyrics payloads, and network responses are bounded, streamed, cached, paged, or mapped off the main thread as appropriate. — No new large data paths.

## Data / Persistence Checklist

- [ ] Room entity, DAO, or database changes include a schema update under `app/schemas`. — No database changes.
- [ ] Database migrations preserve existing user data and fail clearly when migration is impossible. — No database changes.
- [ ] DataStore or preference-key changes are backward compatible. — No preference changes.
- [x] Network DTOs remain isolated from UI models.
- [ ] Provider responses handle missing, malformed, regional, or rate-limited data without crashing the app. — Same `FEmusic_history` endpoint used before; error handling added.

## Playback / Integration Checklist

- [x] Media3 playback, queue, cache, and service behavior remains stable across foreground, background, notification, and process recreation paths.
- [ ] Audio focus, notification controls, widgets, shortcuts, and media session actions are considered when playback behavior changes. — No playback changes.
- [ ] External integrations handle absent credentials, revoked auth, network failure, and API changes. — No external integration changes.
- [ ] Native, AAR, or ABI-sensitive changes account for mobile/tv and `universal`, `arm64`, `armeabi`, `x86`, and `x86_64` variants. — Pure Kotlin changes, no ABI impact.

## Localization / Assets Checklist

- [ ] User-facing strings are added to the base resources and translated resources are updated or intentionally left for translation follow-up. — No new strings.
- [ ] Unused string resources, drawables, and metadata are removed when replaced. — No assets changed.
- [ ] Image assets have explicit display dimensions and are decoded at the displayed size. — No new images.
- [ ] Fastlane metadata, screenshots, icons, or release text are updated when user-facing store behavior changes. — No store-facing changes.

## Privacy / Security Checklist

- [x] No secrets, keys, tokens, keystores, signing files, private certificates, or local machine paths are committed.
- [x] Logs do not expose access tokens, cookies, auth headers, user identifiers, listening history, or local file paths.
- [x] New network calls are justified by the feature and use existing client, proxy, timeout, and error-handling patterns.
- [x] User data remains local unless the PR explicitly documents the integration and consent path.

## Verification

- [x] Android Studio sync: Compiles cleanly on `feat/history-auto-refresh` branch.
- [x] Manual device/emulator verification: User reports build succeeds and feature works correctly.
- [ ] UI screenshot/recording attached: — No visual change.
- [ ] Accessibility or touch-target review: — No new interactive elements.
- [x] Regression areas checked: Local history (Room events flow, multi-select, remove-from-history), source switching, search/filter, shuffle FAB, song menus, retry button — all unchanged.
- [x] CI expectation: Should pass. No new dependencies, no Gradle changes, no AndroidManifest changes.

## Reviewer Focus

- `HistoryViewModel.kt` — the new `suspend fun fetchRemoteHistorySilent()` with `withContext(Dispatchers.IO)`, state snapshot pattern, and error handling. Also: removal of dead `historyPage` field and deduplication via `toRemoteUiState()`.
- `HistoryScreen.kt` — two new `LaunchedEffect(isLoggedIn)` blocks (pre-fetch + sync listener with retry). Verify the `return@collect` labels inside `collect` lambdas are correct. Verify the `is Success` guard on the pre-fetch effect.
- `YouTube.kt` — `MutableSharedFlow<Unit>(extraBufferCapacity = 1)` + `tryEmit` — verify thread safety and buffer semantics.
- `MusicService.kt` — single `.onSuccess { notifyHistorySynced() }` call site — verify it's on the correct code path (successful remote tracking registration only).

## Release Notes

YouTube remote history now silently stays up-to-date when you open the History screen or when a track's playback is synced to YouTube — no manual refresh needed.