### PR TITLE
fix(settings): unify player-aware bottom padding

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/BottomSheetPage.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/BottomSheetPage.kt
@@ -86,6 +86,7 @@ fun BottomSheetPage(
     modifier: Modifier = Modifier,
     state: BottomSheetPageState,
     background: Color = MaterialTheme.colorScheme.surfaceColorAtElevation(NavigationBarDefaults.Elevation),
+    contentWindowInsets: WindowInsets = WindowInsets.navigationBars,
 ) {
     val focusManager = LocalFocusManager.current
     val coroutineScope = rememberCoroutineScope()
@@ -167,7 +168,7 @@ fun BottomSheetPage(
                     Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 16.dp)
-                        .windowInsetsPadding(WindowInsets.navigationBars),
+                        .windowInsetsPadding(contentWindowInsets),
             ) {
                 state.content(this)
             }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AboutScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AboutScreen.kt
@@ -245,7 +245,7 @@ private fun AboutScreenContent(
                     contentPadding =
                         PaddingValues(
                             top = innerPadding.calculateTopPadding() + 8.dp,
-                            bottom = 32.dp,
+                            bottom = SettingsDimensions.ScreenBottomPadding,
                         ),
                     listState = listState,
                 )

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AccountSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AccountSettings.kt
@@ -371,7 +371,7 @@ fun AccountSettings(
                     start = 16.dp,
                     top = innerPadding.calculateTopPadding() + 8.dp,
                     end = 16.dp,
-                    bottom = 32.dp,
+                    bottom = SettingsDimensions.ScreenBottomPadding,
                 ),
             verticalArrangement = Arrangement.spacedBy(14.dp),
         ) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AiIntegrationSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AiIntegrationSettings.kt
@@ -176,7 +176,8 @@ fun AiIntegrationSettings(
     Column(
         Modifier
             .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom))
