### PR TITLE
refactor(player): centralize format helpers + unify title/artist tap handling

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/db/entities/FormatEntity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/db/entities/FormatEntity.kt
@@ -9,6 +9,7 @@ package moe.rukamori.archivetune.db.entities
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import kotlin.math.roundToInt
 
 @Entity(tableName = "format")
 data class FormatEntity(
@@ -23,3 +24,34 @@ data class FormatEntity(
     val perceptualLoudnessDb: Double? = null,
     val playbackUrl: String?
 )
+
+fun FormatEntity.containerLabel(): String =
+    mimeType.substringAfter("/").substringBefore(";").uppercase()
+
+fun FormatEntity.codecLabel(): String {
+    val rawCodec = codecs.ifBlank { mimeType.substringAfter("/") }.uppercase()
+    val rawMime = mimeType.substringAfter("/").substringBefore(";").uppercase()
+
+    return when {
+        rawCodec.contains("FLAC") || rawCodec.contains("ALAC") -> "Lossless"
+        rawCodec.contains("OPUS") -> "OPUS"
+        rawCodec.contains("AAC") || rawCodec.contains("MP4A") -> "AAC"
+        rawCodec.contains("VORBIS") -> "VORBIS"
+        rawMime.contains("OPUS") -> "OPUS"
+        rawMime.contains("AAC") || rawMime.contains("MP4A") -> "AAC"
+        rawMime.contains("VORBIS") -> "VORBIS"
+        rawMime.isNotBlank() -> rawMime
+        else -> rawCodec
+    }
+}
+
+fun FormatEntity.formattedBitrate(): String =
+    if (bitrate > 0) "${bitrate / 1000} kbps" else "Unknown"
+
+fun FormatEntity.formattedSampleRate(): String? =
+    sampleRate?.takeIf { it > 0 }?.let {
+        "${(it / 100.0).roundToInt() / 10.0} kHz"
+    }
+
+fun FormatEntity.formattedFileSize(): String =
+    if (contentLength > 0) "${(contentLength / 1024.0 / 1024.0).roundToInt()} MB" else ""

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
@@ -9,8 +9,6 @@
 
 package moe.rukamori.archivetune.ui.player
 
-import android.content.ClipData
-import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
 import android.content.res.Configuration
@@ -329,7 +327,6 @@ fun BottomSheetPlayer(
     pureBlack: Boolean,
 ) {
     val context = LocalContext.current
-    val clipboardManager = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
     val menuState = LocalMenuState.current
 
     val bottomSheetPageState = LocalBottomSheetPageState.current
@@ -1082,7 +1079,6 @@ fun BottomSheetPlayer(
                 state = state,
                 menuState = menuState,
                 bottomSheetPageState = bottomSheetPageState,
-                clipboardManager = clipboardManager,
                 context = context,
                 onSliderValueChange = onSliderValueChange,
                 onSliderValueChangeFinished = onSliderValueChangeFinished,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerArtistText.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerArtistText.kt
@@ -26,14 +26,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import moe.rukamori.archivetune.models.MediaMetadata
 
-/**
- * Renders a comma-separated artist line where **each artist name is individually tappable**.
- *
- * This is a generic, single-purpose leaf primitive (think "a smarter Text") — it owns the only
- * tricky bit of the artist line: mapping a tap position back to the artist span underneath it.
- * It carries no style opinions of its own, so every player style can reuse it without this file
- * ever needing changes when a new style is added.
- */
 @Composable
 fun ClickableArtists(
     artists: List<MediaMetadata.Artist>,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerArtistText.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerArtistText.kt
@@ -7,8 +7,7 @@
 
 package moe.rukamori.archivetune.ui.player
 
-import androidx.compose.foundation.combinedClickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -16,7 +15,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.TextLayoutResult
@@ -26,6 +24,19 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import moe.rukamori.archivetune.models.MediaMetadata
 
+/**
+ * Renders a comma-separated artist line where **each artist name is individually tappable**.
+ *
+ * This is a generic, single-purpose leaf primitive (think "a smarter Text") — it owns the only
+ * tricky bit of the artist line: mapping a tap position back to the artist span underneath it.
+ * It carries no style opinions of its own, so every player style can reuse it without this file
+ * ever needing changes when a new style is added.
+ *
+ * Note on marquee: callers typically apply [androidx.compose.foundation.basicMarquee] via
+ * [modifier]. Hit-testing uses the static [TextLayoutResult], so a tap landing during the marquee
+ * scroll resolves against the un-scrolled layout. This matches the pre-existing behavior of the
+ * classic player and is acceptable for the short, rarely-scrolling artist line.
+ */
 @Composable
 fun ClickableArtists(
     artists: List<MediaMetadata.Artist>,
@@ -36,17 +47,18 @@ fun ClickableArtists(
     textAlign: TextAlign? = null,
     onLongClick: (() -> Unit)? = null,
 ) {
-    val annotatedString = buildAnnotatedString {
-        artists.forEachIndexed { index, artist ->
-            pushStringAnnotation(tag = "artist", annotation = artist.id.orEmpty())
-            append(artist.name)
-            pop()
-            if (index != artists.lastIndex) append(", ")
+    val annotatedString = remember(artists) {
+        buildAnnotatedString {
+            artists.forEachIndexed { index, artist ->
+                pushStringAnnotation(tag = "artist_${artist.id.orEmpty()}", annotation = artist.id.orEmpty())
+                append(artist.name)
+                pop()
+                if (index != artists.lastIndex) append(", ")
+            }
         }
     }
 
     var layoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }
-    var clickOffset by remember { mutableStateOf<Offset?>(null) }
 
     Text(
         text = annotatedString,
@@ -56,30 +68,17 @@ fun ClickableArtists(
         maxLines = 1,
         overflow = TextOverflow.Ellipsis,
         onTextLayout = { layoutResult = it },
-        modifier = modifier
-            .pointerInput(Unit) {
-                awaitPointerEventScope {
-                    while (true) {
-                        val event = awaitPointerEvent()
-                        event.changes.firstOrNull()?.position?.let { clickOffset = it }
-                    }
-                }
-            }
-            .combinedClickable(
-                enabled = true,
-                indication = null,
-                interactionSource = remember { MutableInteractionSource() },
-                onClick = {
-                    val tapPosition = clickOffset
-                    val layout = layoutResult
-                    if (tapPosition != null && layout != null) {
-                        val offset = layout.getOffsetForPosition(tapPosition)
-                        annotatedString.getStringAnnotations(offset, offset)
-                            .firstOrNull()
-                            ?.let { onArtistClick(it.item) }
-                    }
+        modifier = modifier.pointerInput(annotatedString) {
+            detectTapGestures(
+                onTap = { offset ->
+                    val layout = layoutResult ?: return@detectTapGestures
+                    val position = layout.getOffsetForPosition(offset)
+                    annotatedString.getStringAnnotations(position, position)
+                        .firstOrNull()
+                        ?.let { onArtistClick(it.item) }
                 },
-                onLongClick = onLongClick,
-            ),
+                onLongPress = onLongClick?.let { handler -> { handler() } },
+            )
+        },
     )
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerArtistText.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerArtistText.kt
@@ -1,0 +1,93 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package moe.rukamori.archivetune.ui.player
+
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import moe.rukamori.archivetune.models.MediaMetadata
+
+/**
+ * Renders a comma-separated artist line where **each artist name is individually tappable**.
+ *
+ * This is a generic, single-purpose leaf primitive (think "a smarter Text") — it owns the only
+ * tricky bit of the artist line: mapping a tap position back to the artist span underneath it.
+ * It carries no style opinions of its own, so every player style can reuse it without this file
+ * ever needing changes when a new style is added.
+ */
+@Composable
+fun ClickableArtists(
+    artists: List<MediaMetadata.Artist>,
+    onArtistClick: (artistId: String) -> Unit,
+    style: TextStyle,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    textAlign: TextAlign? = null,
+    onLongClick: (() -> Unit)? = null,
+) {
+    val annotatedString = buildAnnotatedString {
+        artists.forEachIndexed { index, artist ->
+            pushStringAnnotation(tag = "artist", annotation = artist.id.orEmpty())
+            append(artist.name)
+            pop()
+            if (index != artists.lastIndex) append(", ")
+        }
+    }
+
+    var layoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }
+    var clickOffset by remember { mutableStateOf<Offset?>(null) }
+
+    Text(
+        text = annotatedString,
+        style = style,
+        color = color,
+        textAlign = textAlign,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+        onTextLayout = { layoutResult = it },
+        modifier = modifier
+            .pointerInput(Unit) {
+                awaitPointerEventScope {
+                    while (true) {
+                        val event = awaitPointerEvent()
+                        event.changes.firstOrNull()?.position?.let { clickOffset = it }
+                    }
+                }
+            }
+            .combinedClickable(
+                enabled = true,
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() },
+                onClick = {
+                    val tapPosition = clickOffset
+                    val layout = layoutResult
+                    if (tapPosition != null && layout != null) {
+                        val offset = layout.getOffsetForPosition(tapPosition)
+                        annotatedString.getStringAnnotations(offset, offset)
+                            .firstOrNull()
+                            ?.let { onArtistClick(it.item) }
+                    }
+                },
+                onLongClick = onLongClick,
+            ),
+    )
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerComponents.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerComponents.kt
@@ -9,7 +9,6 @@
 
 package moe.rukamori.archivetune.ui.player
 
-import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -137,8 +136,6 @@ fun PlayerTitleSection(
     textBackgroundColor: Color,
     navController: NavController,
     state: BottomSheetState,
-    @Suppress("UNUSED_PARAMETER") clipboardManager: ClipboardManager,
-    @Suppress("UNUSED_PARAMETER") context: Context,
 ) {
     // Tap/long-press behavior is centralized; this style keeps its own visual rendering.
     val actions = rememberPlayerTitleActions(
@@ -1556,7 +1553,6 @@ fun PlayerControlsContent(
     state: BottomSheetState,
     menuState: MenuState,
     bottomSheetPageState: BottomSheetPageState,
-    clipboardManager: ClipboardManager,
     context: Context,
     onSliderValueChange: (Long) -> Unit,
     onSliderValueChangeFinished: () -> Unit,
@@ -1584,8 +1580,6 @@ fun PlayerControlsContent(
                 textBackgroundColor = textBackgroundColor,
                 navController = navController,
                 state = state,
-                clipboardManager = clipboardManager,
-                context = context
             )
         }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerComponents.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerComponents.kt
@@ -113,6 +113,7 @@ import moe.rukamori.archivetune.constants.PlayerBackgroundStyle
 import moe.rukamori.archivetune.constants.PlayerButtonsStyle
 import moe.rukamori.archivetune.constants.PlayerDesignStyle
 import moe.rukamori.archivetune.db.entities.FormatEntity
+import moe.rukamori.archivetune.db.entities.codecLabel
 import moe.rukamori.archivetune.constants.PlayerHorizontalPadding
 import moe.rukamori.archivetune.constants.SliderStyle
 import moe.rukamori.archivetune.extensions.togglePlayPause
@@ -2602,23 +2603,6 @@ private fun V8QualityChip(
                 maxLines = 1,
             )
         }
-    }
-}
-
-private fun FormatEntity.codecLabel(): String {
-    val rawCodec = codecs.ifBlank { mimeType.substringAfter("/") }.uppercase()
-    val rawMime = mimeType.substringAfter("/").substringBefore(";").uppercase()
-
-    return when {
-        rawCodec.contains("FLAC") || rawCodec.contains("ALAC") -> "Lossless"
-        rawCodec.contains("OPUS") -> "OPUS"
-        rawCodec.contains("AAC") || rawCodec.contains("MP4A") -> "AAC"
-        rawCodec.contains("VORBIS") -> "VORBIS"
-        rawMime.contains("OPUS") -> "OPUS"
-        rawMime.contains("AAC") || rawMime.contains("MP4A") -> "AAC"
-        rawMime.contains("VORBIS") -> "VORBIS"
-        rawMime.isNotBlank() -> rawMime
-        else -> rawCodec
     }
 }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerComponents.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerComponents.kt
@@ -9,12 +9,10 @@
 
 package moe.rukamori.archivetune.ui.player
 
-import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
-import android.widget.Toast
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.RepeatMode
@@ -82,7 +80,6 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.ColorMatrix
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
@@ -90,13 +87,9 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.TextLayoutResult
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -144,9 +137,15 @@ fun PlayerTitleSection(
     textBackgroundColor: Color,
     navController: NavController,
     state: BottomSheetState,
-    clipboardManager: ClipboardManager,
-    context: Context
+    @Suppress("UNUSED_PARAMETER") clipboardManager: ClipboardManager,
+    @Suppress("UNUSED_PARAMETER") context: Context,
 ) {
+    // Tap/long-press behavior is centralized; this style keeps its own visual rendering.
+    val actions = rememberPlayerTitleActions(
+        mediaMetadata = mediaMetadata,
+        navController = navController,
+        state = state,
+    )
     AnimatedContent(
         targetState = mediaMetadata.title,
         transitionSpec = { fadeIn() togetherWith fadeOut() },
@@ -166,89 +165,24 @@ fun PlayerTitleSection(
                     enabled = true,
                     indication = null,
                     interactionSource = remember { MutableInteractionSource() },
-                    onClick = {
-                        if (mediaMetadata.album != null) {
-                            state.snapTo(state.collapsedBound)
-                            navController.navigate("album/${mediaMetadata.album.id}")
-                        }
-                    },
-                    onLongClick = {
-                        val clip = ClipData.newPlainText("Copied Title", title)
-                        clipboardManager.setPrimaryClip(clip)
-                        Toast.makeText(context, "Copied Title", Toast.LENGTH_SHORT).show()
-                    }
+                    onClick = actions.onTitleClick,
+                    onLongClick = actions.onCopyTitle,
                 ),
         )
     }
 
     Spacer(Modifier.height(6.dp))
 
-    val annotatedString = buildAnnotatedString {
-        mediaMetadata.artists.forEachIndexed { index, artist ->
-            val tag = "artist_${artist.id.orEmpty()}"
-            pushStringAnnotation(tag = tag, annotation = artist.id.orEmpty())
-            withStyle(SpanStyle(color = textBackgroundColor, fontSize = 16.sp)) {
-                append(artist.name)
-            }
-            pop()
-            if (index != mediaMetadata.artists.lastIndex) append(", ")
-        }
-    }
-
-    Box(
+    ClickableArtists(
+        artists = mediaMetadata.artists,
+        onArtistClick = actions.onArtistClick,
+        style = MaterialTheme.typography.titleMedium.copy(color = textBackgroundColor, fontSize = 16.sp),
+        onLongClick = actions.onCopyArtists,
         modifier = Modifier
             .fillMaxWidth()
             .basicMarquee()
-            .padding(end = 12.dp)
-    ) {
-        var layoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }
-        var clickOffset by remember { mutableStateOf<Offset?>(null) }
-        Text(
-            text = annotatedString,
-            style = MaterialTheme.typography.titleMedium.copy(color = textBackgroundColor),
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            onTextLayout = { layoutResult = it },
-            modifier = Modifier
-                .pointerInput(Unit) {
-                    awaitPointerEventScope {
-                        while (true) {
-                            val event = awaitPointerEvent()
-                            val tapPosition = event.changes.firstOrNull()?.position
-                            if (tapPosition != null) {
-                                clickOffset = tapPosition
-                            }
-                        }
-                    }
-                }
-                .combinedClickable(
-                    enabled = true,
-                    indication = null,
-                    interactionSource = remember { MutableInteractionSource() },
-                    onClick = {
-                        val tapPosition = clickOffset
-                        val layout = layoutResult
-                        if (tapPosition != null && layout != null) {
-                            val offset = layout.getOffsetForPosition(tapPosition)
-                            annotatedString.getStringAnnotations(offset, offset)
-                                .firstOrNull()
-                                ?.let { ann ->
-                                    val artistId = ann.item
-                                    if (artistId.isNotBlank()) {
-                                        navController.navigate("artist/$artistId")
-                                        state.collapseSoft()
-                                    }
-                                }
-                        }
-                    },
-                    onLongClick = {
-                        val clip = ClipData.newPlainText("Copied Artist", annotatedString)
-                        clipboardManager.setPrimaryClip(clip)
-                        Toast.makeText(context, "Copied Artist", Toast.LENGTH_SHORT).show()
-                    }
-                )
-        )
-    }
+            .padding(end = 12.dp),
+    )
 }
 
 @Composable
@@ -1779,9 +1713,6 @@ fun V8PlayerControlsContent(
 ) {
     val foreground = Color.White
     val secondaryForeground = foreground.copy(alpha = 0.72f)
-    val artists = remember(mediaMetadata.artists) {
-        mediaMetadata.artists.joinToString(", ") { it.name }
-    }
     val onMenuClick = remember(mediaMetadata, navController, state, menuState, bottomSheetPageState) {
         {
             menuState.show {
@@ -1799,23 +1730,9 @@ fun V8PlayerControlsContent(
             }
         }
     }
-    val onTitleClick = remember(mediaMetadata.album, navController, state) {
-        {
-            if (mediaMetadata.album != null) {
-                state.snapTo(state.collapsedBound)
-                navController.navigate("album/${mediaMetadata.album.id}")
-            }
-        }
-    }
-    val firstArtistId = mediaMetadata.artists.firstOrNull()?.id
-    val onArtistClick = remember(firstArtistId, navController, state) {
-        {
-            if (!firstArtistId.isNullOrBlank()) {
-                state.collapseSoft()
-                navController.navigate("artist/$firstArtistId")
-            }
-        }
-    }
+    val titleActions = rememberPlayerTitleActions(mediaMetadata, navController, state)
+    val onTitleClick = titleActions.onTitleClick
+    val onArtistClick = titleActions.onArtistClick
     val onPlayPauseClick = remember(playbackState, playerConnection) {
         {
             if (playbackState == STATE_ENDED) {
@@ -1867,7 +1784,7 @@ fun V8PlayerControlsContent(
 
             V8MetadataActions(
                 title = mediaMetadata.title,
-                artists = artists,
+                artists = mediaMetadata.artists,
                 liked = currentSongLiked,
                 foreground = foreground,
                 onMenuClick = onMenuClick,
@@ -1946,9 +1863,6 @@ fun V8PlayerContent(
     val secondaryForeground = foreground.copy(alpha = 0.72f)
     val artworkUrl = mediaMetadata.thumbnailUrl?.highRes()
     val subtitle = queueTitle ?: mediaMetadata.album?.title.orEmpty()
-    val artists = remember(mediaMetadata.artists) {
-        mediaMetadata.artists.joinToString(", ") { it.name }
-    }
     val onMenuClick = {
         menuState.show {
             PlayerMenu(
@@ -1965,25 +1879,15 @@ fun V8PlayerContent(
         }
     }
 
-    val onTitleClick = {
-        if (mediaMetadata.album != null) {
-            state.snapTo(state.collapsedBound)
-            navController.navigate("album/${mediaMetadata.album.id}")
-        }
-    }
-    val firstArtistId = mediaMetadata.artists.firstOrNull()?.id
-    val onArtistClick = {
-        if (!firstArtistId.isNullOrBlank()) {
-            state.collapseSoft()
-            navController.navigate("artist/$firstArtistId")
-        }
-    }
+    val titleActions = rememberPlayerTitleActions(mediaMetadata, navController, state)
+    val onTitleClick = titleActions.onTitleClick
+    val onArtistClick = titleActions.onArtistClick
 
     if (landscape) {
         V8LandscapeContent(
             mediaMetadata = mediaMetadata,
             subtitle = subtitle,
-            artists = artists,
+            artists = mediaMetadata.artists,
             artworkUrl = artworkUrl,
             canvasPrimaryUrl = canvasPrimaryUrl,
             canvasFallbackUrl = canvasFallbackUrl,
@@ -2023,7 +1927,7 @@ fun V8PlayerContent(
         V8PortraitContent(
             mediaMetadata = mediaMetadata,
             subtitle = subtitle,
-            artists = artists,
+            artists = mediaMetadata.artists,
             artworkUrl = artworkUrl,
             canvasPrimaryUrl = canvasPrimaryUrl,
             canvasFallbackUrl = canvasFallbackUrl,
@@ -2066,7 +1970,7 @@ fun V8PlayerContent(
 private fun V8PortraitContent(
     mediaMetadata: MediaMetadata,
     subtitle: String,
-    artists: String,
+    artists: List<MediaMetadata.Artist>,
     artworkUrl: String?,
     canvasPrimaryUrl: String?,
     canvasFallbackUrl: String?,
@@ -2092,7 +1996,7 @@ private fun V8PortraitContent(
     onSliderValueChangeFinished: () -> Unit,
     onVolumeChange: (Float) -> Unit,
     onTitleClick: () -> Unit,
-    onArtistClick: () -> Unit,
+    onArtistClick: (artistId: String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     BoxWithConstraints(modifier = modifier.fillMaxSize()) {
@@ -2216,7 +2120,7 @@ private fun V8PortraitContent(
 private fun V8LandscapeContent(
     mediaMetadata: MediaMetadata,
     subtitle: String,
-    artists: String,
+    artists: List<MediaMetadata.Artist>,
     artworkUrl: String?,
     canvasPrimaryUrl: String?,
     canvasFallbackUrl: String?,
@@ -2242,7 +2146,7 @@ private fun V8LandscapeContent(
     onSliderValueChangeFinished: () -> Unit,
     onVolumeChange: (Float) -> Unit,
     onTitleClick: () -> Unit,
-    onArtistClick: () -> Unit,
+    onArtistClick: (artistId: String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     BoxWithConstraints(modifier = modifier.fillMaxSize()) {
@@ -2405,13 +2309,13 @@ private fun V8Artwork(
 @Composable
 private fun V8MetadataActions(
     title: String,
-    artists: String,
+    artists: List<MediaMetadata.Artist>,
     liked: Boolean,
     foreground: Color,
     onMenuClick: () -> Unit,
     onToggleLike: () -> Unit,
     onTitleClick: () -> Unit,
-    onArtistClick: () -> Unit,
+    onArtistClick: (artistId: String) -> Unit,
 ) {
     Row(
         modifier = Modifier.fillMaxWidth(),
@@ -2437,19 +2341,12 @@ private fun V8MetadataActions(
                         onClick = onTitleClick,
                     ),
             )
-            Text(
-                text = artists,
+            ClickableArtists(
+                artists = artists,
+                onArtistClick = onArtistClick,
                 style = MaterialTheme.typography.titleMedium,
                 color = foreground,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier
-                    .basicMarquee()
-                    .clickable(
-                        indication = null,
-                        interactionSource = remember { MutableInteractionSource() },
-                        onClick = onArtistClick,
-                    ),
+                modifier = Modifier.basicMarquee(),
             )
         }
 
@@ -2830,22 +2727,9 @@ fun V9PlayerContent(
     landscape: Boolean = false,
 ) {
     val artworkUrl = mediaMetadata.thumbnailUrl?.highRes()
-    val artists = remember(mediaMetadata.artists) {
-        mediaMetadata.artists.joinToString(", ") { it.name }
-    }
-    val onTitleClick = {
-        if (mediaMetadata.album != null) {
-            state.snapTo(state.collapsedBound)
-            navController.navigate("album/${mediaMetadata.album.id}")
-        }
-    }
-    val firstArtistId = mediaMetadata.artists.firstOrNull()?.id
-    val onArtistClick = {
-        if (!firstArtistId.isNullOrBlank()) {
-            state.collapseSoft()
-            navController.navigate("artist/$firstArtistId")
-        }
-    }
+    val titleActions = rememberPlayerTitleActions(mediaMetadata, navController, state)
+    val onTitleClick = titleActions.onTitleClick
+    val onArtistClick = titleActions.onArtistClick
     val onPlayPauseClick = {
         if (playbackState == STATE_ENDED) {
             playerConnection.player.seekTo(0, 0)
@@ -2858,7 +2742,7 @@ fun V9PlayerContent(
     if (landscape) {
         V9LandscapeContent(
             title = mediaMetadata.title,
-            artists = artists,
+            artists = mediaMetadata.artists,
             artworkUrl = artworkUrl,
             canvasPrimaryUrl = canvasPrimaryUrl,
             canvasFallbackUrl = canvasFallbackUrl,
@@ -2888,7 +2772,7 @@ fun V9PlayerContent(
     } else {
         V9PortraitContent(
             title = mediaMetadata.title,
-            artists = artists,
+            artists = mediaMetadata.artists,
             artworkUrl = artworkUrl,
             canvasPrimaryUrl = canvasPrimaryUrl,
             canvasFallbackUrl = canvasFallbackUrl,
@@ -2921,7 +2805,7 @@ fun V9PlayerContent(
 @Composable
 private fun V9PortraitContent(
     title: String,
-    artists: String,
+    artists: List<MediaMetadata.Artist>,
     artworkUrl: String?,
     canvasPrimaryUrl: String?,
     canvasFallbackUrl: String?,
@@ -2945,7 +2829,7 @@ private fun V9PortraitContent(
     onSliderValueChange: (Long) -> Unit,
     onSliderValueChangeFinished: () -> Unit,
     onTitleClick: () -> Unit,
-    onArtistClick: () -> Unit,
+    onArtistClick: (artistId: String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     BoxWithConstraints(modifier = modifier.fillMaxSize()) {
@@ -3060,7 +2944,7 @@ private fun V9PortraitContent(
 @Composable
 private fun V9LandscapeContent(
     title: String,
-    artists: String,
+    artists: List<MediaMetadata.Artist>,
     artworkUrl: String?,
     canvasPrimaryUrl: String?,
     canvasFallbackUrl: String?,
@@ -3084,7 +2968,7 @@ private fun V9LandscapeContent(
     onSliderValueChange: (Long) -> Unit,
     onSliderValueChangeFinished: () -> Unit,
     onTitleClick: () -> Unit,
-    onArtistClick: () -> Unit,
+    onArtistClick: (artistId: String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     BoxWithConstraints(modifier = modifier.fillMaxSize()) {
@@ -3294,10 +3178,10 @@ private fun V9Artwork(
 @Composable
 private fun V9Metadata(
     title: String,
-    artists: String,
+    artists: List<MediaMetadata.Artist>,
     textColor: Color,
     onTitleClick: () -> Unit,
-    onArtistClick: () -> Unit,
+    onArtistClick: (artistId: String) -> Unit,
 ) {
     Column(
         modifier = Modifier.fillMaxWidth(),
@@ -3321,22 +3205,15 @@ private fun V9Metadata(
                     onClick = onTitleClick,
                 ),
         )
-        Text(
-            text = artists,
-            style = MaterialTheme.typography.titleLarge,
-            fontWeight = FontWeight.SemiBold,
+        ClickableArtists(
+            artists = artists,
+            onArtistClick = onArtistClick,
+            style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.SemiBold),
             color = textColor.copy(alpha = 0.72f),
             textAlign = TextAlign.Center,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
             modifier = Modifier
                 .fillMaxWidth()
-                .basicMarquee()
-                .clickable(
-                    indication = null,
-                    interactionSource = remember { MutableInteractionSource() },
-                    onClick = onArtistClick,
-                ),
+                .basicMarquee(),
         )
     }
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerTitleActions.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerTitleActions.kt
@@ -19,14 +19,24 @@ import androidx.navigation.NavController
 import moe.rukamori.archivetune.models.MediaMetadata
 import moe.rukamori.archivetune.ui.component.BottomSheetState
 
+/**
+ * Centralized *behavior* for the title/artist block shared by every player design style.
+ *
+ * This intentionally contains **no UI** — each player style keeps rendering its own `Text`s,
+ * layout, typography and decorations. Only the tap/long-press behavior lives here, so:
+ *  - the historical inconsistency (title used `snapTo`, artist used `collapseSoft`) has a single
+ *    source of truth and is fixed in one place, and
+ *  - the behavior can no longer drift between styles.
+ *
+ * Adding a new player style does **not** require touching this file: just call
+ * [rememberPlayerTitleActions] and wire the callbacks into whatever UI the style draws.
+ */
 @Immutable
 class PlayerTitleActions(
     /** Navigate to the current song's album (no-op if the song has no album). */
     val onTitleClick: () -> Unit,
     /** Navigate to a specific artist by id (no-op for blank ids). */
     val onArtistClick: (artistId: String) -> Unit,
-    /** Navigate to the first artist, if any. Convenience for styles without per-artist hit testing. */
-    val onFirstArtistClick: () -> Unit,
     /** Copy the song title to the clipboard and show a toast. */
     val onCopyTitle: () -> Unit,
     /** Copy the comma-joined artist names to the clipboard and show a toast. */
@@ -45,24 +55,25 @@ fun rememberPlayerTitleActions(
     val artistLine = remember(mediaMetadata.artists) {
         mediaMetadata.artists.joinToString(", ") { it.name }
     }
-    val firstArtistId = mediaMetadata.artists.firstOrNull()?.id
 
-    return remember(mediaMetadata, navController, state, context, clipboardManager, artistLine, firstArtistId) {
-        val navigateToArtist: (String) -> Unit = { artistId ->
-            if (artistId.isNotBlank()) {
-                state.collapseSoft()
-                navController.navigate("artist/$artistId")
-            }
-        }
+    return remember(mediaMetadata, navController, state, artistLine) {
         PlayerTitleActions(
             onTitleClick = {
                 mediaMetadata.album?.let { album ->
+                    // collapseSoft animates the sheet AND updates its internal anchor, keeping
+                    // isCollapsed/isExpanded in sync. (Previously this used snapTo, which jumped
+                    // without animation and left the anchor stale, so tapping the title from the
+                    // home screen failed to collapse the player reliably.)
                     state.collapseSoft()
                     navController.navigate("album/${album.id}")
                 }
             },
-            onArtistClick = navigateToArtist,
-            onFirstArtistClick = { firstArtistId?.let(navigateToArtist) },
+            onArtistClick = { artistId ->
+                if (artistId.isNotBlank()) {
+                    state.collapseSoft()
+                    navController.navigate("artist/$artistId")
+                }
+            },
             onCopyTitle = {
                 clipboardManager.setPrimaryClip(
                     ClipData.newPlainText("Copied Title", mediaMetadata.title)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerTitleActions.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerTitleActions.kt
@@ -19,18 +19,6 @@ import androidx.navigation.NavController
 import moe.rukamori.archivetune.models.MediaMetadata
 import moe.rukamori.archivetune.ui.component.BottomSheetState
 
-/**
- * Centralized *behavior* for the title/artist block shared by every player design style.
- *
- * This intentionally contains **no UI** — each player style keeps rendering its own `Text`s,
- * layout, typography and decorations. Only the tap/long-press behavior lives here, so:
- *  - the historical inconsistency (title used `snapTo`, artist used `collapseSoft`) has a single
- *    source of truth and is fixed in one place, and
- *  - the behavior can no longer drift between styles.
- *
- * Adding a new player style does **not** require touching this file: just call
- * [rememberPlayerTitleActions] and wire the callbacks into whatever UI the style draws.
- */
 @Immutable
 class PlayerTitleActions(
     /** Navigate to the current song's album (no-op if the song has no album). */
@@ -69,11 +57,7 @@ fun rememberPlayerTitleActions(
         PlayerTitleActions(
             onTitleClick = {
                 mediaMetadata.album?.let { album ->
-                    // NOTE: kept as snapTo for now to stay behavior-preserving during the
-                    // extraction. A later commit flips this single line to `state.collapseSoft()`
-                    // to fix the collapse-on-title bug (snapTo skips the animation AND does not
-                    // update the sheet anchor, leaving isCollapsed/isExpanded out of sync).
-                    state.snapTo(state.collapsedBound)
+                    state.collapseSoft()
                     navController.navigate("album/${album.id}")
                 }
             },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerTitleActions.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerTitleActions.kt
@@ -1,0 +1,96 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package moe.rukamori.archivetune.ui.player
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.widget.Toast
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import androidx.navigation.NavController
+import moe.rukamori.archivetune.models.MediaMetadata
+import moe.rukamori.archivetune.ui.component.BottomSheetState
+
+/**
+ * Centralized *behavior* for the title/artist block shared by every player design style.
+ *
+ * This intentionally contains **no UI** — each player style keeps rendering its own `Text`s,
+ * layout, typography and decorations. Only the tap/long-press behavior lives here, so:
+ *  - the historical inconsistency (title used `snapTo`, artist used `collapseSoft`) has a single
+ *    source of truth and is fixed in one place, and
+ *  - the behavior can no longer drift between styles.
+ *
+ * Adding a new player style does **not** require touching this file: just call
+ * [rememberPlayerTitleActions] and wire the callbacks into whatever UI the style draws.
+ */
+@Immutable
+class PlayerTitleActions(
+    /** Navigate to the current song's album (no-op if the song has no album). */
+    val onTitleClick: () -> Unit,
+    /** Navigate to a specific artist by id (no-op for blank ids). */
+    val onArtistClick: (artistId: String) -> Unit,
+    /** Navigate to the first artist, if any. Convenience for styles without per-artist hit testing. */
+    val onFirstArtistClick: () -> Unit,
+    /** Copy the song title to the clipboard and show a toast. */
+    val onCopyTitle: () -> Unit,
+    /** Copy the comma-joined artist names to the clipboard and show a toast. */
+    val onCopyArtists: () -> Unit,
+)
+
+@Composable
+fun rememberPlayerTitleActions(
+    mediaMetadata: MediaMetadata,
+    navController: NavController,
+    state: BottomSheetState,
+): PlayerTitleActions {
+    val context = LocalContext.current
+    val clipboardManager =
+        context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+    val artistLine = remember(mediaMetadata.artists) {
+        mediaMetadata.artists.joinToString(", ") { it.name }
+    }
+    val firstArtistId = mediaMetadata.artists.firstOrNull()?.id
+
+    return remember(mediaMetadata, navController, state, context, clipboardManager, artistLine, firstArtistId) {
+        val navigateToArtist: (String) -> Unit = { artistId ->
+            if (artistId.isNotBlank()) {
+                state.collapseSoft()
+                navController.navigate("artist/$artistId")
+            }
+        }
+        PlayerTitleActions(
+            onTitleClick = {
+                mediaMetadata.album?.let { album ->
+                    // NOTE: kept as snapTo for now to stay behavior-preserving during the
+                    // extraction. A later commit flips this single line to `state.collapseSoft()`
+                    // to fix the collapse-on-title bug (snapTo skips the animation AND does not
+                    // update the sheet anchor, leaving isCollapsed/isExpanded out of sync).
+                    state.snapTo(state.collapsedBound)
+                    navController.navigate("album/${album.id}")
+                }
+            },
+            onArtistClick = navigateToArtist,
+            onFirstArtistClick = { firstArtistId?.let(navigateToArtist) },
+            onCopyTitle = {
+                clipboardManager.setPrimaryClip(
+                    ClipData.newPlainText("Copied Title", mediaMetadata.title)
+                )
+                Toast.makeText(context, "Copied Title", Toast.LENGTH_SHORT).show()
+            },
+            onCopyArtists = {
+                clipboardManager.setPrimaryClip(
+                    ClipData.newPlainText("Copied Artist", artistLine)
+                )
+                Toast.makeText(context, "Copied Artist", Toast.LENGTH_SHORT).show()
+            },
+        )
+    }
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/QueueComponents.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/QueueComponents.kt
@@ -77,6 +77,10 @@ import androidx.media3.common.Player
 import coil3.compose.AsyncImage
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.db.entities.FormatEntity
+import moe.rukamori.archivetune.db.entities.containerLabel
+import moe.rukamori.archivetune.db.entities.formattedBitrate
+import moe.rukamori.archivetune.db.entities.formattedFileSize
+import moe.rukamori.archivetune.db.entities.formattedSampleRate
 import moe.rukamori.archivetune.models.MediaMetadata
 import moe.rukamori.archivetune.ui.component.ActionPromptDialog
 import moe.rukamori.archivetune.ui.component.BottomSheetPageState
@@ -514,13 +518,11 @@ fun QueueCollapsedContentV2(
 
     Column(modifier = modifier.fillMaxWidth()) {
         if (showCodecOnPlayer && currentFormat != null) {
-            val codec =
-                currentFormat.codecs
-                    .takeIf { it.isNotBlank() }
-                    ?: currentFormat.mimeType.substringAfter("/", missingDelimiterValue = currentFormat.mimeType).uppercase()
+            val codec = currentFormat.codecs
+                .takeIf { it.isNotBlank() }
+                ?: currentFormat.containerLabel()
 
-            val container =
-                currentFormat.mimeType.substringAfter("/", missingDelimiterValue = currentFormat.mimeType).uppercase()
+            val container = currentFormat.containerLabel()
 
             val codecLabel =
                 if (container.isNotBlank() && !codec.equals(container, ignoreCase = true)) {
@@ -529,29 +531,12 @@ fun QueueCollapsedContentV2(
                     codec
                 }
 
-            val bitrate =
-                if (currentFormat.bitrate > 0) {
-                    "${currentFormat.bitrate / 1000} kbps"
-                } else {
-                    "Unknown"
-                }
+            val bitrate = currentFormat.formattedBitrate()
 
-            val sampleRateText =
-                currentFormat.sampleRate?.takeIf { it > 0 }?.let { sampleRate ->
-                    val khz = (sampleRate / 100.0).roundToInt() / 10.0
-                    "$khz kHz"
-                }
-
-            val fileSizeText =
-                if (currentFormat.contentLength > 0) {
-                    "${(currentFormat.contentLength / 1024.0 / 1024.0).roundToInt()} MB"
-                } else {
-                    ""
-                }
-
-            val extraText =
-                listOfNotNull(sampleRateText, fileSizeText.takeIf { it.isNotBlank() })
-                    .joinToString(separator = " • ")
+            val extraText = listOfNotNull(
+                currentFormat.formattedSampleRate(),
+                currentFormat.formattedFileSize().takeIf { it.isNotBlank() }
+            ).joinToString(separator = " • ")
             
             CodecInfoRow(
                 codec = codecLabel,
@@ -750,11 +735,11 @@ fun QueueCollapsedContentV3(
 
     Column(modifier = modifier.fillMaxWidth()) {
         if (showCodecOnPlayer && currentFormat != null) {
-            val codec = currentFormat.mimeType.substringAfter("/").uppercase()
-            val bitrate = "${currentFormat.bitrate / 1000} kbps"
+            val container = currentFormat.containerLabel()
+            val bitrate = currentFormat.formattedBitrate()
             
             CodecInfoRow(
-                codec = codec,
+                codec = container,
                 bitrate = bitrate,
                 fileSize = "",
                 textColor = textBackgroundColor.copy(alpha = 0.5f)
@@ -893,14 +878,12 @@ fun QueueCollapsedContentV1(
 ) {
     Column(modifier = modifier.fillMaxWidth()) {
         if (showCodecOnPlayer && currentFormat != null) {
-            val codec = currentFormat.mimeType.substringAfter("/").uppercase()
-            val bitrate = "${currentFormat.bitrate / 1000} kbps"
-            val fileSize = if (currentFormat.contentLength > 0) {
-                "${(currentFormat.contentLength / 1024.0 / 1024.0).roundToInt()} MB"
-            } else ""
+            val container = currentFormat.containerLabel()
+            val bitrate = currentFormat.formattedBitrate()
+            val fileSize = currentFormat.formattedFileSize()
             
             CodecInfoRow(
-                codec = codec,
+                codec = container,
                 bitrate = bitrate,
                 fileSize = fileSize,
                 textColor = textBackgroundColor.copy(alpha = 0.7f)
@@ -1041,14 +1024,12 @@ fun QueueCollapsedContentV4(
 ) {
     Column(modifier = modifier.fillMaxWidth()) {
         if (showCodecOnPlayer && currentFormat != null) {
-            val codec = currentFormat.mimeType.substringAfter("/").uppercase()
-            val bitrate = "${currentFormat.bitrate / 1000} kbps"
-            val fileSize = if (currentFormat.contentLength > 0) {
-                "${(currentFormat.contentLength / 1024.0 / 1024.0).roundToInt()} MB"
-            } else ""
+            val container = currentFormat.containerLabel()
+            val bitrate = currentFormat.formattedBitrate()
+            val fileSize = currentFormat.formattedFileSize()
             
             CodecInfoRow(
-                codec = codec,
+                codec = container,
                 bitrate = bitrate,
                 fileSize = fileSize,
                 textColor = textBackgroundColor.copy(alpha = 0.6f)
@@ -1194,14 +1175,12 @@ fun QueueCollapsedContentV7(
 ) {
     Column(modifier = modifier.fillMaxWidth()) {
         if (showCodecOnPlayer && currentFormat != null) {
-            val codec = currentFormat.mimeType.substringAfter("/").uppercase()
-            val bitrate = "${currentFormat.bitrate / 1000} kbps"
-            val fileSize = if (currentFormat.contentLength > 0) {
-                "${(currentFormat.contentLength / 1024.0 / 1024.0).roundToInt()} MB"
-            } else ""
+            val container = currentFormat.containerLabel()
+            val bitrate = currentFormat.formattedBitrate()
+            val fileSize = currentFormat.formattedFileSize()
 
             CodecInfoRow(
-                codec = codec,
+                codec = container,
                 bitrate = bitrate,
                 fileSize = fileSize,
                 textColor = textBackgroundColor.copy(alpha = 0.6f)
@@ -1373,16 +1352,12 @@ fun QueueCollapsedContentV9(
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         if (showCodecOnPlayer && currentFormat != null) {
-            val codec = currentFormat.mimeType.substringAfter("/").uppercase()
-            val bitrate = "${currentFormat.bitrate / 1000} kbps"
-            val fileSize = if (currentFormat.contentLength > 0) {
-                "${(currentFormat.contentLength / 1024.0 / 1024.0).roundToInt()} MB"
-            } else {
-                ""
-            }
+            val container = currentFormat.containerLabel()
+            val bitrate = currentFormat.formattedBitrate()
+            val fileSize = currentFormat.formattedFileSize()
 
             CodecInfoRow(
-                codec = codec,
+                codec = container,
                 bitrate = bitrate,
                 fileSize = fileSize,
                 textColor = textBackgroundColor.copy(alpha = 0.6f),


### PR DESCRIPTION
# Pull Request

## Summary

This PR bundles two related player-UI refactors.

**(1) FormatEntity display helpers:** extracts 5 reusable extension functions (`containerLabel`, `codecLabel`, `formattedBitrate`, `formattedSampleRate`, `formattedFileSize`) into `FormatEntity.kt`, replacing ~70 lines of duplicated inline parsing across 6 queue composables and a `private` duplicate in `PlayerComponents.kt`; the inline logic named its variable `codec` while actually extracting the **container**, now honestly named `container`.

**(2) Title/artist tap handling:** centralizes the duplicated title/artist tap behavior into a single `rememberPlayerTitleActions()` helper and adds a reusable `ClickableArtists` primitive so each artist name is individually tappable, with Classic, V7, V8 and V9 now sharing one implementation instead of hand-rolling their own lambdas. It also fixes a real bug where tapping the song title used `state.snapTo(...)` — which jumped without animation and left the bottom-sheet anchor stale — so the player now collapses reliably via `collapseSoft()`. No format display changes; per-style visual rendering is preserved.

## Linked Work

- Closes: -
- Related: #814 (PR moved to here)

## Change Type

- [ ] Feature
- [x] Bug fix
- [x] UI / UX
- [ ] Performance / memory
- [ ] Playback / Media3
- [ ] Lyrics / provider integration
- [ ] Search / YouTube / network data
- [x] Local library / Room database
- [ ] Widgets / notification / shortcuts
- [ ] Settings / preferences / DataStore
- [ ] Discord / Last.fm / ListenBrainz / external integration
- [ ] Localization / strings / fastlane metadata
- [ ] Build / Gradle / CI / release packaging
- [ ] Dependency update
- [ ] Documentation only

## Affected Surfaces

- [x] `:app`
- [ ] `:innertube`
- [ ] `:betterlyrics`
- [ ] `:kugou`
- [ ] `:lrclib`
- [ ] `:lastfm`
- [ ] `:simpmusic`
- [ ] `:paxsenix`
- [ ] `:unison`
- [ ] `:canvas`
- [ ] `:shazamkit`
- [ ] `:spotifycore`
- [ ] `server`
- [ ] `fastlane`
- [ ] `.github`
- [ ] Other:

## Screenshots / Recordings

Format row is unchanged. Title-tap now animates the player closed; artist tap targets a specific artist.

| Before | After |
| --- | --- |
| `WEBM • 141 kbps • 3 MB` | `WEBM • 141 kbps • 3 MB` |

## Behavior Notes

- **Format display unchanged**: all 9 player styles (V1–V9) show the exact same codec / bitrate / size text as before. The refactor only changes *how* the strings are produced, not *what* they contain.
- **Variable naming fix**: inline `val codec = mimeType.substringAfter("/")` was extracting the container, not the codec; now `val container = currentFormat.containerLabel()`.
- **Local file bitrate edge case**: `formattedBitrate()` returns `"Unknown"` or not showed at all when `bitrate == 0` (local files), instead of the previous `"0 kbps"`.
- **Per-artist tap (UX change)**: tapping an artist in V7/V8/V9 now opens that specific artist's page (previously: always opened the first artist). Classic (V1-V4 and V6) already behaved this way.
- **Title-tap collapse fix**: tapping the song title now animates the player closed and keeps the sheet's collapsed/expanded state in sync (previously `snapTo` jumped with no animation and left the anchor stale, so the player failed to collapse reliably from the home screen).
- **Per-style visuals preserved**: fonts, colors, alignment, and layout for each style are untouched; only the shared tap/format logic moved.

## Architecture Checklist

- [x] The change preserves UDF flow: UI -> ViewModel -> UseCase/domain -> Repository/data.
- [x] Screen state is represented structurally with `Loading`, `Success`, `Empty`, and `Error` where this PR introduces or changes screen state. _(N/A — no screen-state changes.)_
- [x] Composables receive immutable, UI-specific domain models instead of raw Room, network, or service entities. _(Extension functions on `FormatEntity` are pure; `PlayerTitleActions` is `@Immutable`.)_
- [x] Business work is not triggered directly from composition.
- [x] Exceptions are surfaced through explicit state or result types instead of being swallowed.
- [x] No `runBlocking` is introduced in app execution paths.

## Compose / Material Checklist

- [x] UI state is hoisted out of composable layout code.
- [x] Reactive state is collected with `collectAsStateWithLifecycle()`. _(N/A — no new state collection.)_
- [x] New UI models are annotated with `@Immutable` or `@Stable`. _(`PlayerTitleActions` is `@Immutable`.)_
- [x] Lazy layouts use stable `key` values and explicit `contentType`. _(N/A — no lazy-layout changes.)_
- [x] Non-primitive constants, structural lambdas, and allocation-heavy objects in hot paths are remembered. _(`rememberPlayerTitleActions` and the `ClickableArtists` annotated string are remembered.)_
- [x] Rapidly changing inputs such as scroll, gesture, animation, or playback progress use `derivedStateOf` where appropriate. _(N/A.)_
- [x] UI strings come from `stringResource()` and duplicated visible strings on the same screen are avoided. _(No new user-facing strings added.)_
- [x] Interactive elements keep a minimum 48dp touch target.
- [x] Material 3 / Material 3 Expressive tokens are used for color, typography, shape, and motion instead of hardcoded UI values.
- [x] Edge-to-edge layouts handle and consume `WindowInsets` correctly when this PR changes screen layout. _(N/A — no layout/inset changes.)_

## Concurrency / Performance Checklist

- [x] Business coroutines are scoped to `viewModelScope` or an existing lifecycle-owned application/service scope. _(N/A.)_
- [x] Disk, database, network, parsing, and heavy mapping work is dispatched to `Dispatchers.IO` or `Dispatchers.Default`. _(N/A — lightweight string ops.)_
- [x] Cancellation is handled explicitly where long-running work is involved. _(N/A.)_
- [x] The change avoids blocking the main thread.
- [x] The change avoids unnecessary allocations in recomposition loops. _(Annotated string and joined artist line are memoized.)_
- [x] Large lists, images, lyrics payloads, and network responses are bounded, streamed, cached, paged, or mapped off the main thread as appropriate. _(N/A.)_

## Data / Persistence Checklist

- [x] Room entity, DAO, or database changes include a schema update under `app/schemas`. _(N/A — only pure extension functions added to existing `FormatEntity`; no schema change.)_
- [x] Database migrations preserve existing user data and fail clearly when migration is impossible. _(N/A.)_
- [x] DataStore or preference-key changes are backward compatible. _(N/A.)_
- [x] Network DTOs remain isolated from UI models. _(N/A.)_
- [x] Provider responses handle missing, malformed, regional, or rate-limited data without crashing the app. _(N/A.)_

## Playback / Integration Checklist

- [x] Media3 playback, queue, cache, and service behavior remains stable across foreground, background, notification, and process recreation paths. _(No playback logic changed.)_
- [x] Audio focus, notification controls, widgets, shortcuts, and media session actions are considered when playback behavior changes. _(N/A.)_
- [x] External integrations handle absent credentials, revoked auth, network failure, and API changes. _(N/A.)_
- [x] Native, AAR, or ABI-sensitive changes account for mobile/tv and all ABI variants. _(N/A.)_

## Localization / Assets Checklist

- [x] User-facing strings are added to the base resources and translated resources are updated or intentionally left for translation follow-up. _(No new user-facing strings; the existing "Copied" toasts are unchanged by this PR.)_
- [x] Unused string resources, drawables, and metadata are removed when replaced.
- [x] Image assets have explicit display dimensions and are decoded at the displayed size. _(N/A.)_
- [x] Fastlane metadata, screenshots, icons, or release text are updated when user-facing store behavior changes. _(N/A.)_

## Privacy / Security Checklist

- [x] No secrets, keys, tokens, keystores, signing files, private certificates, or local machine paths are committed.
- [x] Logs do not expose access tokens, cookies, auth headers, user identifiers, listening history, or local file paths.
- [x] New network calls are justified by the feature and use existing client, proxy, timeout, and error-handling patterns. _(No new network calls.)_
- [x] User data remains local unless the PR explicitly documents the integration and consent path.

## Verification

- [x] Android Studio sync: passed
- [x] Manual device/emulator verification: Tested on Poco X7 Pro: title tap → album + collapse, per-artist tap on V1–V9, format row unchanged
- [ ] UI screenshot/recording attached:
- [ ] Accessibility or touch-target review:
- [x] Regression areas checked: queue format row, all 9 player styles, bottom-sheet collapse/expand state
- [x] CI expectation: build passes

## Reviewer Focus

- `FormatEntity.kt` — the 5 new extension functions and the `codec` → `container` naming correction.
- `PlayerTitleActions.kt` — single source of truth for title/artist tap + clipboard behavior; note `collapseSoft()` vs the old `snapTo()`.
- `PlayerArtistText.kt` — `ClickableArtists` hit-tests taps to the correct artist span via the static text layout (see the in-file note on marquee).
- `PlayerComponents.kt` — Classic/V8/V9 now delegate to the shared helper/primitive; `String` artist params became `List<MediaMetadata.Artist>` through the V8/V9 pipeline.
- V7 inherits V8's controls via `V8PlayerControlsContent` in `Player.kt`.

## Release Notes

Tapping a song's title now smoothly collapses the player, and tapping an artist opens that specific artist's page across all player styles.
