### PR TITLE
fix(MusicService): extend cache-corruption recovery to malformed container parse errors

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
@@ -45,6 +45,7 @@ import androidx.datastore.preferences.core.edit
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
+import androidx.media3.common.ParserException
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.common.Player.EVENT_POSITION_DISCONTINUITY
@@ -2394,13 +2395,21 @@ class MusicService :
         return false
     }
 
-    private fun isCacheCorruptionError(error: PlaybackException): Boolean {
-        if (
-            error.errorCode != PlaybackException.ERROR_CODE_IO_UNSPECIFIED &&
-            error.errorCode != PlaybackException.ERROR_CODE_IO_READ_POSITION_OUT_OF_RANGE
-        ) {
+    private fun isCacheCorruptionError(
+        error: PlaybackException,
+        isContentCached: Boolean,
+    ): Boolean {
+        val isIoError =
+            error.errorCode == PlaybackException.ERROR_CODE_IO_UNSPECIFIED ||
+                error.errorCode == PlaybackException.ERROR_CODE_IO_READ_POSITION_OUT_OF_RANGE
+        val isContainerParseError =
+            error.errorCode == PlaybackException.ERROR_CODE_PARSING_CONTAINER_MALFORMED ||
+                error.errorCode == PlaybackException.ERROR_CODE_PARSING_CONTAINER_UNSUPPORTED
+
+        if (!isIoError && !isContainerParseError) {
             return false
         }
+
         var throwable: Throwable? = error.cause
         while (throwable != null) {
             when {
@@ -2408,12 +2417,19 @@ class MusicService :
                 throwable is IOException &&
                     throwable.message?.contains("unexpected end of stream", ignoreCase = true) == true ->
                     return true
-                // Truncated MP4 atoms frequently surface as extractor IllegalState/IllegalArgument
-                // exceptions WITHOUT a wrapped EOFException.
                 throwable is IllegalStateException || throwable is IllegalArgumentException ->
                     if (throwable.stackTrace.any { it.className.startsWith("androidx.media3.extractor") }) {
                         return true
                     }
+                isContainerParseError && isContentCached && throwable is ParserException ->
+                    return true
+                isContainerParseError && isContentCached &&
+                    throwable.message?.let {
+                        it.contains("Invalid integer size", ignoreCase = true) ||
+                            it.contains("Skipping atom with length", ignoreCase = true) ||
+                            it.contains("contentIsMalformed=true", ignoreCase = true)
+                    } == true ->
+                    return true
             }
             throwable = throwable.cause
         }
@@ -5269,6 +5285,11 @@ private fun onMediaItemTransitionInternal() {
             cachedInDownload || cachedInPlayer
         }.getOrDefault(false)
 
+        val hasAnyCachedData = isFullyCachedMedia || runCatching {
+            downloadCache.getCachedSpans(currentMediaId).isNotEmpty() ||
+                playerCache.getCachedSpans(currentMediaId).isNotEmpty()
+        }.getOrDefault(false)
+
         val isConnectionError = (error.cause?.cause is PlaybackException) &&
                 (error.cause?.cause as PlaybackException).errorCode == PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED
 
@@ -5291,7 +5312,7 @@ private fun onMediaItemTransitionInternal() {
             }
         }
 
-        if (!isLocalMedia && isCacheCorruptionError(error)) {
+        if (!isLocalMedia && isCacheCorruptionError(error, hasAnyCachedData)) {
             // Snapshot on the Main thread before dispatching; these can change.
             val mediaItemIndex = player.currentMediaItemIndex
             val resumePosition = player.currentPosition.coerceAtLeast(0L)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
@@ -2403,9 +2403,8 @@ class MusicService :
             error.errorCode == PlaybackException.ERROR_CODE_IO_UNSPECIFIED ||
                 error.errorCode == PlaybackException.ERROR_CODE_IO_READ_POSITION_OUT_OF_RANGE
         val isContainerParseError =
-            error.errorCode == PlaybackException.ERROR_CODE_PARSING_CONTAINER_MALFORMED ||
-                error.errorCode == PlaybackException.ERROR_CODE_PARSING_CONTAINER_UNSUPPORTED
-
+            error.errorCode == PlaybackException.ERROR_CODE_PARSING_CONTAINER_MALFORMED
+        
         if (!isIoError && !isContainerParseError) {
             return false
         }


### PR DESCRIPTION
# Pull Request

## Summary

This is a follow-up PR that extends the newly merged cache-corruption recovery path in `MusicService` to handle container-parsing errors (such as the 3001 `ParserException` experienced in the field) when they occur on cached media. 

Previously, `isCacheCorruptionError()` only listened for `ERROR_CODE_IO_UNSPECIFIED` and `ERROR_CODE_IO_READ_POSITION_OUT_OF_RANGE`. This meant that a corrupted or truncated cached MP4 file throwing a `3001` container-parse error (`ERROR_CODE_PARSING_CONTAINER_MALFORMED`) would bypass the recovery block, fall back to the remote parser retry path (which simply retries without purging the cache), and cause an infinite playback failure/retry loop for the user on revisit.

This PR solves that by:
1. Gating `isCacheCorruptionError()` on both IO and container-parse errors.
2. Introducing a `hasAnyCachedData` signal (which checks if any cached spans, including partial ones, exist) to ensure we only treat parse failures as cache corruption when there are cached bytes on disk.
3. Purging the corrupted cache when matched, so subsequent preparation cleanly fetches fresh, uncorrupted bytes.

## Linked Work

- Closes: -<!-- e.g. Link any issue tracking the 3001 error here, if any -->
- Related: -

## Change Type

- [ ] Feature
- [x] Bug fix
- [ ] UI / UX
- [x] Performance / memory
- [x] Playback / Media3
- [ ] Lyrics / provider integration
- [ ] Search / YouTube / network data
- [ ] Local library / Room database
- [ ] Widgets / notification / shortcuts
- [ ] Settings / preferences / DataStore
- [ ] Discord / Last.fm / ListenBrainz / external integration
- [ ] Localization / strings / fastlane metadata
- [ ] Build / Gradle / CI / release packaging
- [ ] Dependency update
- [ ] Documentation only

## Affected Surfaces

- [x] `:app`
- [ ] `:innertube`
- [ ] `:betterlyrics`
- [ ] `:kugou`
- [ ] `:lrclib`
- [ ] `:lastfm`
- [ ] `:simpmusic`
- [ ] `:paxsenix`
- [ ] `:unison`
- [ ] `:canvas`
- [ ] `:shazamkit`
- [ ] `:spotifycore`
- [ ] `server`
- [ ] `fastlane`
- [ ] `.github`
- [x] Other: `MusicService.kt` playback error-handling path only

## Screenshots / Recordings

| Before | After |
| --- | --- |
| N/A (no UI change) | N/A (no UI change) |

## Behavior Notes

* **Trigger Paths:**
  * When a playback error occurs, if it's a parsing error (`3001`), we check if there are cached spans (fully or partially) for the media ID.
  * If cached bytes exist (`hasAnyCachedData == true`) and `isCacheCorruptionError` matches a `ParserException` or typical corrupt atom messages ("Invalid integer size", "Skipping atom with length", "contentIsMalformed=true"), we mark it as cache corruption.
  * The recovery logic then purges the streaming cache, purges the download cache (if it wasn't a completed download), and re-prepares after the purge on the main thread.
* **Fallbacks preserved:**
  * Genuinely broken remote stream URLs (uncached) will **not** trigger a cache purge. They correctly fall through to `isRetryableRemoteParserFailure()` to re-resolve the URL.
  * Local files are ignored entirely (`!isLocalMedia`).

## Architecture Checklist

- [x] The change preserves UDF flow: UI -> ViewModel -> UseCase/domain -> Repository/data. <!-- N/A: Service-layer error handler -->
- [x] Screen state is represented structurally with `Loading`, `Success`, `Empty`, and `Error` where this PR introduces or changes screen state. <!-- N/A: No UI state changed -->
- [x] Composables receive immutable, UI-specific domain models instead of raw Room, network, or service entities. <!-- N/A -->
- [x] Business work is not triggered directly from composition. <!-- N/A -->
- [x] Exceptions are surfaced through explicit state or result types instead of being swallowed. <!-- N/A: Handled inside onPlayerError -->
- [x] No `runBlocking` is introduced in app execution paths. <!-- All async operations run on Service CoroutineScope with IO dispatcher -->

## Compose / Material Checklist

<!-- N/A: This PR is entirely playback service logic and contains no Compose/UI code. All items checked as N/A -->
- [x] UI state is hoisted out of composable layout code. <!-- N/A -->
- [x] Reactive state is collected with `collectAsStateWithLifecycle()`. <!-- N/A -->
- [x] New UI models are annotated with `@Immutable` or `@Stable`. <!-- N/A -->
- [x] Lazy layouts use stable `key` values and explicit `contentType`. <!-- N/A -->
- [x] Non-primitive constants, structural lambdas, and allocation-heavy objects in hot paths are remembered. <!-- N/A -->
- [x] Rapidly changing inputs such as scroll, gesture, animation, or playback progress use `derivedStateOf` where appropriate. <!-- N/A -->
- [x] UI strings come from `stringResource()` and duplicated visible strings on the same screen are avoided. <!-- N/A -->
- [x] Interactive elements keep a minimum 48dp touch target. <!-- N/A -->
- [x] Material 3 / Material 3 Expressive tokens are used for color, typography, shape, and motion instead of hardcoded UI values. <!-- N/A -->
- [x] Edge-to-edge layouts handle and consume `WindowInsets` correctly when this PR changes screen layout. <!-- N/A -->

<h2>Concurrency / Performance Checklist</h2>

- [x] Business coroutines are scoped to `viewModelScope` or an existing lifecycle-owned application/service scope. <!-- Scoped to Service CoroutineScope -->
- [x] Disk, database, network, parsing, and heavy mapping work is dispatched to `Dispatchers.IO` or `Dispatchers.Default`. <!-- Cache span checks and removal run safely within runCatching / IO dispatchers -->
- [x] Cancellation is handled explicitly where long-running work, playback, downloads, sync, lyrics fetching, or recognition is involved. <!-- N/A: Recovery is extremely short-lived -->
- [x] The change avoids blocking the main thread. <!-- getCachedSpans is wrapped in runCatching on the Main thread as a fast memory metadata check; heavy disk write/delete operations run entirely on Dispatchers.IO -->
- [x] The change avoids unnecessary allocations in recomposition loops, playback loops, polling loops, and provider parsing paths. <!-- Walking the error cause-chain is lightweight and only triggered on rare error events -->
- [x] Large lists, images, lyrics payloads, and network responses are bounded, streamed, cached, paged, or mapped off the main thread as appropriate. <!-- N/A -->

## Data / Persistence Checklist

- [x] Room entity, DAO, or database changes include a schema update under `app/schemas`. <!-- N/A: No database changes -->
- [x] Database migrations preserve existing user data and fail clearly when migration is impossible. <!-- N/A -->
- [x] DataStore or preference-key changes are backward compatible. <!-- N/A -->
- [x] Network DTOs remain isolated from UI models. <!-- N/A -->
- [x] Provider responses handle missing, malformed, regional, or rate-limited data without crashing the app. <!-- N/A -->

## Playback / Integration Checklist

- [x] Media3 playback, queue, cache, and service behavior remains stable across foreground, background, notification, and process recreation paths. <!-- Handled gracefully inside standard Media3 error listener -->
- [x] Audio focus, notification controls, widgets, shortcuts, and media session actions are considered when playback behavior changes. <!-- Normal playback is safely resumed using existing player instance -->
- [x] External integrations handle absent credentials, revoked auth, network failure, and API changes. <!-- N/A -->
- [x] Native, AAR, or ABI-sensitive changes account for mobile/tv and `universal`, `arm64`, `armeabi`, `x86`, and `x86_64` variants. <!-- N/A -->

## Localization / Assets Checklist

- [x] User-facing strings are added to the base resources and translated resources are updated or intentionally left for translation follow-up. <!-- N/A: No UI strings added -->
- [x] Unused string resources, drawables, and metadata are removed when replaced. <!-- N/A -->
- [x] Image assets have explicit display dimensions and are decoded at the displayed size. <!-- N/A -->
- [x] Fastlane metadata, screenshots, icons, or release text are updated when user-facing store behavior changes. <!-- N/A -->

## Privacy / Security Checklist

- [x] No secrets, keys, tokens, keystores, signing files, private certificates, or local machine paths are committed.
- [x] Logs do not expose access tokens, cookies, auth headers, user identifiers, listening history, or local file paths.
- [x] New network calls are justified by the feature and use existing client, proxy, timeout, and error-handling patterns. <!-- N/A: No new network requests -->
- [x] User data remains local unless the PR explicitly documents the integration and consent path.

## Verification

- [] Android Studio sync: <!-- Verified locally -->
- [x] Manual device/emulator verification: Verified that when a cached item encounters a malformed parsing exception (e.g., simulating corrupted container bytes), the cache is wiped successfully and re-prepared from current position instead of loop-crashing. Uncached items encountering parse failures fall back to re-resolving correctly.
- [] UI screenshot/recording attached: N/A (no visual changes)
- [] Accessibility or touch-target review: N/A
- [x] Regression areas checked: Stream URL re-resolving, bot-detection, and standard remote parser failure flows still trigger correctly.
- [x] CI expectation: Service compiles cleanly.

## Reviewer Focus

* `moe.rukamori.archivetune.playback.MusicService.kt`:
  * **`isCacheCorruptionError()`:** Check the added conditions for container-parse errors and how `isContentCached` (from `hasAnyCachedData`) protects remote-only streams from having their cache cleared pointlessly.
  * **`hasAnyCachedData`:** Check the lightweight query of `getCachedSpans` on both `downloadCache` and `playerCache` to verify partial downloads are accounted for.

## Release Notes

Fixed an issue where playback would get stuck in a failure loop with error code 3001 (ParserException) when encountering a corrupted or truncated song file in the cache. ArchiveTune now automatically clears the bad segment and retries.