### PR TITLE
feat: add description and unit label for history duration setting

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/Preference.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/Preference.kt
@@ -773,6 +773,14 @@ fun SliderPreference(
                         style = MaterialTheme.typography.bodyLarge,
                     )
 
+                    Spacer(Modifier.height(12.dp))
+
+                    Text(
+                        text = stringResource(R.string.history_duration_desc),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.secondary,
+                    )
+
                     Spacer(Modifier.height(16.dp))
 
                     val sliderState = rememberSliderState(
@@ -801,7 +809,7 @@ fun SliderPreference(
     PreferenceEntry(
         modifier = modifier,
         title = title,
-        description = value.toString(),
+        description = stringResource(R.string.history_duration_seconds, value),
         icon = icon,
         onClick = { showDialog = true },
         isEnabled = isEnabled,

--- a/app/src/main/res/values/archivetune_strings.xml
+++ b/app/src/main/res/values/archivetune_strings.xml
@@ -384,6 +384,8 @@
     <string name="past_year">Past year</string>
     <string name="top_length">My Top list length</string>
     <string name="history_duration">History duration</string>
+    <string name="history_duration_desc">Minimum playback time to count a song as listened</string>
+    <string name="history_duration_seconds">%1$s s</string>
     <string name="information">Information</string>
     <string name="description">Description</string>
     <string name="numbers">Numbers</string>


### PR DESCRIPTION
## Summary

Adds a unit label and description to the History Duration setting row and dialog to make the value immediately understandable. The setting row now displays `"30 s"` instead of a bare `"30"`, consistent with how Crossfade duration is displayed. The slider dialog also shows a short description explaining what the setting controls.

## Linked Work

- Closes:
- Related:

## Change Type

- [ ] Feature
- [ ] Bug fix
- [x] UI / UX
- [ ] Performance / memory
- [ ] Playback / Media3
- [ ] Lyrics / provider integration
- [ ] Search / YouTube / network data
- [ ] Local library / Room database
- [ ] Widgets / notification / shortcuts
- [x] Settings / preferences / DataStore
- [ ] Discord / Last.fm / ListenBrainz / external integration
- [x] Localization / strings / fastlane metadata
- [ ] Build / Gradle / CI / release packaging
- [ ] Dependency update
- [ ] Documentation only

## Affected Surfaces

- [x] `:app`
- [ ] `:innertube`
- [ ] `:betterlyrics`
- [ ] `:kugou`
- [ ] `:lrclib`
- [ ] `:lastfm`
- [ ] `:simpmusic`
- [ ] `:paxsenix`
- [ ] `:unison`
- [ ] `:canvas`
- [ ] `:shazamkit`
- [ ] `:spotifycore`
- [ ] `server`
- [ ] `fastlane`
- [ ] `.github`
- [ ] Other:

## Screenshots / Recordings

| Before | After |
| --- | --- |
| Setting row shows `"30"` with no unit | Setting row shows `"30 s"` |
| Dialog has no description text | Dialog shows `"Minimum playback time to count a song as listened"` |

## Behavior Notes

- The setting row description changes from a bare integer (e.g. `"30"`) to a value with unit (e.g. `"30 s"`), matching the Crossfade duration entry directly above it.
- The slider dialog now shows a secondary description text below the current value, matching the structure of `CrossfadeSliderPreference`.
- `history_duration_seconds` is a dedicated string resource and does not reuse `audio_crossfade_seconds`.
- No DataStore, playback, or preference logic is changed.

## Architecture Checklist

- [ ] The change preserves UDF flow: UI -> ViewModel -> UseCase/domain -> Repository/data.
- [ ] Screen state is represented structurally with `Loading`, `Success`, `Empty`, and `Error` where this PR introduces or changes screen state.
- [ ] Composables receive immutable, UI-specific domain models instead of raw Room, network, or service entities.
- [ ] Business work is not triggered directly from composition.
- [ ] Exceptions are surfaced through explicit state or result types instead of being swallowed.
- [ ] No `runBlocking` is introduced in app execution paths.

## Compose / Material Checklist

- [ ] UI state is hoisted out of composable layout code.
- [ ] Reactive state is collected with `collectAsStateWithLifecycle()`.
- [ ] New UI models are annotated with `@Immutable` or `@Stable`.
- [ ] Lazy layouts use stable `key` values and explicit `contentType`.
- [ ] Non-primitive constants, structural lambdas, and allocation-heavy objects in hot paths are remembered.
- [ ] Rapidly changing inputs such as scroll, gesture, animation, or playback progress use `derivedStateOf` where appropriate.
- [x] UI strings come from `stringResource()` and duplicated visible strings on the same screen are avoided.
- [ ] Interactive elements keep a minimum 48dp touch target.
- [x] Material 3 / Material 3 Expressive tokens are used for color, typography, shape, and motion instead of hardcoded UI values.
- [ ] Edge-to-edge layouts handle and consume `WindowInsets` correctly when this PR changes screen layout.

## Concurrency / Performance Checklist

- [ ] Business coroutines are scoped to `viewModelScope` or an existing lifecycle-owned application/service scope.
- [ ] Disk, database, network, parsing, and heavy mapping work is dispatched to `Dispatchers.IO` or `Dispatchers.Default`.
- [ ] Cancellation is handled explicitly where long-running work, playback, downloads, sync, lyrics fetching, or recognition is involved.
- [x] The change avoids blocking the main thread.
- [x] The change avoids unnecessary allocations in recomposition loops, playback loops, polling loops, and provider parsing paths.
- [ ] Large lists, images, lyrics payloads, and network responses are bounded, streamed, cached, paged, or mapped off the main thread as appropriate.

## Data / Persistence Checklist

- [ ] Room entity, DAO, or database changes include a schema update under `app/schemas`.
- [ ] Database migrations preserve existing user data and fail clearly when migration is impossible.
- [x] DataStore or preference-key changes are backward compatible.
- [ ] Network DTOs remain isolated from UI models.
- [ ] Provider responses handle missing, malformed, regional, or rate-limited data without crashing the app.

## Playback / Integration Checklist

- [ ] Media3 playback, queue, cache, and service behavior remains stable across foreground, background, notification, and process recreation paths.
- [ ] Audio focus, notification controls, widgets, shortcuts, and media session actions are considered when playback behavior changes.
- [ ] External integrations handle absent credentials, revoked auth, network failure, and API changes.
- [ ] Native, AAR, or ABI-sensitive changes account for mobile/tv and `universal`, `arm64`, `armeabi`, `x86`, and `x86_64` variants.

## Localization / Assets Checklist

- [x] User-facing strings are added to the base resources and translated resources are updated or intentionally left for translation follow-up.
- [ ] Unused string resources, drawables, and metadata are removed when replaced.
- [ ] Image assets have explicit display dimensions and are decoded at the displayed size.
- [ ] Fastlane metadata, screenshots, icons, or release text are updated when user-facing store behavior changes.

## Privacy / Security Checklist

- [x] No secrets, keys, tokens, keystores, signing files, private certificates, or local machine paths are committed.
- [x] Logs do not expose access tokens, cookies, auth headers, user identifiers, listening history, or local file paths.
- [ ] New network calls are justified by the feature and use existing client, proxy, timeout, and error-handling patterns.
- [x] User data remains local unless the PR explicitly documents the integration and consent path.

## Verification

- [ ] Android Studio sync:
- [x] Manual device/emulator verification: Poco X7 Pro
- [ ] UI screenshot/recording attached:
- [ ] Accessibility or touch-target review:
- [x] Regression areas checked: No DataStore, playback, or preference logic changed. Only `Preference.kt` and `archivetune_strings.xml` touched.
- [ ] CI expectation:

## Reviewer Focus

- `Preference.kt` — `SliderPreference`: description and dialog content changes only, verify styling matches `CrossfadeSliderPreference`.
- `archivetune_strings.xml` — two new strings: `history_duration_desc` and `history_duration_seconds`. Translation follow-up needed.

## Release Notes

History Duration setting now displays its value with a seconds unit label (`"30 s"`) and includes a short description in the slider dialog.