### PR TITLE
fix(player): don't swallow first back press when dismissing player UI

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/BottomSheet.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/BottomSheet.kt
@@ -166,9 +166,6 @@ class BottomSheetState(
     val isExpandedOrExpanding: Boolean
         get() = targetAnchor == EXPANDED_ANCHOR
 
-    val isCollapsedOrCollapsing: Boolean
-        get() = targetAnchor == COLLAPSED_ANCHOR || targetAnchor == DISMISSED_ANCHOR
-
     val progress by derivedStateOf {
         1f - (animatable.upperBound!! - animatable.value) / (animatable.upperBound!! - collapsedBound)
     }
@@ -219,6 +216,7 @@ class BottomSheetState(
         updateAnchor(
             when (value) {
                 expandedBound -> EXPANDED_ANCHOR
+                collapsedBound -> COLLAPSED_ANCHOR
                 dismissedBound -> DISMISSED_ANCHOR
                 else -> COLLAPSED_ANCHOR
             }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/BottomSheet.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/BottomSheet.kt
@@ -96,7 +96,7 @@ fun BottomSheet(
                 )
             ),
     ) {
-        if (!state.isCollapsed && !state.isDismissed) {
+        if (state.isExpandedOrExpanding) {
             BackHandler(onBack = state::collapseSoft)
         }
 
@@ -138,6 +138,7 @@ class BottomSheetState(
     private val onAnchorChanged: (Int) -> Unit,
     private val animationsDisabled: Boolean,
     val collapsedBound: Dp,
+    initialAnchor: Int = DISMISSED_ANCHOR,
 ) : DraggableState by draggableState {
     val dismissedBound: Dp
         get() = animatable.lowerBound!!
@@ -146,6 +147,9 @@ class BottomSheetState(
         get() = animatable.upperBound!!
 
     val value by animatable.asState()
+
+    var targetAnchor by mutableIntStateOf(initialAnchor)
+        private set
 
     val isDismissed by derivedStateOf {
         value == animatable.lowerBound!!
@@ -159,19 +163,30 @@ class BottomSheetState(
         value == animatable.upperBound
     }
 
+    val isExpandedOrExpanding: Boolean
+        get() = targetAnchor == EXPANDED_ANCHOR
+
+    val isCollapsedOrCollapsing: Boolean
+        get() = targetAnchor == COLLAPSED_ANCHOR || targetAnchor == DISMISSED_ANCHOR
+
     val progress by derivedStateOf {
         1f - (animatable.upperBound!! - animatable.value) / (animatable.upperBound!! - collapsedBound)
     }
 
+    private fun updateAnchor(anchor: Int) {
+        targetAnchor = anchor
+        onAnchorChanged(anchor)
+    }
+
     fun collapse(animationSpec: AnimationSpec<Dp>) {
-        onAnchorChanged(COLLAPSED_ANCHOR)
+        updateAnchor(COLLAPSED_ANCHOR)
         coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
             animatable.animateTo(collapsedBound, animationSpec)
         }
     }
 
     fun expand(animationSpec: AnimationSpec<Dp>) {
-        onAnchorChanged(EXPANDED_ANCHOR)
+        updateAnchor(EXPANDED_ANCHOR)
         coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
             animatable.animateTo(animatable.upperBound!!, animationSpec)
         }
@@ -194,13 +209,20 @@ class BottomSheetState(
     }
 
     fun dismiss() {
-        onAnchorChanged(DISMISSED_ANCHOR)
+        updateAnchor(DISMISSED_ANCHOR)
         coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
             animatable.animateTo(animatable.lowerBound!!, if (animationsDisabled) snap() else BottomSheetAnimationSpec)
         }
     }
 
     fun snapTo(value: Dp) {
+        updateAnchor(
+            when (value) {
+                expandedBound -> EXPANDED_ANCHOR
+                dismissedBound -> DISMISSED_ANCHOR
+                else -> COLLAPSED_ANCHOR
+            }
+        )
         coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
             animatable.snapTo(value)
         }
@@ -349,6 +371,7 @@ fun rememberBottomSheetState(
             animatable = animatable,
             animationsDisabled = animationsDisabled,
             collapsedBound = collapsedBound,
+            initialAnchor = previousAnchor,
         )
     }
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/LyricsScreen.kt
@@ -133,6 +133,7 @@ fun LyricsScreen(
     onLyricsSyncOffsetChange: (Int) -> Unit,
     onQueueClick: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
+    backHandlerEnabled: Boolean = true,
 ) {
     val playerConnection = LocalPlayerConnection.current ?: return
     val player = playerConnection.player
@@ -281,7 +282,7 @@ fun LyricsScreen(
     val isLoading = playbackState == STATE_BUFFERING || sliderPosition != null
     val orientation = LocalConfiguration.current.orientation
 
-    BackHandler(onBack = onBackClick)
+    BackHandler(enabled = backHandlerEnabled, onBack = onBackClick)
 
     Box(modifier = modifier.fillMaxSize()) {
         AppleMusicBackground(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
@@ -752,14 +752,13 @@ fun BottomSheetPlayer(
 
     BackHandler(
         enabled =
-        isLyricsScreenVisible ||
-            (!queueSheetState.isCollapsed && !queueSheetState.isDismissed) ||
-            (!state.isCollapsed && !state.isDismissed)
+        queueSheetState.isExpandedOrExpanding ||
+            state.isExpandedOrExpanding
     ) {
         when {
-            isLyricsScreenVisible -> isLyricsScreenVisible = false
-            !queueSheetState.isCollapsed && !queueSheetState.isDismissed -> queueSheetState.collapseSoft()
-            !state.isCollapsed && !state.isDismissed -> state.collapseSoft()
+            isLyricsScreenVisible && state.isExpandedOrExpanding -> isLyricsScreenVisible = false
+            queueSheetState.isExpandedOrExpanding -> queueSheetState.collapseSoft()
+            state.isExpandedOrExpanding -> state.collapseSoft()
         }
     }
 
@@ -1642,6 +1641,7 @@ fun BottomSheetPlayer(
         mediaMetadata?.let { metadata ->
             MikoLyricsTransition(
                 visible = isLyricsScreenVisible,
+                backHandlerEnabled = isLyricsScreenVisible && state.isExpandedOrExpanding,
                 mediaMetadata = metadata,
                 navController = navController,
                 lyricsSyncOffset = lyricsSyncOffset,
@@ -1687,6 +1687,7 @@ fun BottomSheetPlayer(
 @Composable
 private fun MikoLyricsTransition(
     visible: Boolean,
+    backHandlerEnabled: Boolean,
     mediaMetadata: MediaMetadata,
     navController: NavController,
     lyricsSyncOffset: Int,
@@ -1738,6 +1739,7 @@ private fun MikoLyricsTransition(
                     lyricsSyncOffset = lyricsSyncOffset,
                     onLyricsSyncOffsetChange = onLyricsSyncOffsetChange,
                     onQueueClick = onQueueClick,
+                    backHandlerEnabled = backHandlerEnabled,
                 )
             }
         }


### PR DESCRIPTION
# Pull Request

## Summary

Fixes a bug where the first back press/gesture was silently swallowed right after dismissing the player UI — the player/queue/lyrics closed, but the next back did nothing once, and only worked on the second press. This happened on every screen. There are several causes with the same symptom: (1) the player/queue back handlers were gated on `isCollapsed`/`isDismissed`, which compare the *live animated value* and only flip once the slow collapse spring (`StiffnessLow`) finishes settling, so the handler stayed enabled and consumed the back press during the animation; (2) collapsing the player by drag/fling/gesture while on the lyrics page left the player back handler's lyrics branch enabled, so the first back press was spent clearing the lyrics flag in the background; (3) closing the lyrics page in place kept `LyricsScreen` composed during its exit animation, so its `BackHandler` swallowed the next press until the animation finished. The state now tracks the anchor *intent* (`targetAnchor`), updated immediately when a transition starts, with the back handlers gating on the new `isExpandedOrExpanding`; the player's lyrics branch is additionally gated on the sheet being expanded; and the lyrics `BackHandler` is gated on the transition's `visible` intent — so back is responsive the instant dismissal begins, while reopening the player still resumes the lyrics page.

## Linked Work

- Closes: -
- Related: -

## Change Type

- [ ] Feature
- [x] Bug fix
- [x] UI / UX
- [ ] Performance / memory
- [ ] Playback / Media3
- [ ] Lyrics / provider integration
- [ ] Search / YouTube / network data
- [ ] Local library / Room database
- [ ] Widgets / notification / shortcuts
- [ ] Settings / preferences / DataStore
- [ ] Discord / Last.fm / ListenBrainz / external integration
- [ ] Localization / strings / fastlane metadata
- [ ] Build / Gradle / CI / release packaging
- [ ] Dependency update
- [ ] Documentation only

## Affected Surfaces

- [x] `:app`
- [ ] `:innertube`
- [ ] `:betterlyrics`
- [ ] `:kugou`
- [ ] `:lrclib`
- [ ] `:lastfm`
- [ ] `:simpmusic`
- [ ] `:paxsenix`
- [ ] `:unison`
- [ ] `:canvas`
- [ ] `:shazamkit`
- [ ] `:spotifycore`
- [ ] `server`
- [ ] `fastlane`
- [ ] `.github`
- [ ] Other:

## Screenshots / Recordings

Behavioral/timing fix — best shown as a short screen recording.

| Before | After |
| --- | --- |
| Collapse player / queue, or close lyrics → a back press gets eaten until the animation finishes | Back is responsive immediately; reopening the player still resumes lyrics |

- **Root cause (sheet)**: `isCollapsed = value == collapsedBound` (and `isDismissed`) only become `true` after the `BottomSheetSoftAnimationSpec` (`StiffnessLow`) spring fully settles, which takes a noticeable amount of time. The back handlers in `BottomSheet` and `Player` stayed `enabled` for that whole window, so the first back press was consumed re-collapsing an already-collapsing sheet (a visual no-op).
- **Root cause (lyrics, drag-collapse)**: collapsing the player by drag/fling/gesture while on the lyrics page left the player back handler's `isLyricsScreenVisible` branch enabled. Because the lyrics flag is intentionally kept set while collapsed (so reopening resumes lyrics), the first back press was spent flipping that flag in the background instead of going to the system.
- **Root cause (lyrics, close-in-place)**: `MikoLyricsTransition` keeps `LyricsScreen` composed while its exit animation plays (`visible || boundedProgress > 0.001f`), and `LyricsScreen` held an unconditional `BackHandler`, so the next back press during the close animation was consumed by the still-composed lyrics screen.
- **Fix (sheet)**: `BottomSheetState` now exposes `targetAnchor`, updated synchronously by `collapse()` / `expand()` / `dismiss()` / `snapTo()`. Back handlers gate on the new `isExpandedOrExpanding` derived from intent, not the live animated value.
- **Fix (lyrics, drag-collapse)**: the lyrics branch of the player back handler is gated on `state.isExpandedOrExpanding`, so it only intercepts back while the player is actually open. `isLyricsScreenVisible` is left untouched, preserving resume-to-lyrics on reopen.
- **Fix (lyrics, close-in-place)**: `LyricsScreen` takes a `backHandlerEnabled` parameter (gating its `BackHandler`); `MikoLyricsTransition` passes `visible`, so the handler disables the instant dismissal starts rather than when the exit animation ends.
- **Scope**: only the player/queue/lyrics back handlers' enable conditions change. The 39 existing `isCollapsed`/`isExpanded`/`isDismissed` usages (including content visibility, background fade, and status-bar logic) are untouched and still use the live value.
- **Queue sheet included**: the same handler also guards the queue sheet, so collapsing the queue no longer eats a back press either.
- **`snapTo` consistency**: `snapTo()` now keeps `targetAnchor` in sync, so drag-cancel and `PlayerMenu` snap paths don't leave a stale intent.
- **No animation/feel changes**: spring specs, durations, and visuals are unchanged.

## Architecture Checklist

- [x] The change preserves UDF flow: UI -> ViewModel -> UseCase/domain -> Repository/data.
- [x] Screen state is represented structurally with `Loading`, `Success`, `Empty`, and `Error` where this PR introduces or changes screen state. _(N/A — no screen-state changes.)_
- [x] Composables receive immutable, UI-specific domain models instead of raw Room, network, or service entities.
- [x] Business work is not triggered directly from composition.
- [x] Exceptions are surfaced through explicit state or result types instead of being swallowed.
- [x] No `runBlocking` is introduced in app execution paths.

## Compose / Material Checklist

- [x] UI state is hoisted out of composable layout code. _(`targetAnchor` lives in the hoisted `BottomSheetState`.)_
- [x] Reactive state is collected with `collectAsStateWithLifecycle()`. _(N/A — no new flow collection.)_
- [x] New UI models are annotated with `@Immutable` or `@Stable`. _(`BottomSheetState` is already `@Stable`.)_
- [x] Lazy layouts use stable `key` values and explicit `contentType`. _(N/A.)_
- [x] Non-primitive constants, structural lambdas, and allocation-heavy objects in hot paths are remembered. _(`targetAnchor` is a plain `mutableIntStateOf`; the new helpers are plain getters with no allocation.)_
- [x] Rapidly changing inputs such as scroll, gesture, animation, or playback progress use `derivedStateOf` where appropriate. _(Existing `derivedStateOf` for `isCollapsed`/`isExpanded` retained; the intent helpers intentionally read `targetAnchor` directly so they react immediately.)_
- [x] UI strings come from `stringResource()` and duplicated visible strings on the same screen are avoided. _(No strings touched.)_
- [x] Interactive elements keep a minimum 48dp touch target.
- [x] Material 3 / Material 3 Expressive tokens are used for color, typography, shape, and motion instead of hardcoded UI values.
- [x] Edge-to-edge layouts handle and consume `WindowInsets` correctly when this PR changes screen layout. _(N/A — no layout changes.)_

## Concurrency / Performance Checklist

- [x] Business coroutines are scoped to `viewModelScope` or an existing lifecycle-owned application/service scope. _(Animations use the existing sheet `coroutineScope`.)_
- [x] Disk, database, network, parsing, and heavy mapping work is dispatched to `Dispatchers.IO` or `Dispatchers.Default`. _(N/A.)_
- [x] Cancellation is handled explicitly where long-running work is involved. _(N/A.)_
- [x] The change avoids blocking the main thread.
- [x] The change avoids unnecessary allocations in recomposition loops.
- [x] Large lists, images, lyrics payloads, and network responses are bounded, streamed, cached, paged, or mapped off the main thread as appropriate. _(N/A.)_

## Data / Persistence Checklist

- [x] Room entity, DAO, or database changes include a schema update under `app/schemas`. _(N/A.)_
- [x] Database migrations preserve existing user data and fail clearly when migration is impossible. _(N/A.)_
- [x] DataStore or preference-key changes are backward compatible. _(N/A.)_
- [x] Network DTOs remain isolated from UI models. _(N/A.)_
- [x] Provider responses handle missing, malformed, regional, or rate-limited data without crashing the app. _(N/A.)_

## Playback / Integration Checklist

- [x] Media3 playback, queue, cache, and service behavior remains stable across foreground, background, notification, and process recreation paths. _(`initialAnchor` is threaded into `BottomSheetState` so `targetAnchor` is correct after process recreation.)_
- [x] Audio focus, notification controls, widgets, shortcuts, and media session actions are considered when playback behavior changes. _(N/A — no playback behavior change.)_
- [x] External integrations handle absent credentials, revoked auth, network failure, and API changes. _(N/A.)_
- [x] Native, AAR, or ABI-sensitive changes account for mobile/tv and all ABI variants. _(N/A.)_

## Localization / Assets Checklist

- [x] User-facing strings are added to the base resources and translated resources are updated or intentionally left for translation follow-up. _(No strings changed.)_
- [x] Unused string resources, drawables, and metadata are removed when replaced.
- [x] Image assets have explicit display dimensions and are decoded at the displayed size. _(N/A.)_
- [x] Fastlane metadata, screenshots, icons, or release text are updated when user-facing store behavior changes. _(N/A.)_

## Privacy / Security Checklist

- [x] No secrets, keys, tokens, keystores, signing files, private certificates, or local machine paths are committed.
- [x] Logs do not expose access tokens, cookies, auth headers, user identifiers, listening history, or local file paths.
- [x] New network calls are justified by the feature and use existing client, proxy, timeout, and error-handling patterns. _(No network calls.)_
- [x] User data remains local unless the PR explicitly documents the integration and consent path.

## Verification

- [x] GitHub Actions build: build successfully<!-- fill in once the CI build completes -->
- [x] Manual device/emulator verification: collapse player via tap-title, mini-player drag-down, and back gesture; collapse queue; close lyrics in place (back returns to player, second back collapses); collapse from the lyrics page via drag/fling → next back works immediately; reopening the player from the lyrics page still resumes lyrics.
- [ ] UI screenshot/recording attached: <!-- attach a short before/after recording if possible -->
- [x] Accessibility or touch-target review: no touch targets changed.
- [x] Regression areas checked: queue sheet collapse, lyrics open/close + resume-to-lyrics, drag-to-collapse and drag-cancel, expand/collapse state after returning from album/artist navigation.

## Reviewer Focus

- `BottomSheet.kt` — new `targetAnchor` (intent) + `isExpandedOrExpanding`; `updateAnchor()` centralizes the anchor update across `collapse`/`expand`/`dismiss`/`snapTo`; `initialAnchor` threaded from `rememberBottomSheetState`.
- `Player.kt` — the player/queue back handler now gates on `isExpandedOrExpanding`; the lyrics branch additionally requires `state.isExpandedOrExpanding` so it doesn't intercept back once the player is collapsed (while leaving `isLyricsScreenVisible` set for resume-to-lyrics); `MikoLyricsTransition` passes `backHandlerEnabled = visible` to `LyricsScreen`.
- `LyricsScreen.kt` — new `backHandlerEnabled` parameter (default `true`) gating its `BackHandler`.
- Confirm that switching only the back handlers to intent-based logic (while leaving content-visibility/fade logic on the live value) is the intended split.

## Release Notes

Back presses are now responsive right after collapsing the player or queue, or closing the lyrics page, instead of a press being ignored until the animation finishes.