-            .verticalScroll(rememberScrollState()),
+            .verticalScroll(rememberScrollState())
+            .padding(bottom = SettingsDimensions.ScreenBottomPadding),
     ) {
         Spacer(
             Modifier.windowInsetsPadding(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AodCustomizedScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AodCustomizedScreen.kt
@@ -540,7 +540,7 @@ fun AodCustomizedScreen(
                 key = "aod_bottom_space",
                 contentType = "spacer",
             ) {
-                Spacer(modifier = Modifier.height(16.dp))
+                Spacer(modifier = Modifier.height(SettingsDimensions.ScreenBottomPadding))
             }
         }
     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceSettings.kt
@@ -407,7 +407,8 @@ fun AppearanceSettings(
     Column(
         Modifier
             .windowInsetsPadding(LocalPlayerAwareWindowInsets.current)
-            .verticalScroll(rememberScrollState()),
+            .verticalScroll(rememberScrollState())
+            .padding(bottom = SettingsDimensions.ScreenBottomPadding),
     ) {
         PreferenceGroup(title = stringResource(R.string.theme)) {
             item {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/BackupAndRestore.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/BackupAndRestore.kt
@@ -200,7 +200,8 @@ fun BackupAndRestore(
     Column(
         Modifier
             .windowInsetsPadding(LocalPlayerAwareWindowInsets.current)
-            .verticalScroll(rememberScrollState()),
+            .verticalScroll(rememberScrollState())
+            .padding(bottom = SettingsDimensions.ScreenBottomPadding),
     ) {
         PreferenceGroup(title = stringResource(R.string.internal_service)) {
             item {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/ChangelogScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/ChangelogScreen.kt
@@ -165,7 +165,7 @@ fun ChangelogScreen(
                             ReleaseCard(release = release)
                         }
 
-                        item { Spacer(modifier = Modifier.height(8.dp)) }
+                        item { Spacer(modifier = Modifier.height(SettingsDimensions.ScreenBottomPadding)) }
                     }
                 }
             }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/ContentSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/ContentSettings.kt
@@ -13,6 +13,7 @@ import android.content.Intent
 import android.os.Build
 import android.provider.Settings
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -66,7 +67,8 @@ fun ContentSettings(navController: NavController) {
     Column(
         Modifier
             .windowInsetsPadding(LocalPlayerAwareWindowInsets.current)
-            .verticalScroll(rememberScrollState()),
+            .verticalScroll(rememberScrollState())
+            .padding(bottom = SettingsDimensions.ScreenBottomPadding),
     ) {
         PreferenceGroup(title = stringResource(R.string.general)) {
             item {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/CustomizeBackground.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/CustomizeBackground.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import coil3.compose.AsyncImage
+import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.constants.PlayerBackgroundStyle
 import moe.rukamori.archivetune.constants.PlayerCustomBlurKey
@@ -87,8 +88,17 @@ fun CustomizeBackground(navController: NavController) {
                 Modifier
                     .padding(innerPadding)
                     .fillMaxSize()
-                    .verticalScroll(rememberScrollState())
-                    .padding(16.dp),
+                    .windowInsetsPadding(
+                        LocalPlayerAwareWindowInsets.current.only(
+                            WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom,
+                        ),
+                    ).verticalScroll(rememberScrollState())
+                    .padding(
+                        start = 16.dp,
+                        top = 16.dp,
+                        end = 16.dp,
+                        bottom = SettingsDimensions.ScreenBottomPadding,
+                    ),
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
             val heightScale = 1.4f

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DebugSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DebugSettings.kt
@@ -31,13 +31,16 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -112,6 +115,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.LocalPlayerConnection
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.ui.component.IconButton
@@ -180,6 +184,11 @@ fun DebugSettings(navController: NavController) {
                 Modifier
                     .fillMaxSize()
                     .padding(innerPadding)
+                    .windowInsetsPadding(
+                        LocalPlayerAwareWindowInsets.current.only(
+                            WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom,
+                        ),
+                    )
                     .verticalScroll(rememberScrollState()),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
@@ -243,7 +252,7 @@ fun DebugSettings(navController: NavController) {
                 }
             }
 
-            Spacer(modifier = Modifier.height(24.dp))
+            Spacer(modifier = Modifier.height(SettingsDimensions.ScreenBottomPadding))
         }
     }
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DebugSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DebugSettings.kt
@@ -188,8 +188,7 @@ fun DebugSettings(navController: NavController) {
                         LocalPlayerAwareWindowInsets.current.only(
                             WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom,
                         ),
-                    )
-                    .verticalScroll(rememberScrollState()),
+                    ).verticalScroll(rememberScrollState()),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             PreferenceGroup(title = stringResource(R.string.experimental_features)) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/IntegrationScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/IntegrationScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -56,7 +57,8 @@ fun IntegrationScreen(
     Column(
         Modifier
             .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom))
-            .verticalScroll(rememberScrollState()),
+            .verticalScroll(rememberScrollState())
+            .padding(bottom = SettingsDimensions.ScreenBottomPadding),
     ) {
         Spacer(
             Modifier.windowInsetsPadding(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/InternetSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/InternetSettings.kt
@@ -178,7 +178,8 @@ fun InternetSettings(
     Column(
         Modifier
             .windowInsetsPadding(LocalPlayerAwareWindowInsets.current)
-            .verticalScroll(rememberScrollState()),
+            .verticalScroll(rememberScrollState())
+            .padding(bottom = SettingsDimensions.ScreenBottomPadding),
     ) {
         InternetWarningBox()
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LastFMSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LastFMSettings.kt
@@ -151,7 +151,8 @@ private fun LastFmSettingsContent(
     Column(
         Modifier
             .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom))
-            .verticalScroll(rememberScrollState()),
+            .verticalScroll(rememberScrollState())
+            .padding(bottom = SettingsDimensions.ScreenBottomPadding),
     ) {
         Spacer(
             Modifier.windowInsetsPadding(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LyricsAnimationSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LyricsAnimationSettings.kt
@@ -84,7 +84,7 @@ fun LyricsAnimationSettings(
                         LocalPlayerAwareWindowInsets.current.only(
                             WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom,
                         ),
-                    ).padding(bottom = 16.dp),
+                    ).padding(bottom = SettingsDimensions.ScreenBottomPadding),
         ) {
             PreferenceGroup(title = "Animation Tuning") {
                 item {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LyricsSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LyricsSettings.kt
@@ -227,7 +227,8 @@ fun LyricsSettings(
     Column(
         Modifier
             .windowInsetsPadding(LocalPlayerAwareWindowInsets.current)
-            .verticalScroll(rememberScrollState()),
+            .verticalScroll(rememberScrollState())
+            .padding(bottom = SettingsDimensions.ScreenBottomPadding),
     ) {
         var showLyricsTextSizeDialog by rememberSaveable { mutableStateOf(false) }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/MusicTogetherScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/MusicTogetherScreen.kt
@@ -425,7 +425,8 @@ fun MusicTogetherScreen(
                 Modifier
                     .weight(1f)
                     .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom))
-                    .verticalScroll(rememberScrollState()),
+                    .verticalScroll(rememberScrollState())
+                    .padding(bottom = SettingsDimensions.ScreenBottomPadding),
         ) {
             StatusCard(
                 state = sessionState,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlayerSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlayerSettings.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -244,7 +245,8 @@ fun PlayerSettings(
     Column(
         Modifier
             .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom))
-            .verticalScroll(rememberScrollState()),
+            .verticalScroll(rememberScrollState())
+            .padding(bottom = SettingsDimensions.ScreenBottomPadding),
     ) {
         Spacer(
             Modifier.windowInsetsPadding(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PoTokenScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PoTokenScreen.kt
@@ -290,6 +290,7 @@ fun PoTokenScreen(
                     WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom,
                 ),
             ).verticalScroll(rememberScrollState())
+            .padding(bottom = SettingsDimensions.ScreenBottomPadding)
             .animateContentSize(
                 animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
             ),

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PrivacySettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PrivacySettings.kt
@@ -150,7 +150,8 @@ fun PrivacySettings(
     Column(
         Modifier
             .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom))
-            .verticalScroll(rememberScrollState()),
+            .verticalScroll(rememberScrollState())
+            .padding(bottom = SettingsDimensions.ScreenBottomPadding),
     ) {
         Spacer(
             Modifier.windowInsetsPadding(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsDimensions.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsDimensions.kt
@@ -20,6 +20,7 @@ object SettingsDimensions {
     val BannerCardCornerRadius = 20.dp
 
     val ScreenHorizontalPadding = 16.dp
+    val ScreenBottomPadding = 32.dp
     val SectionSpacing = 14.dp
     val RowVerticalPadding = 14.dp
     val RowHorizontalPadding = 16.dp

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsScreen.kt
@@ -16,11 +16,9 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.windowInsetsPadding
@@ -166,7 +164,7 @@ fun SettingsScreen(
             contentPadding =
                 PaddingValues(
                     top = innerPadding.calculateTopPadding(),
-                    bottom = 32.dp,
+                    bottom = SettingsDimensions.ScreenBottomPadding,
                 ),
         ) {
             if (hasUpdate && !isUpdateDismissed) {
@@ -217,10 +215,6 @@ fun SettingsScreen(
                     count = settingsItems.size,
                     modifier = Modifier.padding(horizontal = 26.dp),
                 )
-            }
-
-            item(key = "bottom_spacer", contentType = "settings_spacer") {
-                Spacer(modifier = Modifier.height(24.dp))
             }
         }
     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/StorageSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/StorageSettings.kt
@@ -92,9 +92,9 @@ import moe.rukamori.archivetune.ui.player.CanvasArtworkPlaybackCache
 import moe.rukamori.archivetune.ui.utils.backToMain
 import moe.rukamori.archivetune.ui.utils.formatFileSize
 import moe.rukamori.archivetune.utils.rememberPreference
-import moe.rukamori.archivetune.viewmodels.StorageFolderUiModel
 import moe.rukamori.archivetune.viewmodels.StorageCacheClearUiKind
 import moe.rukamori.archivetune.viewmodels.StorageCacheClearUiModel
+import moe.rukamori.archivetune.viewmodels.StorageFolderUiModel
 import moe.rukamori.archivetune.viewmodels.StorageLocationUiModel
 import moe.rukamori.archivetune.viewmodels.StorageLocationUiOptions
 import moe.rukamori.archivetune.viewmodels.StorageMigrationUiModel
@@ -283,7 +283,12 @@ fun StorageSettings(
             Modifier
                 .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom))
                 .verticalScroll(rememberScrollState())
-                .padding(12.dp),
+                .padding(
+                    start = 12.dp,
+                    top = 12.dp,
+                    end = 12.dp,
+                    bottom = SettingsDimensions.ScreenBottomPadding,
+                ),
         ) {
             Spacer(
                 Modifier.windowInsetsPadding(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/UpdateScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/UpdateScreen.kt
@@ -932,10 +932,13 @@ fun UpdateScreen(
         }
     }
 
-    BottomSheetPage(
-        state = updateSheetState,
-        contentWindowInsets = LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Bottom),
-    )
+    Box(modifier = Modifier.fillMaxSize()) {
+        BottomSheetPage(
+            state = updateSheetState,
+            modifier = Modifier.align(Alignment.BottomCenter),
+            contentWindowInsets = LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Bottom),
+        )
+    }
 
     if (updateSheetLoading) {
         AlertDialog(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/UpdateScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/UpdateScreen.kt
@@ -245,6 +245,8 @@ fun UpdateScreen(
         ) {
             Text(text = stringResource(R.string.update_text))
         }
+
+        Spacer(Modifier.height(SettingsDimensions.ScreenBottomPadding))
     }
 
     val onCheckForUpdate: () -> Unit = {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/UpdateScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/UpdateScreen.kt
@@ -246,7 +246,7 @@ fun UpdateScreen(
             Text(text = stringResource(R.string.update_text))
         }
 
-        Spacer(Modifier.height(SettingsDimensions.ScreenBottomPadding))
+        Spacer(Modifier.height(12.dp))
     }
 
     val onCheckForUpdate: () -> Unit = {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/UpdateScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/UpdateScreen.kt
@@ -927,12 +927,15 @@ fun UpdateScreen(
             }
 
             item {
-                Spacer(modifier = Modifier.height(16.dp))
+                Spacer(modifier = Modifier.height(SettingsDimensions.ScreenBottomPadding))
             }
         }
     }
 
-    BottomSheetPage(state = updateSheetState)
+    BottomSheetPage(
+        state = updateSheetState,
+        contentWindowInsets = LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Bottom),
+    )
 
     if (updateSheetLoading) {
         AlertDialog(


### PR DESCRIPTION
# Pull Request

## Summary

Unify bottom spacing across Settings screens and subpages when the mini-player is visible.

Some Settings screens already used `LocalPlayerAwareWindowInsets`, so their content was not fully covered by the mini-player, but the final item could still sit too close to it. This PR introduces `SettingsDimensions.ScreenBottomPadding` as the shared bottom spacing value and applies it across the main Settings page, Settings subpages, and Developer Options.

This also fixes the local Update bottom sheet by anchoring it to the bottom of the screen while keeping its action spacing visually consistent.

## Linked Work

- Closes: -
- Related: -

## Change Type

- [ ] Feature
- [x] Bug fix
- [x] UI / UX
- [ ] Performance / memory
- [ ] Playback / Media3
- [ ] Lyrics / provider integration
- [ ] Search / YouTube / network data
- [ ] Local library / Room database
- [ ] Widgets / notification / shortcuts
- [x] Settings / preferences / DataStore
- [ ] Discord / Last.fm / ListenBrainz / external integration
- [ ] Localization / strings / fastlane metadata
- [ ] Build / Gradle / CI / release packaging
- [ ] Dependency update
- [ ] Documentation only

## Affected Surfaces

- [x] `:app`
- [ ] `:core`
- [ ] `:betterlyrics`
- [ ] `:kugou`
- [ ] `:lrclib`
- [ ] `:lastfm`
- [ ] `:simpmusic`
- [ ] `:paxsenix`
- [ ] `:unison`
- [ ] `:canvas`
- [ ] `:shazamkit`
- [ ] `:spotifycore`
- [ ] Other:

## Screenshots / Recordings

| Before | After |
| --- | --- |
| Some Settings subpages could scroll their last item too close to the mini-player. | Settings subpages now keep consistent bottom spacing above the mini-player. |
| The local Update bottom sheet could appear unanchored / visually cramped near the bottom action. | The Update bottom sheet is anchored to the bottom and keeps balanced spacing around the action button. |

## Behavior Notes

- Adds `SettingsDimensions.ScreenBottomPadding` as the shared bottom spacing value for Settings screens.
- Removes the extra bottom spacer from the main Settings page and uses shared bottom content padding instead.
- Applies consistent bottom spacing across Settings subpages that use player-aware insets.
- Makes Developer Options use `LocalPlayerAwareWindowInsets` so its content respects the mini-player.
- Adds player-aware spacing to Settings subpages that were missing it, such as `CustomizeBackground`.
- Aligns existing hardcoded bottom values such as `8.dp`, `16.dp`, and `32.dp` where they represented Settings screen bottom spacing.
- Anchors the local Update bottom sheet to the bottom of the screen.
- Keeps Update bottom sheet action spacing balanced by matching the bottom spacer to the spacing above the action button.
- Keeps app-level/global bottom sheet behavior unchanged.
- Does not change DataStore, playback, network, or business logic.

## Architecture Checklist

- [x] The change preserves UDF flow: UI -> ViewModel -> UseCase/domain -> Repository/data. (UI layout spacing only.)
- [x] Screen state is represented structurally with `Loading`, `Success`, `Empty`, and `Error` where this PR introduces or changes screen state. (N/A: no new screen state.)
- [x] Composables receive immutable, UI-specific domain models instead of raw Room, network, or service entities. (N/A.)
- [x] Business work is not triggered directly from composition. (No new business work.)
- [x] Exceptions are surfaced through explicit state or result types instead of being swallowed. (N/A.)
- [x] No `runBlocking` is introduced in app execution paths.

## Compose / Material Checklist

- [x] UI state is hoisted out of composable layout code. (No new state.)
- [x] Reactive state is collected with `collectAsStateWithLifecycle()`. (N/A: no new Flow collection.)
- [x] New UI models are annotated with `@Immutable` or `@Stable`. (N/A: no new UI models.)
- [x] Lazy layouts use stable `key` values and explicit `contentType`. (Existing lazy layout behavior preserved.)
- [x] Non-primitive constants, structural lambdas, and allocation-heavy objects in hot paths are remembered. (N/A.)
- [x] Rapidly changing inputs such as scroll, gesture, animation, or playback progress use `derivedStateOf` where appropriate. (N/A.)
- [x] UI strings come from `stringResource()` and duplicated visible strings on the same screen are avoided. (No new strings.)
- [x] Interactive elements keep a minimum 48dp touch target. (No new interactive elements.)
- [x] Material 3 / Material 3 Expressive tokens are used for color, typography, shape, and motion instead of hardcoded UI values. (No new visual tokens.)
- [x] Edge-to-edge layouts handle and consume `WindowInsets` correctly when this PR changes screen layout.

## Concurrency / Performance Checklist

- [x] Business coroutines are scoped to `viewModelScope` or an existing lifecycle-owned application/service scope. (No coroutine changes.)
- [x] Disk, database, network, parsing, and heavy mapping work is dispatched to `Dispatchers.IO` or `Dispatchers.Default`. (N/A.)
- [x] Cancellation is handled explicitly where long-running work, playback, downloads, sync, lyrics fetching, or recognition is involved. (N/A.)
- [x] The change avoids blocking the main thread.
- [x] The change avoids unnecessary allocations in recomposition loops, playback loops, polling loops, and provider parsing paths.
- [x] Large lists, images, lyrics payloads, and network responses are bounded, streamed, cached, paged, or mapped off the main thread as appropriate. (N/A.)

## Data / Persistence Checklist

- [x] Room entity, DAO, or database changes include a schema update under `app/schemas`. (N/A: no Room changes.)
- [x] Database migrations preserve existing user data and fail clearly when migration is impossible. (N/A.)
- [x] DataStore or preference-key changes are backward compatible. (No preference changes.)
- [x] Network DTOs remain isolated from UI models. (N/A.)
- [x] Provider responses handle missing, malformed, regional, or rate-limited data without crashing the app. (N/A.)

## Playback / Integration Checklist

- [x] Media3 playback, queue, cache, and service behavior remains stable across foreground, background, notification, and process recreation paths. (No playback changes.)
- [x] Audio focus, notification controls, widgets, shortcuts, and media session actions are considered when playback behavior changes. (N/A.)
- [x] External integrations handle absent credentials, revoked auth, network failure, and API changes. (N/A.)
- [x] Native, AAR, or ABI-sensitive changes account for mobile/tv and `universal`, `arm64`, `armeabi`, `x86`, and `x86_64` variants. (No ABI changes.)

## Localization / Assets Checklist

- [x] User-facing strings are added to the base resources and translated resources are updated or intentionally left for translation follow-up. (No new strings.)
- [x] Unused string resources, drawables, and metadata are removed when replaced. (None.)
- [x] Image assets have explicit display dimensions and are decoded at the displayed size. (N/A.)
- [x] Fastlane metadata, screenshots, icons, or release text are updated when user-facing store behavior changes. (N/A.)

## Privacy / Security Checklist

- [x] No secrets, keys, tokens, keystores, signing files, private certificates, or local machine paths are committed.
- [x] Logs do not expose access tokens, cookies, auth headers, user identifiers, listening history, or local file paths.
- [x] New network calls are justified by the feature and use existing client, proxy, timeout, and error-handling patterns. (No new network calls.)
- [x] User data remains local unless the PR explicitly documents the integration and consent path.

## Verification

- [ ] Android Studio sync:
- [x] Manual device/emulator verification:
  - Built and tested the branch locally.
  - Verified Settings subpages keep consistent spacing above the mini-player.
  - Verified Appearance/Penampilan no longer scrolls the last item too close to the mini-player.
  - Verified Developer Options respects mini-player-aware bottom insets.
  - Verified the local Update bottom sheet is anchored to the bottom of the screen.
  - Verified Update bottom sheet action spacing is balanced with the content above it.
  - Verified affected Settings pages remain scrollable with and without the mini-player.
- [x] UI screenshot/recording attached:
- [x] Accessibility or touch-target review: No new interactive elements.
- [x] Regression areas checked: Settings page, Settings subpages, Developer Options, Update screen, Update bottom sheet, mini-player visible state.
- [ ] CI expectation:

## Reviewer Focus

Please focus on whether `SettingsDimensions.ScreenBottomPadding` is the right shared spacing token for Settings page and subpage bottom content.

Files to review closely:

- `SettingsDimensions.kt`
  - Adds the shared bottom spacing value.
- `SettingsScreen.kt`
  - Removes the previous extra spacer and uses shared bottom content padding.
- `DebugSettings.kt`
  - Adds player-aware bottom/horizontal insets.
- `UpdateScreen.kt`
  - Keeps Update screen content spacing consistent.
  - Anchors the local Update bottom sheet to the bottom of the screen.
  - Keeps the bottom action spacing visually balanced.
- `BottomSheetPage.kt`
  - Allows callers to override content window insets where needed.
- Settings subpages
  - Aligns bottom spacing so final content does not sit too close to the mini-player.
- `CustomizeBackground.kt`
  - Adds player-aware insets because it is a Settings subpage reachable from Appearance.

## Release Notes

Settings screens now keep consistent bottom spacing above the mini-player.