### PR TITLE
refactor(HistoryDuration): lower minimum duration and clean up hardcoded float literals

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
@@ -634,8 +634,9 @@ val LyricsLineBlurKey = booleanPreferencesKey("lyricsLineBlur")
 val TopSize = stringPreferencesKey("topSize")
 
 const val HISTORY_DURATION_DEFAULT = 30
-const val HISTORY_DURATION_MIN = 15
+const val HISTORY_DURATION_MIN = 5
 const val HISTORY_DURATION_MAX = 60
+val HISTORY_DURATION_RANGE = HISTORY_DURATION_MIN.toFloat()..HISTORY_DURATION_MAX.toFloat()
 val HISTORY_DURATION_LEGACY_FLOAT_KEY = floatPreferencesKey("historyDuration")
 val HistoryDuration = intPreferencesKey("historyDuration")
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/Preference.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/Preference.kt
@@ -93,6 +93,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import moe.rukamori.archivetune.R
+import moe.rukamori.archivetune.constants.HISTORY_DURATION_DEFAULT
+import moe.rukamori.archivetune.constants.HISTORY_DURATION_RANGE
 import kotlin.math.roundToInt
 
 val LocalPreferenceInGroup = compositionLocalOf { false }
@@ -758,7 +760,7 @@ fun SliderPreference(
                 showDialog = false
             },
             onReset = {
-                sliderValue = 30f
+                sliderValue = HISTORY_DURATION_DEFAULT.toFloat()
             },
             content = {
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
@@ -775,7 +777,7 @@ fun SliderPreference(
 
                     val sliderState = rememberSliderState(
                         value = sliderValue,
-                        valueRange = 15f..60f,
+                        valueRange = HISTORY_DURATION_RANGE,
                         onValueChangeFinished = {},
                     )
                     sliderState.onValueChange = { sliderValue = it }


### PR DESCRIPTION
## What
- Lower history duration minimum from 15 to 5 seconds
- Extract HISTORY_DURATION_RANGE constant and replace all hardcoded float literals in SliderPreference with constants

## Why
The 15 second minimum was too restrictive. All magic numbers in SliderPreference are now driven by constants in PreferenceKeys.kt, so any future range or default change only requires touching one place.

## Changes
- `PreferenceKeys.kt` — HISTORY_DURATION_MIN 15 → 5, add HISTORY_DURATION_RANGE
- `Preference.kt` — replace hardcoded 15f..60f and 30f with HISTORY_DURATION_RANGE and HISTORY_DURATION_DEFAULT