### PR TITLE
fix(YouTube): handle singleColumnBrowseResultsRenderer in playlist() for YTM mixes

### DIFF
--- a/innertube/src/main/kotlin/moe/rukamori/archivetune/innertube/YouTube.kt
+++ b/innertube/src/main/kotlin/moe/rukamori/archivetune/innertube/YouTube.kt
@@ -696,10 +696,30 @@ object YouTube {
             browseId = "VL$playlistId",
             setLogin = true
         ).body<BrowseResponse>()
-        val primarySection = response.contents?.twoColumnBrowseResultsRenderer?.tabs
-            ?.firstOrNull()?.tabRenderer?.content?.sectionListRenderer
-        val allFirstColumnContents = primarySection?.contents.orEmpty()
-        val base = allFirstColumnContents.firstOrNull {
+
+        val allSections = buildList {
+            response.contents?.sectionListRenderer?.contents?.let(::addAll)
+            response.contents?.singleColumnBrowseResultsRenderer?.tabs
+                ?.firstOrNull()
+                ?.tabRenderer
+                ?.content
+                ?.sectionListRenderer
+                ?.contents
+                ?.let(::addAll)
+            response.contents?.twoColumnBrowseResultsRenderer?.tabs
+                ?.firstOrNull()
+                ?.tabRenderer
+                ?.content
+                ?.sectionListRenderer
+                ?.contents
+                ?.let(::addAll)
+            response.contents?.twoColumnBrowseResultsRenderer?.secondaryContents
+                ?.sectionListRenderer
+                ?.contents
+                ?.let(::addAll)
+        }
+
+        val base = allSections.firstOrNull {
             it.musicResponsiveHeaderRenderer != null || it.musicEditablePlaylistDetailHeaderRenderer != null
         }
         val header = base?.musicResponsiveHeaderRenderer ?: base?.musicEditablePlaylistDetailHeaderRenderer?.header?.musicResponsiveHeaderRenderer
@@ -716,27 +736,37 @@ object YouTube {
 
         val description = base?.musicEditablePlaylistDetailHeaderRenderer?.header
             ?.musicDetailHeaderRenderer?.description?.runs?.joinToString("") { it.text }
-            ?: allFirstColumnContents.firstNotNullOfOrNull {
+            ?: allSections.firstNotNullOfOrNull {
                 it.musicDescriptionShelfRenderer?.description?.runs?.joinToString("") { run -> run.text }
             }
+
         val secondarySection = response.contents
             ?.twoColumnBrowseResultsRenderer
             ?.secondaryContents
             ?.sectionListRenderer
         val secondaryContents = secondarySection?.contents.orEmpty()
+
         val songContents = buildList {
             secondaryContents.forEach { content ->
                 addAll(content.playlistSongContents())
             }
-            allFirstColumnContents.forEach { content ->
+            allSections.forEach { content ->
                 addAll(content.playlistSongContents())
             }
         }
         val songsContinuation = secondaryContents.firstNotNullOfOrNull { content ->
             content.playlistSongContinuation()
-        } ?: allFirstColumnContents.firstNotNullOfOrNull { content ->
+        } ?: allSections.firstNotNullOfOrNull { content ->
             content.playlistSongContinuation()
         }
+
+        val primarySection = response.contents?.twoColumnBrowseResultsRenderer?.tabs
+            ?.firstOrNull()?.tabRenderer?.content?.sectionListRenderer
+        val singleColumnSection = response.contents?.singleColumnBrowseResultsRenderer?.tabs
+            ?.firstOrNull()
+            ?.tabRenderer
+            ?.content
+            ?.sectionListRenderer
 
         PlaylistPage(
             playlist = PlaylistItem(
@@ -764,6 +794,7 @@ object YouTube {
             songsContinuation = songsContinuation,
             continuation = secondarySection?.continuations?.getContinuation()
                 ?: primarySection?.continuations?.getContinuation()
+                ?: singleColumnSection?.continuations?.getContinuation()
         )
     }
 

--- a/innertube/src/main/kotlin/moe/rukamori/archivetune/innertube/pages/HomePage.kt
+++ b/innertube/src/main/kotlin/moe/rukamori/archivetune/innertube/pages/HomePage.kt
@@ -61,7 +61,13 @@ data class HomePage(
                     }.mapNotNull {
                         fromMusicTwoRowItemRenderer(it)
                     }.ifEmpty {
-                        return null
+                        renderer.contents.mapNotNull {
+                            it.musicResponsiveListItemRenderer
+                        }.mapNotNull {
+                            SearchPage.toYTItem(it)
+                        }.ifEmpty {
+                            return null
+                        }
                     }
                 )
             }


### PR DESCRIPTION
## Problem

YTM mixes like \"Mixed for you\" items could not load their playlist content. The app would show an error instead of the playlist songs.

## Root Cause

`YouTube.playlist()` only handled the `twoColumnBrowseResultsRenderer` response format. YTM mixes return responses using `singleColumnBrowseResultsRenderer`, which caused the response header to not be found, throwing `PLAYLIST_PRIVATE`.

## Fix

Modified `YouTube.playlist()` to collect section contents from **all three** response formats (matching the pattern already used by `AlbumPage.getSectionContents()`):

1. `contents.sectionListRenderer`
2. `contents.singleColumnBrowseResultsRenderer` ← new, fixes mixes
3. `contents.twoColumnBrowseResultsRenderer` (primary + secondary)

Header, description, songs, and continuation are then found from the combined section list. Secondary column songs (with proper `setVideoId`) are still prioritized first for correct ordering.

## Testing

Existing playlist loading for regular YTM playlists continues to work since the two-column format is still handled (secondary songs deduplicated by `distinctBy { it.id }` at the ViewModel level).