### PR TITLE
fix(home,playlist): speed up loading of YouTube generated personal pl…

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/HomeViewModel.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/HomeViewModel.kt
@@ -637,9 +637,9 @@ class HomeViewModel
                     isAccountLoggedIn.value = loggedIn
 
                     if (loggedIn && prepareYouTubeAccount(cookie)) {
-                        refreshAccountIdentity()
-                        launch {
-                            refreshAccountPlaylistsInternal()
+                        supervisorScope {
+                            launch { refreshAccountIdentity() }
+                            launch { refreshAccountPlaylistsInternal() }
                         }
                     } else {
                         clearAccountData()
@@ -712,8 +712,10 @@ class HomeViewModel
                             .toPlaybackAuthState()
                     YouTube.authState = authState
 
-                    refreshAccountIdentity()
-                    refreshAccountPlaylistsInternal()
+                    supervisorScope {
+                        launch { refreshAccountIdentity() }
+                        launch { refreshAccountPlaylistsInternal() }
+                    }
 
                     if (forceSyncOnSwitch && context.dataStore.get(YtmSyncKey, true) && authState.hasLoginCookie) {
                         syncUtils.performFullSync(authoritative = true)
@@ -773,6 +775,12 @@ class HomeViewModel
                                     return@collect
                                 }
 
+                                supervisorScope {
+                                    kotlinx.coroutines.delay(100)
+                                    launch { refreshAccountIdentity() }
+                                    launch { refreshAccountPlaylistsInternal() }
+                                }
+
                                 if (loginTransition) {
                                     launch {
                                         try {
@@ -784,14 +792,6 @@ class HomeViewModel
                                             reportException(e)
                                         }
                                     }
-                                }
-
-                                kotlinx.coroutines.delay(100)
-
-                                refreshAccountIdentity()
-
-                                launch {
-                                    refreshAccountPlaylistsInternal()
                                 }
                             } else {
                                 clearAccountData()

--- a/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/OnlinePlaylistViewModel.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/OnlinePlaylistViewModel.kt
@@ -29,7 +29,6 @@ import moe.rukamori.archivetune.db.MusicDatabase
 import moe.rukamori.archivetune.innertube.YouTube
 import moe.rukamori.archivetune.innertube.models.PlaylistItem
 import moe.rukamori.archivetune.innertube.models.SongItem
-import moe.rukamori.archivetune.innertube.utils.completed
 import moe.rukamori.archivetune.utils.reportException
 import javax.inject.Inject
 
@@ -124,11 +123,10 @@ class OnlinePlaylistViewModel
 
                 YouTube
                     .playlist(playlistId)
-                    .completed()
                     .onSuccess { playlistPage ->
                         _playlist.value = playlistPage.playlist
                         _playlistSongs.value = playlistPage.songs
-                        continuation = null
+                        continuation = playlistPage.songsContinuation ?: playlistPage.continuation
                         prefetchViewCounts(playlistPage.songs.map { song -> song.id })
                     }.onFailure { throwable ->
                         _error.value = throwable.message ?: "Failed to load playlist"


### PR DESCRIPTION
…aylists

Reduce blocking network work that caused ArchiveTune to take ~1 minute to show YouTube-generated personal playlists (Liked Music, My Supermix, My Mix 01-04).
Changes:
- OnlinePlaylistViewModel: remove .completed() from initial playlist load. Show the first page immediately and set continuation = songsContinuation or continuation, letting loadMoreSongs() fetch later pages on demand.
- Utils: lower LibraryPage.completed() maxRequests from 500 to 50 so the home "Mixes" / account-playlists row does not make hundreds of sequential continuation requests.
- HomeViewModel: run refreshAccountIdentity() and refreshAccountPlaylistsInternal() in parallel instead of serializing the playlist fetch behind account info and channel listing.

Fixes slow loading of YouTube-generated auto playlists.

Related: https://github.com/ArchiveTuneApp/core/pull/1