### PR TITLE
feat: add Paxsenix: YouTube lyrics provider

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
@@ -156,6 +156,7 @@ val EnablePaxsenixAppleMusicLyricsKey = booleanPreferencesKey("enablePaxsenixApp
 val EnablePaxsenixNeteaseLyricsKey = booleanPreferencesKey("enablePaxsenixNeteaseLyrics")
 val EnablePaxsenixSpotifyLyricsKey = booleanPreferencesKey("enablePaxsenixSpotifyLyrics")
 val EnablePaxsenixMusixmatchLyricsKey = booleanPreferencesKey("enablePaxsenixMusixmatchLyrics")
+val EnablePaxsenixYouTubeLyricsKey = booleanPreferencesKey("enablePaxsenixYouTubeLyrics")
 val EnableUnisonLyricsKey = booleanPreferencesKey("enableUnisonLyrics")
 val HideExplicitKey = booleanPreferencesKey("hideExplicit")
 val HideVideoKey = booleanPreferencesKey("hideVideo")
@@ -539,6 +540,7 @@ enum class PreferredLyricsProvider {
     PAXSENIX_NETEASE,
     PAXSENIX_SPOTIFY,
     PAXSENIX_MUSIXMATCH,
+    PAXSENIX_YOUTUBE,
 }
 
 val DefaultLyricsProviderOrder = listOf(
@@ -550,7 +552,8 @@ val DefaultLyricsProviderOrder = listOf(
     PreferredLyricsProvider.PAXSENIX_APPLE_MUSIC,
     PreferredLyricsProvider.PAXSENIX_NETEASE,
     PreferredLyricsProvider.PAXSENIX_SPOTIFY,
-    PreferredLyricsProvider.PAXSENIX_MUSIXMATCH,
+        PreferredLyricsProvider.PAXSENIX_MUSIXMATCH,
+        PreferredLyricsProvider.PAXSENIX_YOUTUBE,
 )
 
 fun deserializeLyricsProviderOrder(orderStr: String?): List<PreferredLyricsProvider> {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/LyricsHelper.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/LyricsHelper.kt
@@ -50,6 +50,7 @@ constructor(
             PaxsenixNeteaseLyricsProvider,
             PaxsenixSpotifyLyricsProvider,
             PaxsenixMusixmatchLyricsProvider,
+            PaxsenixYouTubeLyricsProvider,
             YouTubeSubtitleLyricsProvider,
             YouTubeLyricsProvider,
         )
@@ -232,6 +233,7 @@ constructor(
             PreferredLyricsProvider.PAXSENIX_NETEASE to PaxsenixNeteaseLyricsProvider,
             PreferredLyricsProvider.PAXSENIX_SPOTIFY to PaxsenixSpotifyLyricsProvider,
             PreferredLyricsProvider.PAXSENIX_MUSIXMATCH to PaxsenixMusixmatchLyricsProvider,
+            PreferredLyricsProvider.PAXSENIX_YOUTUBE to PaxsenixYouTubeLyricsProvider,
             PreferredLyricsProvider.UNISON to UnisonLyricsProvider,
         )
         val userOrdered = orderedEnums.mapNotNull { providerMap[it] }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/PaxsenixYouTubeLyricsProvider.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/lyrics/PaxsenixYouTubeLyricsProvider.kt
@@ -1,0 +1,39 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package moe.rukamori.archivetune.lyrics
+
+import android.content.Context
+import moe.rukamori.archivetune.constants.EnablePaxsenixYouTubeLyricsKey
+import moe.rukamori.archivetune.paxsenix.PaxsenixLyrics
+import moe.rukamori.archivetune.utils.dataStore
+import moe.rukamori.archivetune.utils.get
+
+object PaxsenixYouTubeLyricsProvider : LyricsProvider {
+    override val name = "Paxsenix: YouTube"
+
+    override fun isEnabled(context: Context): Boolean = context.dataStore[EnablePaxsenixYouTubeLyricsKey] ?: true
+
+    override suspend fun getLyrics(
+        id: String,
+        title: String,
+        artist: String,
+        album: String?,
+        duration: Int,
+    ): Result<String> = PaxsenixLyrics.getYouTubeLyrics(title, artist, duration)
+
+    override suspend fun getAllLyrics(
+        id: String,
+        title: String,
+        artist: String,
+        album: String?,
+        duration: Int,
+        callback: (String) -> Unit,
+    ) {
+        getLyrics(id, title, artist, album, duration).onSuccess(callback)
+    }
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LyricsSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LyricsSettings.kt
@@ -73,6 +73,7 @@ import moe.rukamori.archivetune.constants.EnablePaxsenixAppleMusicLyricsKey
 import moe.rukamori.archivetune.constants.EnablePaxsenixLyricsKey
 import moe.rukamori.archivetune.constants.EnablePaxsenixMusixmatchLyricsKey
 import moe.rukamori.archivetune.constants.EnablePaxsenixNeteaseLyricsKey
+import moe.rukamori.archivetune.constants.EnablePaxsenixYouTubeLyricsKey
 import moe.rukamori.archivetune.constants.EnablePaxsenixSpotifyLyricsKey
 import moe.rukamori.archivetune.constants.EnableSimpMusicLyricsKey
 import moe.rukamori.archivetune.constants.EnableUnisonLyricsKey
@@ -162,6 +163,7 @@ fun LyricsSettings(
     val (enablePaxsenixNeteaseLyrics, onEnablePaxsenixNeteaseLyricsChange) = rememberPreference(key = EnablePaxsenixNeteaseLyricsKey, defaultValue = true)
     val (enablePaxsenixSpotifyLyrics, onEnablePaxsenixSpotifyLyricsChange) = rememberPreference(key = EnablePaxsenixSpotifyLyricsKey, defaultValue = true)
     val (enablePaxsenixMusixmatchLyrics, onEnablePaxsenixMusixmatchLyricsChange) = rememberPreference(key = EnablePaxsenixMusixmatchLyricsKey, defaultValue = true)
+    val (enablePaxsenixYouTubeLyrics, onEnablePaxsenixYouTubeLyricsChange) = rememberPreference(key = EnablePaxsenixYouTubeLyricsKey, defaultValue = true)
     val (enableUnisonLyrics, onEnableUnisonLyricsChange) = rememberPreference(key = EnableUnisonLyricsKey, defaultValue = true)
     val (providerOrderStr, onProviderOrderStrChange) = rememberPreference(
         key = LyricsProviderOrderKey,
@@ -504,6 +506,15 @@ fun LyricsSettings(
                 )
             }
 
+            item(visible = enablePaxsenixLyrics) {
+                SwitchPreference(
+                    title = { Text("Paxsenix: YouTube") },
+                    icon = { Icon(painterResource(R.drawable.lyrics), null) },
+                    checked = enablePaxsenixYouTubeLyrics,
+                    onCheckedChange = onEnablePaxsenixYouTubeLyricsChange,
+                )
+            }
+
             item {
                 PreferenceEntry(
                     title = { Text(stringResource(R.string.set_first_lyrics_provider)) },
@@ -622,6 +633,7 @@ private fun PreferredLyricsProvider.displayName(): String = when (this) {
     PreferredLyricsProvider.PAXSENIX_NETEASE -> "Paxsenix: NetEase"
     PreferredLyricsProvider.PAXSENIX_SPOTIFY -> "Paxsenix: Spotify"
     PreferredLyricsProvider.PAXSENIX_MUSIXMATCH -> "Paxsenix: Musixmatch"
+    PreferredLyricsProvider.PAXSENIX_YOUTUBE -> "Paxsenix: YouTube"
     PreferredLyricsProvider.UNISON -> "Unison"
 }
 

--- a/paxsenix/src/main/kotlin/moe/rukamori/archivetune/paxsenix/PaxsenixLyrics.kt
+++ b/paxsenix/src/main/kotlin/moe/rukamori/archivetune/paxsenix/PaxsenixLyrics.kt
@@ -318,6 +318,51 @@ object PaxsenixLyrics {
         throw IllegalStateException("Spotify lyrics unavailable")
     }
 
+    suspend fun getYouTubeLyrics(
+        title: String,
+        artist: String,
+        durationSeconds: Int,
+    ): Result<String> = runCatching {
+        val durationMs = resolveDurationMs(durationSeconds)
+        val query = "$title $artist"
+        System.err.println("PaxsenixLyrics: Requesting YouTube lyrics for: $query (Duration: $durationSeconds)")
+
+        val searchResponse = client.get("youtube/search") {
+            parameter("q", query)
+        }
+        if (searchResponse.status != HttpStatusCode.OK) {
+            System.err.println("PaxsenixLyrics: YouTube search failed with status: ${searchResponse.status}")
+            throw IllegalStateException("YouTube lyrics unavailable")
+        }
+
+        val items = searchResponse.body<List<PaxsenixSearchItem>>()
+        val bestMatch = if (durationMs > 0) {
+            items.minByOrNull { abs(it.durationMs - durationMs) }
+        } else {
+            items.firstOrNull()
+        }
+
+        if (bestMatch != null) {
+            val diff = abs(bestMatch.durationMs - durationMs)
+            System.err.println("PaxsenixLyrics: Best YouTube match: ${bestMatch.name ?: bestMatch.title} (ID: ${bestMatch.realId}, Duration: ${bestMatch.durationMs}, Diff: $diff)")
+            if (durationMs <= 0 || (diff < 10000)) {
+                val lyricsResponse = client.get("youtube/lyrics") {
+                    parameter("id", bestMatch.realId)
+                }
+                System.err.println("PaxsenixLyrics: YouTube lyrics status: ${lyricsResponse.status}")
+                if (lyricsResponse.status == HttpStatusCode.OK) {
+                    val data = cleanJsonLyrics(lyricsResponse.body<String>())
+                    if (data.isNotBlank() && !data.contains("\"error\"") && !data.contains("\"isError\"")) {
+                        System.err.println("PaxsenixLyrics: SUCCESS from YouTube")
+                        return@runCatching data
+                    }
+                    System.err.println("PaxsenixLyrics: YouTube returned error: ${data.take(200)}")
+                }
+            }
+        }
+        throw IllegalStateException("YouTube lyrics unavailable")
+    }
+
     suspend fun getMusixmatchLyrics(
         title: String,
         artist: String,


### PR DESCRIPTION
Adds a new lyrics source `Paxsenix: YouTube` using the Paxsenix API.

**Changes:**
- New `PaxsenixYouTubeLyricsProvider` implementing `LyricsProvider`
- `getYouTubeLyrics()` method in Paxsenix backend (search → lyrics by video ID)
- Preference key, enum entry, and default order registration
- Provider registration in `LyricsHelper` (base list + ordering map)
- Settings UI toggle and display name