### PR TITLE
feat(AccountSettings): add smart 'Add another account' button

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AccountSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AccountSettings.kt
@@ -98,6 +98,7 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -216,6 +217,7 @@ fun AccountSettings(
 
     var showToken by remember { mutableStateOf(false) }
     var showTokenEditor by remember { mutableStateOf(false) }
+    var showUnsavedAccountDialog by remember { mutableStateOf(false) }
 
     LaunchedEffect(isLoggedIn) {
         if (!isLoggedIn) {
@@ -392,6 +394,14 @@ fun AccountSettings(
                     onSwitchAccount = switchToAccount,
                     onSwitchAccountChannel = switchToAccountChannel,
                     onRemoveAccount = removeAccount,
+                    onAddAnotherAccount = {
+                        val isSaved = savedAccounts.accounts.any { it.innerTubeCookie == innerTubeCookie }
+                        if (isLoggedIn && !isSaved) {
+                            showUnsavedAccountDialog = true
+                        } else {
+                            navController.navigate(buildLoginRoute())
+                        }
+                    },
                 )
             }
 
@@ -506,6 +516,69 @@ fun AccountSettings(
             onDismiss = { showTokenEditor = false },
         )
     }
+
+    if (showUnsavedAccountDialog) {
+        Dialog(onDismissRequest = { showUnsavedAccountDialog = false }) {
+            Card(
+                shape = CardShape,
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                ),
+                elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
+            ) {
+                Column(
+                    modifier = Modifier.padding(24.dp),
+                    verticalArrangement = Arrangement.spacedBy(20.dp),
+                ) {
+                    Text(
+                        text = stringResource(R.string.unsaved_account_dialog_title),
+                        style = MaterialTheme.typography.headlineSmall,
+                        fontWeight = FontWeight.Bold,
+                    )
+                    Text(
+                        text = stringResource(R.string.unsaved_account_dialog_text),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        TextButton(
+                            onClick = { showUnsavedAccountDialog = false },
+                        ) {
+                            Text(text = stringResource(R.string.unsaved_account_dialog_cancel))
+                        }
+                        Spacer(modifier = Modifier.width(4.dp))
+                        TextButton(
+                            onClick = {
+                                showUnsavedAccountDialog = false
+                                navController.navigate(buildLoginRoute())
+                            },
+                        ) {
+                            Text(
+                                text = stringResource(R.string.unsaved_account_dialog_no_thanks),
+                            )
+                        }
+                        Spacer(modifier = Modifier.width(4.dp))
+                        TextButton(
+                            onClick = {
+                                showUnsavedAccountDialog = false
+                                saveCurrentAccount()
+                                navController.navigate(buildLoginRoute())
+                            },
+                        ) {
+                            Text(
+                                text = stringResource(R.string.unsaved_account_dialog_save_yes),
+                                fontWeight = FontWeight.Bold,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 @Composable
@@ -525,6 +598,7 @@ private fun ProfileIdentityCard(
     onSwitchAccount: (SavedAccount) -> Unit,
     onSwitchAccountChannel: (AccountChannelUiModel) -> Unit,
     onRemoveAccount: (SavedAccount) -> Unit,
+    onAddAnotherAccount: () -> Unit,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val isPressed by interactionSource.collectIsPressedAsState()
@@ -912,6 +986,27 @@ private fun ProfileIdentityCard(
                                 onClick = {
                                     onSaveAccount()
                                     accountMenuExpanded = false
+                                },
+                            )
+
+                            DropdownMenuItem(
+                                text = {
+                                    Text(
+                                        text = stringResource(R.string.add_another_account),
+                                        style = MaterialTheme.typography.bodyMedium,
+                                    )
+                                },
+                                leadingIcon = {
+                                    Icon(
+                                        painter = painterResource(R.drawable.add_circle),
+                                        contentDescription = null,
+                                        tint = MaterialTheme.colorScheme.primary,
+                                        modifier = Modifier.size(20.dp),
+                                    )
+                                },
+                                onClick = {
+                                    accountMenuExpanded = false
+                                    onAddAnotherAccount()
                                 },
                             )
                         }

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -1016,6 +1016,12 @@
     <string name="player_background_style_v8_v9_desc">Không khả dụng với kiểu trình phát V8 và V9</string>
     <string name="recent_requests">Yêu cầu gần đây</string>
     <string name="remove_account">Xóa tài khoản</string>
+    <string name="add_another_account">Thêm tài khoản khác</string>
+    <string name="unsaved_account_dialog_title">Tài khoản chưa được lưu</string>
+    <string name="unsaved_account_dialog_text">Tài khoản hiện tại của bạn chưa được lưu. Bạn có muốn lưu trước khi thêm tài khoản khác không?</string>
+    <string name="unsaved_account_dialog_cancel">Hủy đăng nhập</string>
+    <string name="unsaved_account_dialog_no_thanks">Không cần đâu, cảm ơn</string>
+    <string name="unsaved_account_dialog_save_yes">Có, hãy lưu tài khoản hiện tại</string>
     <string name="romanization">Latinh hóa</string>
     <string name="save_current_account">Lưu tài khoản hiện tại</string>
     <string name="saved_accounts">Tài khoản đã lưu</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1056,5 +1056,11 @@
     <string name="save_current_account">Save current account</string>
     <string name="no_saved_accounts">No saved accounts yet</string>
     <string name="remove_account">Remove account</string>
+    <string name="add_another_account">Add another account</string>
+    <string name="unsaved_account_dialog_title">Account not saved</string>
+    <string name="unsaved_account_dialog_text">Your current account has not been saved yet. Do you want to save it before adding another account?</string>
+    <string name="unsaved_account_dialog_cancel">Cancel login</string>
+    <string name="unsaved_account_dialog_no_thanks">No thanks</string>
+    <string name="unsaved_account_dialog_save_yes">Yes, save current account</string>
     <string name="youtube_channels">YouTube channels</string>
 </resources>


### PR DESCRIPTION
Adds a smart "Add another account" dropdown item below "Save current account" in the account settings ProfileIdentityCard.

**Smart behavior:**
- If the current account is already saved → navigates directly to login
- If the current account is logged in but not saved → shows a dialog with 3 options:
  - **Cancel login** — dismisses the dialog
  - **No thanks** — proceeds to login without saving
  - **Yes, save current account** — saves the current account first, then proceeds to login