### PR TITLE
fix(updater): default daily-nightly builds to daily-nightly channel

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/BuildInfo.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/BuildInfo.kt
@@ -7,6 +7,16 @@
 
 package moe.rukamori.archivetune
 
+import moe.rukamori.archivetune.constants.UpdateChannel
+
+private val DailyNightlyVersionRegex = Regex("""^N\d{8}$""")
+
+internal val isDailyNightlyBuild: Boolean
+    get() = DailyNightlyVersionRegex.matches(BuildConfig.VERSION_NAME)
+
+internal val defaultUpdateChannel: UpdateChannel
+    get() = if (isDailyNightlyBuild) UpdateChannel.DAILY_NIGHTLY else UpdateChannel.STABLE
+
 internal val currentBuildHash: String?
     get() = BuildConfig.NIGHTLY_BUILD_HASH.takeIf { it.isNotBlank() }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -318,7 +318,7 @@ class MainActivity : ComponentActivity() {
     private var pendingVoiceSearchQuery: String? = null
     private var pendingTogetherJoinLink: String? = null
     private var latestVersionName by mutableStateOf(BuildConfig.VERSION_NAME)
-    private var latestUpdateChannel by mutableStateOf(UpdateChannel.STABLE)
+    private var latestUpdateChannel by mutableStateOf(defaultUpdateChannel)
 
     private var playerConnection by mutableStateOf<PlayerConnection?>(null)
     private var isMusicServiceBound = false
@@ -515,7 +515,7 @@ class MainActivity : ComponentActivity() {
                     }
                 }
 
