### PR TITLE
feat(player): add customizable swipe-up actions for now playing screen

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
@@ -188,17 +188,6 @@ val TogetherRequireHostApprovalToJoinKey = booleanPreferencesKey("together_requi
 val TogetherLastJoinLinkKey = stringPreferencesKey("together_last_join_link")
 val TogetherWelcomeShownKey = booleanPreferencesKey("together_welcome_shown")
     
-enum class SwipeUpAction {
-    Lyrics,
-    Queue,
-    Artist,
-    Album,
-    SongInfo,
-    None
-}
-
-val SwipeUpActionKey = stringPreferencesKey("swipe_up_action")
-    
 // ListenBrainz scrobbling
 val ListenBrainzEnabledKey = booleanPreferencesKey("listenbrainz_enabled")
 val ListenBrainzTokenKey = stringPreferencesKey("listenbrainz_token")

--- a/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/constants/PreferenceKeys.kt
@@ -188,6 +188,17 @@ val TogetherRequireHostApprovalToJoinKey = booleanPreferencesKey("together_requi
 val TogetherLastJoinLinkKey = stringPreferencesKey("together_last_join_link")
 val TogetherWelcomeShownKey = booleanPreferencesKey("together_welcome_shown")
     
+enum class SwipeUpAction {
+    Lyrics,
+    Queue,
+    Artist,
+    Album,
+    SongInfo,
+    None
+}
+
+val SwipeUpActionKey = stringPreferencesKey("swipe_up_action")
+    
 // ListenBrainz scrobbling
 val ListenBrainzEnabledKey = booleanPreferencesKey("listenbrainz_enabled")
 val ListenBrainzTokenKey = stringPreferencesKey("listenbrainz_token")
@@ -674,6 +685,16 @@ val RepeatModeKey = intPreferencesKey("repeatMode")
 val SearchSourceKey = stringPreferencesKey("searchSource")
 val SwipeThumbnailKey = booleanPreferencesKey("swipeThumbnail")
 val SwipeSensitivityKey = floatPreferencesKey("swipeSensitivity")
+val SwipeUpActionKey = stringPreferencesKey("swipeUpAction")
+
+enum class SwipeUpAction {
+    LYRICS,
+    QUEUE,
+    ARTIST,
+    ALBUM,
+    SONG_INFO,
+    NONE
+}
 
 enum class SearchSource {
     LOCAL,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
@@ -1380,7 +1380,8 @@ fun BottomSheetPlayer(
                             Thumbnail(
                                 sliderPositionProvider = { sliderPosition },
                                 modifier = Modifier.size(thumbnailSize),
-                                isPlayerExpanded = state.isExpanded
+                                isPlayerExpanded = state.isExpanded,
+                                onSwipeUp = handleSwipeUp,
                             )
                         }
                         Column(
@@ -1639,7 +1640,8 @@ fun BottomSheetPlayer(
                             Thumbnail(
                                 sliderPositionProvider = { sliderPosition },
                                 modifier = Modifier.nestedScroll(state.preUpPostDownNestedScrollConnection),
-                                isPlayerExpanded = state.isExpanded
+                                isPlayerExpanded = state.isExpanded,
+                                onSwipeUp = handleSwipeUp,
                             )
                         }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
@@ -755,33 +755,33 @@ fun BottomSheetPlayer(
         mutableStateOf(false)
     }
 
-    val swipeUpAction by rememberEnumPreference(SwipeUpActionKey, defaultValue = SwipeUpAction.Lyrics)
+    val swipeUpAction by rememberEnumPreference(SwipeUpActionKey, defaultValue = SwipeUpAction.LYRICS)
 
-    val handleSwipeUp = {
+    val handleSwipeUp: () -> Unit = {
         when (swipeUpAction) {
-            SwipeUpAction.Lyrics -> isLyricsScreenVisible = true
-            SwipeUpAction.Queue -> queueSheetState.expandSoft()
-            SwipeUpAction.Artist -> {
+            SwipeUpAction.LYRICS -> isLyricsScreenVisible = true
+            SwipeUpAction.QUEUE -> queueSheetState.expandSoft()
+            SwipeUpAction.ARTIST -> {
                 val firstArtistId = mediaMetadata?.artists?.firstOrNull()?.id
                 if (!firstArtistId.isNullOrBlank()) {
                     state.collapseSoft()
                     navController.navigate("artist/$firstArtistId")
                 }
             }
-            SwipeUpAction.Album -> {
+            SwipeUpAction.ALBUM -> {
                 if (mediaMetadata?.album != null) {
                     state.snapTo(state.collapsedBound)
                     navController.navigate("album/${mediaMetadata?.album?.id}")
                 }
             }
-            SwipeUpAction.SongInfo -> {
+            SwipeUpAction.SONG_INFO -> {
                 mediaMetadata?.id?.let { id ->
                     bottomSheetPageState.show {
                         ShowMediaInfo(id)
                     }
                 }
             }
-            SwipeUpAction.None -> {}
+            SwipeUpAction.NONE -> {}
         }
     }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
@@ -195,6 +195,8 @@ import moe.rukamori.archivetune.constants.PlayerHorizontalPadding
 import moe.rukamori.archivetune.constants.QueuePeekHeight
 import moe.rukamori.archivetune.constants.SliderStyle
 import moe.rukamori.archivetune.constants.SliderStyleKey
+import moe.rukamori.archivetune.constants.SwipeUpAction
+import moe.rukamori.archivetune.constants.SwipeUpActionKey
 import moe.rukamori.archivetune.extensions.togglePlayPause
 import moe.rukamori.archivetune.extensions.toggleRepeatMode
 import moe.rukamori.archivetune.db.entities.FormatEntity
@@ -753,6 +755,36 @@ fun BottomSheetPlayer(
         mutableStateOf(false)
     }
 
+    val swipeUpAction by rememberEnumPreference(SwipeUpActionKey, defaultValue = SwipeUpAction.Lyrics)
+
+    val handleSwipeUp = {
+        when (swipeUpAction) {
+            SwipeUpAction.Lyrics -> isLyricsScreenVisible = true
+            SwipeUpAction.Queue -> queueSheetState.expandSoft()
+            SwipeUpAction.Artist -> {
+                val firstArtistId = mediaMetadata?.artists?.firstOrNull()?.id
+                if (!firstArtistId.isNullOrBlank()) {
+                    state.collapseSoft()
+                    navController.navigate("artist/$firstArtistId")
+                }
+            }
+            SwipeUpAction.Album -> {
+                if (mediaMetadata?.album != null) {
+                    state.snapTo(state.collapsedBound)
+                    navController.navigate("album/${mediaMetadata?.album?.id}")
+                }
+            }
+            SwipeUpAction.SongInfo -> {
+                mediaMetadata?.id?.let { id ->
+                    bottomSheetPageState.show {
+                        ShowMediaInfo(id)
+                    }
+                }
+            }
+            SwipeUpAction.None -> {}
+        }
+    }
+
     BackHandler(
         enabled =
         isLyricsScreenVisible ||
@@ -1086,6 +1118,7 @@ fun BottomSheetPlayer(
                 context = context,
                 onSliderValueChange = onSliderValueChange,
                 onSliderValueChangeFinished = onSliderValueChangeFinished,
+                onSwipeUp = handleSwipeUp,
                 currentFormat = if (playerDesignStyle == PlayerDesignStyle.V7) currentFormat else null,
             )
         }
@@ -1237,6 +1270,7 @@ fun BottomSheetPlayer(
                                     onSliderValueChange = onSliderValueChange,
                                     onSliderValueChangeFinished = onSliderValueChangeFinished,
                                     onVolumeChange = onPlayerVolumeChange,
+                                    onSwipeUp = handleSwipeUp,
                                     landscape = true,
                                 )
                             }
@@ -1278,6 +1312,7 @@ fun BottomSheetPlayer(
                                 onSliderValueChange = onSliderValueChange,
                                 onSliderValueChangeFinished = onSliderValueChangeFinished,
                                 onVolumeChange = onPlayerVolumeChange,
+                                onSwipeUp = handleSwipeUp,
                                 landscape = true,
                                 modifier = Modifier
                                     .fillMaxSize()
@@ -1316,6 +1351,7 @@ fun BottomSheetPlayer(
                             onLyricsClick = { isLyricsScreenVisible = true },
                             onSliderValueChange = onSliderValueChange,
                             onSliderValueChangeFinished = onSliderValueChangeFinished,
+                            onSwipeUp = handleSwipeUp,
                             landscape = true,
                             modifier = Modifier
                                 .fillMaxSize()
@@ -1493,6 +1529,7 @@ fun BottomSheetPlayer(
                                     onSliderValueChange = onSliderValueChange,
                                     onSliderValueChangeFinished = onSliderValueChangeFinished,
                                     onVolumeChange = onPlayerVolumeChange,
+                                    onSwipeUp = handleSwipeUp,
                                 )
                             }
 
@@ -1533,6 +1570,7 @@ fun BottomSheetPlayer(
                                 onSliderValueChange = onSliderValueChange,
                                 onSliderValueChangeFinished = onSliderValueChangeFinished,
                                 onVolumeChange = onPlayerVolumeChange,
+                                onSwipeUp = handleSwipeUp,
                                 modifier = Modifier
                                     .fillMaxSize()
                                     .padding(bottom = queueSheetState.collapsedBound)
@@ -1570,6 +1608,7 @@ fun BottomSheetPlayer(
                             onLyricsClick = { isLyricsScreenVisible = true },
                             onSliderValueChange = onSliderValueChange,
                             onSliderValueChangeFinished = onSliderValueChangeFinished,
+                            onSwipeUp = handleSwipeUp,
                             modifier = Modifier
                                 .fillMaxSize()
                                 .padding(bottom = queueSheetState.collapsedBound)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerComponents.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerComponents.kt
@@ -4026,8 +4026,8 @@ fun Modifier.detectSwipeUpAction(
     var totalDragY = 0f
     var totalDragX = 0f
 
-    androidx.compose.foundation.gestures.detectDragGestures(
-        onDragStart = {
+    detectDragGestures(
+        onDragStart = { _ ->
             totalDragY = 0f
             totalDragX = 0f
         },
@@ -4036,7 +4036,7 @@ fun Modifier.detectSwipeUpAction(
                 onSwipeUp()
             }
         },
-        onDrag = { change, dragAmount ->
+        onDrag = { change: androidx.compose.ui.input.pointer.PointerInputChange, dragAmount: androidx.compose.ui.geometry.Offset ->
             totalDragX += dragAmount.x
             totalDragY += dragAmount.y
             if (kotlin.math.abs(totalDragY) > kotlin.math.abs(totalDragX) && kotlin.math.abs(totalDragY) > 20f) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerComponents.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerComponents.kt
@@ -33,6 +33,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -1625,6 +1627,7 @@ fun PlayerControlsContent(
     context: Context,
     onSliderValueChange: (Long) -> Unit,
     onSliderValueChangeFinished: () -> Unit,
+    onSwipeUp: () -> Unit = {},
     currentFormat: FormatEntity? = null,
 ) {
     val currentSong by playerConnection.currentSong.collectAsState(initial = null)
@@ -1641,7 +1644,8 @@ fun PlayerControlsContent(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = PlayerHorizontalPadding),
+            .padding(horizontal = PlayerHorizontalPadding)
+            .detectSwipeUpAction(onSwipeUp = onSwipeUp),
     ) {
         Column(modifier = Modifier.weight(1f)) {
             PlayerTitleSection(
@@ -1773,6 +1777,7 @@ fun V8PlayerControlsContent(
     onSliderValueChange: (Long) -> Unit,
     onSliderValueChangeFinished: () -> Unit,
     onVolumeChange: (Float) -> Unit,
+    onSwipeUp: () -> Unit = {},
     modifier: Modifier = Modifier,
     landscape: Boolean = false,
 ) {
@@ -1873,6 +1878,7 @@ fun V8PlayerControlsContent(
                 onToggleLike = onToggleLike,
                 onTitleClick = onTitleClick,
                 onArtistClick = onArtistClick,
+                onSwipeUp = onSwipeUp,
             )
 
             Spacer(Modifier.height(contentGap))
@@ -1938,6 +1944,7 @@ fun V8PlayerContent(
     onSliderValueChange: (Long) -> Unit,
     onSliderValueChangeFinished: () -> Unit,
     onVolumeChange: (Float) -> Unit,
+    onSwipeUp: () -> Unit = {},
     modifier: Modifier = Modifier,
     landscape: Boolean = false,
 ) {
@@ -2016,6 +2023,7 @@ fun V8PlayerContent(
             onSliderValueChange = onSliderValueChange,
             onSliderValueChangeFinished = onSliderValueChangeFinished,
             onVolumeChange = onVolumeChange,
+            onSwipeUp = onSwipeUp,
             modifier = modifier,
         )
     } else {
@@ -2056,6 +2064,7 @@ fun V8PlayerContent(
             onSliderValueChange = onSliderValueChange,
             onSliderValueChangeFinished = onSliderValueChangeFinished,
             onVolumeChange = onVolumeChange,
+            onSwipeUp = onSwipeUp,
             modifier = modifier,
         )
     }
@@ -2092,6 +2101,7 @@ private fun V8PortraitContent(
     onVolumeChange: (Float) -> Unit,
     onTitleClick: () -> Unit,
     onArtistClick: () -> Unit,
+    onSwipeUp: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     BoxWithConstraints(modifier = modifier.fillMaxSize()) {
@@ -2169,6 +2179,7 @@ private fun V8PortraitContent(
                 onToggleLike = onToggleLike,
                 onTitleClick = onTitleClick,
                 onArtistClick = onArtistClick,
+                onSwipeUp = onSwipeUp,
             )
 
             Spacer(Modifier.height(controlsGap))
@@ -2242,6 +2253,7 @@ private fun V8LandscapeContent(
     onVolumeChange: (Float) -> Unit,
     onTitleClick: () -> Unit,
     onArtistClick: () -> Unit,
+    onSwipeUp: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     BoxWithConstraints(modifier = modifier.fillMaxSize()) {
@@ -2291,6 +2303,7 @@ private fun V8LandscapeContent(
                     onToggleLike = onToggleLike,
                     onTitleClick = onTitleClick,
                     onArtistClick = onArtistClick,
+                    onSwipeUp = onSwipeUp,
                 )
 
                 Spacer(Modifier.height(18.dp))
@@ -2411,9 +2424,12 @@ private fun V8MetadataActions(
     onToggleLike: () -> Unit,
     onTitleClick: () -> Unit,
     onArtistClick: () -> Unit,
+    onSwipeUp: () -> Unit = {},
 ) {
     Row(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .detectSwipeUpAction(onSwipeUp = onSwipeUp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(18.dp),
     ) {
@@ -2842,6 +2858,7 @@ fun V9PlayerContent(
     onLyricsClick: () -> Unit,
     onSliderValueChange: (Long) -> Unit,
     onSliderValueChangeFinished: () -> Unit,
+    onSwipeUp: () -> Unit = {},
     modifier: Modifier = Modifier,
     landscape: Boolean = false,
 ) {
@@ -2899,6 +2916,7 @@ fun V9PlayerContent(
             onNextClick = playerConnection::seekToNext,
             onSliderValueChange = onSliderValueChange,
             onSliderValueChangeFinished = onSliderValueChangeFinished,
+            onSwipeUp = onSwipeUp,
             modifier = modifier,
         )
     } else {
@@ -2929,6 +2947,7 @@ fun V9PlayerContent(
             onNextClick = playerConnection::seekToNext,
             onSliderValueChange = onSliderValueChange,
             onSliderValueChangeFinished = onSliderValueChangeFinished,
+            onSwipeUp = onSwipeUp,
             modifier = modifier,
         )
     }
@@ -2962,6 +2981,7 @@ private fun V9PortraitContent(
     onSliderValueChangeFinished: () -> Unit,
     onTitleClick: () -> Unit,
     onArtistClick: () -> Unit,
+    onSwipeUp: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     BoxWithConstraints(modifier = modifier.fillMaxSize()) {
@@ -3035,6 +3055,7 @@ private fun V9PortraitContent(
                 textColor = textBackgroundColor,
                 onTitleClick = onTitleClick,
                 onArtistClick = onArtistClick,
+                onSwipeUp = onSwipeUp,
             )
 
             Spacer(Modifier.height(controlsGap))
@@ -3101,6 +3122,7 @@ private fun V9LandscapeContent(
     onSliderValueChangeFinished: () -> Unit,
     onTitleClick: () -> Unit,
     onArtistClick: () -> Unit,
+    onSwipeUp: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     BoxWithConstraints(modifier = modifier.fillMaxSize()) {
@@ -3147,6 +3169,7 @@ private fun V9LandscapeContent(
                     textColor = textBackgroundColor,
                     onTitleClick = onTitleClick,
                     onArtistClick = onArtistClick,
+                    onSwipeUp = onSwipeUp,
                 )
 
                 Spacer(Modifier.height(20.dp))
@@ -3314,9 +3337,12 @@ private fun V9Metadata(
     textColor: Color,
     onTitleClick: () -> Unit,
     onArtistClick: () -> Unit,
+    onSwipeUp: () -> Unit = {},
 ) {
     Column(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .detectSwipeUpAction(onSwipeUp = onSwipeUp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(6.dp),
     ) {
@@ -3991,4 +4017,31 @@ fun PlayerBackground(
             }
         }
     }
+}
+
+fun Modifier.detectSwipeUpAction(
+    sensitivity: Float = 20f,
+    onSwipeUp: () -> Unit
+): Modifier = this.pointerInput(Unit) {
+    var totalDragY = 0f
+    var totalDragX = 0f
+
+    androidx.compose.foundation.gestures.detectDragGestures(
+        onDragStart = {
+            totalDragY = 0f
+            totalDragX = 0f
+        },
+        onDragEnd = {
+            if (totalDragY < -sensitivity && kotlin.math.abs(totalDragY) > kotlin.math.abs(totalDragX)) {
+                onSwipeUp()
+            }
+        },
+        onDrag = { change, dragAmount ->
+            totalDragX += dragAmount.x
+            totalDragY += dragAmount.y
+            if (kotlin.math.abs(totalDragY) > kotlin.math.abs(totalDragX) && kotlin.math.abs(totalDragY) > 20f) {
+                change.consume()
+            }
+        }
+    )
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerComponents.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerComponents.kt
@@ -2166,6 +2166,7 @@ private fun V8PortraitContent(
                 canvasFallbackUrl = canvasFallbackUrl,
                 isPlaying = isPlaying,
                 size = artworkSize,
+                onSwipeUp = onSwipeUp,
             )
 
             Spacer(Modifier.height(artworkToMetadata))
@@ -2276,6 +2277,7 @@ private fun V8LandscapeContent(
                 canvasFallbackUrl = canvasFallbackUrl,
                 isPlaying = isPlaying,
                 size = artworkSize,
+                onSwipeUp = onSwipeUp,
             )
 
             Column(
@@ -2387,6 +2389,7 @@ private fun V8Artwork(
     canvasFallbackUrl: String?,
     isPlaying: Boolean,
     size: androidx.compose.ui.unit.Dp,
+    onSwipeUp: () -> Unit = {},
 ) {
     val artworkRequest = rememberOfflineArtworkImageRequest(artworkUrl)
     Box(
@@ -2411,6 +2414,14 @@ private fun V8Artwork(
                 modifier = Modifier.fillMaxSize(),
             )
         }
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .fillMaxHeight(0.5f)
+                .align(Alignment.BottomCenter)
+                .detectSwipeUpAction(onSwipeUp = onSwipeUp)
+        )
     }
 }
 
@@ -3045,6 +3056,7 @@ private fun V9PortraitContent(
                 isPlaying = isPlaying,
                 size = artworkSize,
                 placeholderColor = textButtonColor.copy(alpha = 0.12f),
+                onSwipeUp = onSwipeUp,
             )
 
             Spacer(Modifier.height(metadataGap))
@@ -3144,6 +3156,7 @@ private fun V9LandscapeContent(
                 isPlaying = isPlaying,
                 size = artworkSize,
                 placeholderColor = textButtonColor.copy(alpha = 0.12f),
+                onSwipeUp = onSwipeUp,
             )
 
             Column(
@@ -3303,6 +3316,7 @@ private fun V9Artwork(
     isPlaying: Boolean,
     size: Dp,
     placeholderColor: Color,
+    onSwipeUp: () -> Unit = {},
 ) {
     val artworkRequest = rememberOfflineArtworkImageRequest(artworkUrl)
     Box(
@@ -3327,6 +3341,14 @@ private fun V9Artwork(
                 modifier = Modifier.fillMaxSize(),
             )
         }
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .fillMaxHeight(0.5f)
+                .align(Alignment.BottomCenter)
+                .detectSwipeUpAction(onSwipeUp = onSwipeUp)
+        )
     }
 }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Thumbnail.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Thumbnail.kt
@@ -133,6 +133,7 @@ fun Thumbnail(
     sliderPositionProvider: () -> Long?,
     modifier: Modifier = Modifier,
     isPlayerExpanded: Boolean = true, // Add parameter to control swipe based on player state
+    onSwipeUp: () -> Unit = {},
 ) {
     val playerConnection = LocalPlayerConnection.current ?: return
     val context = LocalContext.current
@@ -586,6 +587,14 @@ fun Thumbnail(
                                                 modifier = Modifier.fillMaxSize(),
                                             )
                                         }
+
+                                        Box(
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .fillMaxHeight(0.5f)
+                                                .align(Alignment.BottomCenter)
+                                                .detectSwipeUpAction(onSwipeUp = onSwipeUp)
+                                        )
                                     }
                                 }
                             }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Thumbnail.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Thumbnail.kt
@@ -24,6 +24,8 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceSettings.kt
@@ -104,6 +104,8 @@ import moe.rukamori.archivetune.constants.QuickPicksDisplayModeKey
 import moe.rukamori.archivetune.constants.SwipeThumbnailKey
 import moe.rukamori.archivetune.constants.SwipeSensitivityKey
 import moe.rukamori.archivetune.constants.SwipeToSongKey
+import moe.rukamori.archivetune.constants.SwipeUpAction
+import moe.rukamori.archivetune.constants.SwipeUpActionKey
 import moe.rukamori.archivetune.constants.HidePlayerThumbnailKey
 import moe.rukamori.archivetune.constants.ArchiveTuneCanvasKey
 import moe.rukamori.archivetune.constants.ThumbnailCornerRadiusKey
@@ -216,6 +218,10 @@ fun AppearanceSettings(
     val (swipeSensitivity, onSwipeSensitivityChange) = rememberPreference(
         SwipeSensitivityKey,
         defaultValue = 0.73f
+    )
+    val (swipeUpAction, onSwipeUpActionChange) = rememberEnumPreference(
+        SwipeUpActionKey,
+        defaultValue = SwipeUpAction.LYRICS
     )
     val (gridItemSize, onGridItemSizeChange) = rememberEnumPreference(
         GridItemsSizeKey,
@@ -772,6 +778,23 @@ fun AppearanceSettings(
                     description = stringResource(R.string.sensitivity_percentage, (swipeSensitivity * 100).roundToInt()),
                     icon = { Icon(painterResource(R.drawable.tune), null) },
                     onClick = { showSensitivityDialog = true }
+                )
+
+                EnumListPreference(
+                    title = { Text(stringResource(R.string.swipe_up_action)) },
+                    icon = { Icon(painterResource(R.drawable.swipe), null) },
+                    selectedValue = swipeUpAction,
+                    onValueSelected = onSwipeUpActionChange,
+                    valueText = {
+                        when (it) {
+                            SwipeUpAction.LYRICS -> stringResource(R.string.swipe_up_action_lyrics)
+                            SwipeUpAction.QUEUE -> stringResource(R.string.swipe_up_action_queue)
+                            SwipeUpAction.ARTIST -> stringResource(R.string.swipe_up_action_artist)
+                            SwipeUpAction.ALBUM -> stringResource(R.string.swipe_up_action_album)
+                            SwipeUpAction.SONG_INFO -> stringResource(R.string.swipe_up_action_song_info)
+                            SwipeUpAction.NONE -> stringResource(R.string.swipe_up_action_none)
+                        }
+                    }
                 )
             }
         }

--- a/app/src/main/res/values/archivetune_strings.xml
+++ b/app/src/main/res/values/archivetune_strings.xml
@@ -362,6 +362,14 @@
     <string name="storage_cache_cleared">Cache cleared.</string>
     <string name="storage_cache_clear_failed">Cache could not be cleared. Check SD card access.</string>
     <string name="storage_size_ratio">%1$s / %2$s</string>
+
+    <string name="swipe_up_action">Swipe up action</string>
+    <string name="swipe_up_action_lyrics">Lyrics</string>
+    <string name="swipe_up_action_queue">Queue</string>
+    <string name="swipe_up_action_artist">Artist</string>
+    <string name="swipe_up_action_album">Album</string>
+    <string name="swipe_up_action_song_info">Song Info</string>
+    <string name="swipe_up_action_none">None</string>
     <string name="sensitivity_percentage">%1$d%%</string>
     <string name="clear_song_cache_dialog">  Are you sure you want to clear all cached songs?</string>
     <string name="clear_image_cache_dialog">  Are you sure you want to clear all cached image?</string>


### PR DESCRIPTION
## Summary

Implements a configurable swipe-up gesture for the Now Playing screen.

Users can now choose which action is triggered when swiping up from the player artwork / metadata area, allowing the gesture to be adapted to individual workflows instead of being fixed to a single behavior.

### Available Actions

- Lyrics
- Queue
- Artist
- Album
- Song Info
- None

### Changes

- Added `SwipeUpAction` preference and enum support
- Added settings UI for selecting swipe-up behavior
- Implemented reusable swipe-up gesture detection
- Added gesture handling for:
  - Default player layout
  - V8 player layout
  - V9 player layout
- Integrated navigation actions for lyrics, queue, artist, album, and song info
- Added localization strings for the new settings

### Implementation Notes

- Gesture is attached to the lower artwork / metadata region to avoid conflicts with existing controls.
- Seek bar interactions remain unaffected.
- Existing artwork swipe gestures remain unchanged.
- Gesture execution is preference-driven and updates dynamically.

### Testing

- Built successfully using `assembleDebug`
- Tested on device
- Verified all swipe-up actions
- Verified default, V8, and V9 player layouts
- Verified settings persistence after restart

Closes #710 