### PR TITLE
fix(HistoryDuration): guard against ClassCastException during DataSto…

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
@@ -4234,7 +4234,7 @@ class MusicService :
     }
 
     private fun historyThresholdMs(): Long {
-        return (dataStore[HistoryDuration] ?: HISTORY_DURATION_DEFAULT)
+        return (runCatching { dataStore[HistoryDuration] }.getOrNull() ?: HISTORY_DURATION_DEFAULT)
             .coerceIn(HISTORY_DURATION_MIN, HISTORY_DURATION_MAX)
             .toLong() * 1000L
     }


### PR DESCRIPTION
…re migration

Wrap dataStore[HistoryDuration] in runCatching to handle ClassCastException thrown when MusicService reads the key before the Float→Int migration completes, falling back to HISTORY_DURATION_DEFAULT safely.