-            val updateChannel by rememberEnumPreference(UpdateChannelKey, defaultValue = UpdateChannel.STABLE)
+            val updateChannel by rememberEnumPreference(UpdateChannelKey, defaultValue = defaultUpdateChannel)
 
             LaunchedEffect(Unit) {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
@@ -539,7 +539,7 @@ class MainActivity : ComponentActivity() {
                     val channelString = withContext(Dispatchers.IO) { dataStore.data.first()[UpdateChannelKey] }
                     val actualChannel = channelString?.let {
                         try { UpdateChannel.valueOf(it) } catch (_: IllegalArgumentException) { null }
-                    } ?: UpdateChannel.STABLE
+                    } ?: defaultUpdateChannel
 
                     if (actualChannel != UpdateChannel.NIGHTLY) {
                         val versionResult = when (actualChannel) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
@@ -48,6 +48,7 @@ import moe.rukamori.archivetune.BuildConfig
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.constants.DarkModeKey
 import moe.rukamori.archivetune.constants.UpdateChannel
+import moe.rukamori.archivetune.defaultUpdateChannel
 import moe.rukamori.archivetune.constants.PureBlackKey
 import moe.rukamori.archivetune.ui.component.BottomSheet
 import moe.rukamori.archivetune.ui.component.BottomSheetMenu
@@ -450,7 +451,7 @@ fun NavGraphBuilder.navigationBuilder(
         val channelName = backStackEntry.arguments?.getString("channel")
         val channel = channelName?.let {
             runCatching { UpdateChannel.valueOf(it) }.getOrNull()
-        } ?: UpdateChannel.STABLE
+        } ?: defaultUpdateChannel
         ChangelogScreen(navController, scrollBehavior, channel = channel)
     }
     composable("settings/about") {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/UpdateScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/UpdateScreen.kt
@@ -97,6 +97,7 @@ import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.constants.EnableUpdateNotificationKey
 import moe.rukamori.archivetune.constants.UpdateChannel
+import moe.rukamori.archivetune.defaultUpdateChannel
 import moe.rukamori.archivetune.constants.UpdateChannelKey
 import moe.rukamori.archivetune.ui.component.BottomSheetPage
 import moe.rukamori.archivetune.ui.component.BottomSheetPageState
@@ -131,7 +132,7 @@ fun UpdateScreen(
     )
     val (updateChannel, onUpdateChannelChange) = rememberEnumPreference(
         UpdateChannelKey,
-        defaultValue = UpdateChannel.STABLE
+        defaultValue = defaultUpdateChannel
     )
 
     var commits by remember { mutableStateOf<List<GitCommit>>(emptyList()) }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/utils/UpdateCheckWorker.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/utils/UpdateCheckWorker.kt
@@ -13,6 +13,7 @@ import androidx.work.WorkerParameters
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import moe.rukamori.archivetune.BuildConfig
+import moe.rukamori.archivetune.defaultUpdateChannel
 import moe.rukamori.archivetune.constants.EnableUpdateNotificationKey
 import moe.rukamori.archivetune.constants.UpdateChannel
 import moe.rukamori.archivetune.constants.UpdateChannelKey
@@ -35,8 +36,8 @@ class UpdateCheckWorker(
 
             val updateChannel = dataStore.data.map {
                 it[UpdateChannelKey]?.let { value ->
-                    try { UpdateChannel.valueOf(value) } catch (e: Exception) { UpdateChannel.STABLE }
-                } ?: UpdateChannel.STABLE
+                    try { UpdateChannel.valueOf(value) } catch (_: IllegalArgumentException) { defaultUpdateChannel }
+                } ?: defaultUpdateChannel
             }.first()
 
             when (updateChannel) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/utils/UpdateNotificationManager.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/utils/UpdateNotificationManager.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.launch
 import moe.rukamori.archivetune.BuildConfig
 import moe.rukamori.archivetune.MainActivity
 import moe.rukamori.archivetune.R
+import moe.rukamori.archivetune.defaultUpdateChannel
 import moe.rukamori.archivetune.constants.EnableUpdateNotificationKey
 import moe.rukamori.archivetune.constants.LastNotifiedVersionKey
 import moe.rukamori.archivetune.constants.LastUpdateCheckKey
@@ -111,8 +112,8 @@ object UpdateNotificationManager {
 
                 val updateChannel = dataStore.data.map { 
                     it[UpdateChannelKey]?.let { value -> 
-                        try { UpdateChannel.valueOf(value) } catch (e: Exception) { UpdateChannel.STABLE }
-                    } ?: UpdateChannel.STABLE
+                        try { UpdateChannel.valueOf(value) } catch (_: IllegalArgumentException) { defaultUpdateChannel }
+                    } ?: defaultUpdateChannel
                 }.first()
 
                 if (updateChannel == UpdateChannel.NIGHTLY) return@launch


### PR DESCRIPTION
# Pull Request

## Summary

Fix daily-nightly builds defaulting to the Stable update channel during startup when no update channel preference has been saved yet.

Daily-nightly CI rewrites `versionName` to tags like `N20260619`, but the app-launch update checker in `MainActivity` still fell back to `UpdateChannel.STABLE`. This caused daily-nightly builds to compare themselves against the normal release channel and show the release update bottom sheet on cold launch until the user manually re-selected the update channel in settings.

This PR centralizes the build-aware default update channel in `BuildInfo.kt` and uses `DAILY_NIGHTLY` by default for daily-nightly builds while keeping Stable as the default for normal builds.

## Linked Work

- Closes: -
- Related: https://github.com/ArchiveTuneApp/daily-nightly

## Change Type

- [ ] Feature
- [x] Bug fix
- [x] UI / UX
- [ ] Performance / memory
- [ ] Playback / Media3
- [ ] Lyrics / provider integration
- [ ] Search / YouTube / network data
- [ ] Local library / Room database
- [ ] Widgets / notification / shortcuts
- [x] Settings / preferences / DataStore
- [ ] Discord / Last.fm / ListenBrainz / external integration
- [ ] Localization / strings / fastlane metadata
- [x] Build / Gradle / CI / release packaging
- [ ] Dependency update
- [ ] Documentation only

## Affected Surfaces

- [x] `:app`
- [ ] `:core`
- [ ] `:betterlyrics`
- [ ] `:kugou`
- [ ] `:lrclib`
- [ ] `:lastfm`
- [ ] `:simpmusic`
- [ ] `:paxsenix`
- [ ] `:unison`
- [ ] `:canvas`
- [ ] `:shazamkit`
- [ ] `:spotifycore`
- [ ] Other:

## Screenshots / Recordings

| Before | After |
| --- | --- |
| Fresh daily-nightly builds could show the Stable/release update bottom sheet on cold launch. | Fresh daily-nightly builds default to the Daily Nightly update channel and no longer check the Stable/release channel by default. |

## Behavior Notes

- Daily-nightly builds are detected by the CI-generated `versionName` format `NyyyyMMdd`.
- When `UpdateChannelKey` is missing or invalid:
  - daily-nightly builds now default to `UpdateChannel.DAILY_NIGHTLY`;
  - normal builds still default to `UpdateChannel.STABLE`.
- Existing user-selected update channels are preserved. This does not overwrite a stored `UpdateChannelKey`.
- Startup update checks, Settings > Update, update notifications, update worker, and changelog fallback now share the same build-aware default.
- No new DataStore preference key is added.

## Architecture Checklist

- [x] The change preserves UDF flow: UI -> ViewModel -> UseCase/domain -> Repository/data. (No new UI state flow introduced.)
- [x] Screen state is represented structurally with `Loading`, `Success`, `Empty`, and `Error` where this PR introduces or changes screen state. (N/A: no new screen state.)
- [x] Composables receive immutable, UI-specific domain models instead of raw Room, network, or service entities. (N/A.)
- [x] Business work is not triggered directly from composition. (No new work is triggered.)
- [x] Exceptions are surfaced through explicit state or result types instead of being swallowed. (No new exception path.)
- [x] No `runBlocking` is introduced in app execution paths.

## Compose / Material Checklist

- [x] UI state is hoisted out of composable layout code. (Existing state is reused.)
- [x] Reactive state is collected with `collectAsStateWithLifecycle()`. (N/A: no new Flow collection.)
- [x] New UI models are annotated with `@Immutable` or `@Stable`. (N/A: no new UI model.)
- [x] Lazy layouts use stable `key` values and explicit `contentType`. (N/A.)
- [x] Non-primitive constants, structural lambdas, and allocation-heavy objects in hot paths are remembered. (N/A.)
- [x] Rapidly changing inputs such as scroll, gesture, animation, or playback progress use `derivedStateOf` where appropriate. (N/A.)
- [x] UI strings come from `stringResource()` and duplicated visible strings on the same screen are avoided. (No new strings.)
- [x] Interactive elements keep a minimum 48dp touch target. (No new interactive elements.)
- [x] Material 3 / Material 3 Expressive tokens are used for color, typography, shape, and motion instead of hardcoded UI values. (No visual layout changes.)
- [x] Edge-to-edge layouts handle and consume `WindowInsets` correctly when this PR changes screen layout. (No layout changes.)

## Concurrency / Performance Checklist

- [x] Business coroutines are scoped to `viewModelScope` or an existing lifecycle-owned application/service scope. (No new coroutine scope.)
- [x] Disk, database, network, parsing, and heavy mapping work is dispatched to `Dispatchers.IO` or `Dispatchers.Default`. (No new disk/network work.)
- [x] Cancellation is handled explicitly where long-running work, playback, downloads, sync, lyrics fetching, or recognition is involved. (N/A.)
- [x] The change avoids blocking the main thread.
- [x] The change avoids unnecessary allocations in recomposition loops, playback loops, polling loops, and provider parsing paths.
- [x] Large lists, images, lyrics payloads, and network responses are bounded, streamed, cached, paged, or mapped off the main thread as appropriate. (N/A.)

## Data / Persistence Checklist

- [x] Room entity, DAO, or database changes include a schema update under `app/schemas`. (N/A: no Room changes.)
- [x] Database migrations preserve existing user data and fail clearly when migration is impossible. (N/A.)
- [x] DataStore or preference-key changes are backward compatible. No new key is added and existing stored channel values are preserved.
- [x] Network DTOs remain isolated from UI models. (N/A.)
- [x] Provider responses handle missing, malformed, regional, or rate-limited data without crashing the app. (N/A.)

## Playback / Integration Checklist

- [x] Media3 playback, queue, cache, and service behavior remains stable across foreground, background, notification, and process recreation paths. (No playback changes.)
- [x] Audio focus, notification controls, widgets, shortcuts, and media session actions are considered when playback behavior changes. (N/A.)
- [x] External integrations handle absent credentials, revoked auth, network failure, and API changes. (N/A.)
- [x] Native, AAR, or ABI-sensitive changes account for mobile/tv and `universal`, `arm64`, `armeabi`, `x86`, and `x86_64` variants. (No ABI-specific behavior changed.)

## Localization / Assets Checklist

- [x] User-facing strings are added to the base resources and translated resources are updated or intentionally left for translation follow-up. (No new strings.)
- [x] Unused string resources, drawables, and metadata are removed when replaced. (None.)
- [x] Image assets have explicit display dimensions and are decoded at the displayed size. (N/A.)
- [x] Fastlane metadata, screenshots, icons, or release text are updated when user-facing store behavior changes. (N/A.)

## Privacy / Security Checklist

- [x] No secrets, keys, tokens, keystores, signing files, private certificates, or local machine paths are committed.
- [x] Logs do not expose access tokens, cookies, auth headers, user identifiers, listening history, or local file paths.
- [x] New network calls are justified by the feature and use existing client, proxy, timeout, and error-handling patterns. (No new network calls.)
- [x] User data remains local unless the PR explicitly documents the integration and consent path.

## Verification

- [ ] Android Studio sync:
- [ ] Manual device/emulator verification:
  - Fresh daily-nightly install with no saved `UpdateChannelKey` defaults to Daily Nightly.
  - Cold-launch daily-nightly build no longer shows Stable/release update bottom sheet.
  - Settings > Update shows Daily Nightly as the default channel on daily-nightly builds.
  - Normal release build still defaults to Stable.
  - Existing stored update channel selection is preserved.
- [ ] UI screenshot/recording attached:
- [x] Accessibility or touch-target review: No new UI controls.
- [x] Regression areas checked: startup update prompt, update settings screen, update notification fallback, update worker fallback.
- [ ] CI expectation:

## Reviewer Focus

Please focus on whether `BuildInfo.defaultUpdateChannel` is the right single source of truth for update-channel fallback behavior.

Files to review closely:

- `BuildInfo.kt`
  - Detects daily-nightly builds from CI-generated `versionName` like `N20260619`.
- `MainActivity.kt`
  - Uses the build-aware default for app-launch update checks and startup update sheet logic.
- `UpdateScreen.kt`
  - Uses the same default as the startup checker.
- `UpdateNotificationManager.kt` / `UpdateCheckWorker.kt`
  - Use the same fallback when no channel is stored or the stored value is invalid.
- `NavigationBuilder.kt`
  - Uses the same fallback for changelog channel routes without an explicit channel argument.

## Release Notes

Daily-nightly builds now default to the Daily Nightly update channel instead of the Stable release channel.