### PR TITLE
refactor(HistoryDuration): migrate DataStore key from Float to Int (Also fix history duration slider visual resetting to default on screen re-enter)

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
@@ -632,7 +632,12 @@ val LyricsLineSpacingKey = floatPreferencesKey("lyricsLineSpacing")
 val LyricsLineBlurKey = booleanPreferencesKey("lyricsLineBlur")
 
 val TopSize = stringPreferencesKey("topSize")
-val HistoryDuration = floatPreferencesKey("historyDuration")
+
+const val HISTORY_DURATION_DEFAULT = 30
+const val HISTORY_DURATION_MIN = 15
+const val HISTORY_DURATION_MAX = 60
+val HISTORY_DURATION_LEGACY_FLOAT_KEY = floatPreferencesKey("historyDuration")
+val HistoryDuration = intPreferencesKey("historyDuration")
 
 val PlayerButtonsStyleKey = stringPreferencesKey("player_buttons_style")
 val PlayerBackgroundStyleKey = stringPreferencesKey("playerBackgroundStyle")

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
@@ -121,6 +121,9 @@ import moe.rukamori.archivetune.constants.EnableDiscordRPCKey
 import moe.rukamori.archivetune.constants.HideExplicitKey
 import moe.rukamori.archivetune.constants.HideVideoKey
 import moe.rukamori.archivetune.constants.HistoryDuration
+import moe.rukamori.archivetune.constants.HISTORY_DURATION_DEFAULT
+import moe.rukamori.archivetune.constants.HISTORY_DURATION_MIN
+import moe.rukamori.archivetune.constants.HISTORY_DURATION_MAX
 import moe.rukamori.archivetune.constants.MediaSessionConstants.CommandToggleLike
 import moe.rukamori.archivetune.constants.MediaSessionConstants.CommandToggleStartRadio
 import moe.rukamori.archivetune.constants.MediaSessionConstants.CommandToggleRepeatMode
@@ -4231,10 +4234,9 @@ class MusicService :
     }
 
     private fun historyThresholdMs(): Long {
-        return (dataStore[HistoryDuration] ?: 30f)
-            .times(1000f)
-            .roundToLong()
-            .coerceAtLeast(0L)
+        return (dataStore[HistoryDuration] ?: HISTORY_DURATION_DEFAULT)
+            .coerceIn(HISTORY_DURATION_MIN, HISTORY_DURATION_MAX)
+            .toLong() * 1000L
     }
 
     private fun currentHistoryPlayedMs(nowElapsedMs: Long = android.os.SystemClock.elapsedRealtime()): Long {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/Preference.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/Preference.kt
@@ -721,16 +721,16 @@ fun SliderPreference(
     modifier: Modifier = Modifier,
     title: @Composable () -> Unit,
     icon: (@Composable () -> Unit)? = null,
-    value: Float,
-    onValueChange: (Float) -> Unit,
+    value: Int,
+    onValueChange: (Int) -> Unit,
     isEnabled: Boolean = true,
 ) {
     var showDialog by remember {
         mutableStateOf(false)
     }
 
-    var sliderValue by remember {
-        mutableFloatStateOf(value)
+    var sliderValue by remember(value) {
+        mutableFloatStateOf(value.toFloat())
     }
 
     if (showDialog) {
@@ -751,10 +751,10 @@ fun SliderPreference(
             onDismiss = { showDialog = false },
             onConfirm = {
                 showDialog = false
-                onValueChange.invoke(sliderValue)
+                onValueChange.invoke(sliderValue.roundToInt())
             },
             onCancel = {
-                sliderValue = value
+                sliderValue = value.toFloat()
                 showDialog = false
             },
             onReset = {
@@ -799,7 +799,7 @@ fun SliderPreference(
     PreferenceEntry(
         modifier = modifier,
         title = title,
-        description = value.roundToInt().toString(),
+        description = value.toString(),
         icon = icon,
         onClick = { showDialog = true },
         isEnabled = isEnabled,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlayerSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlayerSettings.kt
@@ -50,6 +50,7 @@ import moe.rukamori.archivetune.constants.SkipSilenceKey
 import moe.rukamori.archivetune.constants.StopMusicOnTaskClearKey
 import moe.rukamori.archivetune.constants.WakelockKey
 import moe.rukamori.archivetune.constants.HistoryDuration
+import moe.rukamori.archivetune.constants.HISTORY_DURATION_DEFAULT
 import moe.rukamori.archivetune.constants.CrossfadeDurationKey
 import moe.rukamori.archivetune.constants.CrossfadeEnabledKey
 import moe.rukamori.archivetune.constants.CrossfadeGaplessKey
@@ -147,7 +148,7 @@ fun PlayerSettings(
     )
     val (historyDuration, onHistoryDurationChange) = rememberPreference(
         HistoryDuration,
-        defaultValue = 30f
+        defaultValue = HISTORY_DURATION_DEFAULT
     )
 
     val (crossfadeEnabled, onCrossfadeEnabledChange) = rememberPreference(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/utils/DataStore.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/utils/DataStore.kt
@@ -14,11 +14,16 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
+import androidx.datastore.core.DataMigration
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.MutablePreferences
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.preferencesDataStore
+import moe.rukamori.archivetune.constants.HISTORY_DURATION_LEGACY_FLOAT_KEY
+import moe.rukamori.archivetune.constants.HISTORY_DURATION_MIN
+import moe.rukamori.archivetune.constants.HISTORY_DURATION_MAX
+import moe.rukamori.archivetune.constants.HistoryDuration
 import moe.rukamori.archivetune.extensions.toEnum
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -32,7 +37,31 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.properties.ReadOnlyProperty
 
-val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")
+val Context.dataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "settings",
+    produceMigrations = { _ ->
+        listOf(
+            object : DataMigration<Preferences> {
+                override suspend fun shouldMigrate(currentData: Preferences): Boolean =
+                    currentData[HISTORY_DURATION_LEGACY_FLOAT_KEY] != null &&
+                        currentData[HistoryDuration] == null
+
+                override suspend fun migrate(currentData: Preferences): Preferences =
+                    currentData.toMutablePreferences().apply {
+                        val oldFloat = currentData[HISTORY_DURATION_LEGACY_FLOAT_KEY]
+                        if (oldFloat != null) {
+                            this[HistoryDuration] = oldFloat
+                                .toInt()
+                                .coerceIn(HISTORY_DURATION_MIN, HISTORY_DURATION_MAX)
+                            this.remove(HISTORY_DURATION_LEGACY_FLOAT_KEY)
+                        }
+                    }
+
+                override suspend fun cleanUp() {}
+            }
+        )
+    },
+)
 object PreferenceStore {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val _prefs = MutableStateFlow<Preferences?>(null)


### PR DESCRIPTION
- Change HistoryDuration from floatPreferencesKey to intPreferencesKey
- Add DataMigration to preserve existing users' saved value
- Add HISTORY_DURATION_DEFAULT/MIN/MAX constants to replace magic numbers
- Add coerceIn range enforcement in MusicService.historyThresholdMs()
- Update SliderPreference signature to accept Int natively
- Fix SliderPreference slider resetting to default on screen re-entry