### PR TITLE
feat: add RestoreBackupFileActivity with .backup intent handling and validation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -175,6 +175,25 @@
                 android:resource="@xml/shortcuts" />
         </activity>
 
+        <activity
+            android:name=".RestoreBackupFileActivity"
+            android:exported="true"
+            android:theme="@style/Theme.ArchiveTune"
+            android:noHistory="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="content" />
+                <data android:mimeType="application/octet-stream" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="file" />
+                <data android:mimeType="application/octet-stream" />
+            </intent-filter>
+        </activity>
+
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.FileProvider"

--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -59,6 +59,7 @@ import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.only
@@ -70,10 +71,12 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.AlertDialogDefaults
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -288,6 +291,8 @@ import moe.rukamori.archivetune.utils.rememberEnumPreference
 import moe.rukamori.archivetune.utils.rememberPreference
 import moe.rukamori.archivetune.utils.reportException
 import moe.rukamori.archivetune.utils.setAppLocale
+import moe.rukamori.archivetune.viewmodels.BackupCategory
+import moe.rukamori.archivetune.viewmodels.BackupRestoreViewModel
 import moe.rukamori.archivetune.viewmodels.HomeViewModel
 import moe.rukamori.archivetune.viewmodels.NetworkBannerViewModel
 import moe.rukamori.archivetune.viewmodels.NewsViewModel
@@ -315,6 +320,7 @@ class MainActivity : ComponentActivity() {
     private var pendingDeepLinkQueue: Queue? = null
     private var pendingVoiceSearchQuery: String? = null
     private var pendingTogetherJoinLink: String? = null
+    private var pendingBackupRestoreUri by mutableStateOf<Uri?>(null)
     private var latestVersionName by mutableStateOf(BuildConfig.VERSION_NAME)
     private var latestUpdateChannel by mutableStateOf(defaultUpdateChannel)
 
@@ -451,6 +457,11 @@ class MainActivity : ComponentActivity() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
+        val dataUri = intent.data
+        if (isBackupUri(dataUri)) {
+            pendingBackupRestoreUri = dataUri
+            return
+        }
         if (::navController.isInitialized) {
             handleDeepLinkIntent(intent, navController)
         } else {
@@ -2263,6 +2274,10 @@ class MainActivity : ComponentActivity() {
                         )
                     }
 
+                    pendingBackupRestoreUri?.let { uri ->
+                        BackupRestoreFromIntentDialog(uri = uri)
+                    }
+
                     LaunchedEffect(shouldShowSearchBar, openSearchImmediately) {
                         if (shouldShowSearchBar && openSearchImmediately) {
                             onActiveChange(true)
@@ -2279,11 +2294,22 @@ class MainActivity : ComponentActivity() {
         }
     }
 
+    private fun isBackupUri(uri: Uri?): Boolean {
+        if (uri == null) return false
+        val path = uri.lastPathSegment?.lowercase(Locale.US)
+        return path?.endsWith(".backup") == true || uri.toString().lowercase(Locale.US).endsWith(".backup")
+    }
+
     private fun handleIntent(
         intent: Intent?,
         navController: NavHostController,
     ) {
         if (intent == null) return
+        val dataUri = intent.data
+        if (isBackupUri(dataUri)) {
+            pendingBackupRestoreUri = dataUri
+            return
+        }
         if (intent.action == ACTION_MUSIC_RECOGNITION) {
             navController.openMusicRecognition()
             return
@@ -2547,6 +2573,101 @@ class MainActivity : ComponentActivity() {
             window.navigationBarColor =
                 (if (isDark) Color.Transparent else Color.Black.copy(alpha = 0.2f)).toArgb()
         }
+    }
+
+    @Composable
+    private fun BackupRestoreFromIntentDialog(
+        uri: Uri,
+        viewModel: BackupRestoreViewModel = hiltViewModel(),
+    ) {
+        var selected by remember { mutableStateOf(BackupCategory.entries.toSet()) }
+
+        AlertDialog(
+            onDismissRequest = { pendingBackupRestoreUri = null },
+            icon = { Icon(painterResource(R.drawable.restore), null) },
+            title = { Text(stringResource(R.string.restore_options_title)) },
+            text = {
+                Column {
+                    BackupCategory.entries.forEach { category ->
+                        val isChecked = category in selected
+                        val labelRes =
+                            when (category) {
+                                BackupCategory.LIBRARY -> R.string.backup_category_library
+                                BackupCategory.ACCOUNT -> R.string.backup_category_account
+                                BackupCategory.SETTINGS -> R.string.backup_category_settings
+                            }
+                        val descRes =
+                            when (category) {
+                                BackupCategory.LIBRARY -> R.string.backup_category_library_desc
+                                BackupCategory.ACCOUNT -> R.string.backup_category_account_desc
+                                BackupCategory.SETTINGS -> R.string.backup_category_settings_desc
+                            }
+                        Surface(
+                            modifier = Modifier.fillMaxWidth(),
+                            shape = MaterialTheme.shapes.medium,
+                            color = Color.Transparent,
+                            onClick = {
+                                selected = if (isChecked) selected - category else selected + category
+                            },
+                        ) {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .heightIn(min = 72.dp)
+                                    .padding(horizontal = 4.dp, vertical = 10.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                            ) {
+                                Column(modifier = Modifier.weight(1f)) {
+                                    Text(
+                                        text = stringResource(labelRes),
+                                        style = MaterialTheme.typography.bodyLarge,
+                                        fontWeight = FontWeight.Medium,
+                                        color = MaterialTheme.colorScheme.onSurface,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis,
+                                    )
+                                    Text(
+                                        text = stringResource(descRes),
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        maxLines = 2,
+                                        overflow = TextOverflow.Ellipsis,
+                                    )
+                                }
+                                androidx.compose.material3.Checkbox(
+                                    checked = isChecked,
+                                    onCheckedChange = { checked ->
+                                        selected = if (checked) selected + category else selected - category
+                                    },
+                                )
+                            }
+                        }
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        val uri = pendingBackupRestoreUri ?: return@TextButton
+                        pendingBackupRestoreUri = null
+                        viewModel.restore(this@MainActivity, uri, selected)
+                    },
+                    enabled = selected.isNotEmpty(),
+                    shapes = ButtonDefaults.shapes(),
+                ) {
+                    Text(stringResource(R.string.action_restore))
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = { pendingBackupRestoreUri = null },
+                    shapes = ButtonDefaults.shapes(),
+                ) {
+                    Text(stringResource(android.R.string.cancel))
+                }
+            },
+        )
     }
 
     companion object {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/RestoreBackupFileActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/RestoreBackupFileActivity.kt
@@ -1,0 +1,313 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package moe.rukamori.archivetune
+
+import android.net.Uri
+import android.os.Bundle
+import android.widget.Toast
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.foundation.background
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import dagger.hilt.android.AndroidEntryPoint
+import moe.rukamori.archivetune.ui.component.DefaultDialog
+import moe.rukamori.archivetune.ui.menu.LoadingScreen
+import moe.rukamori.archivetune.ui.theme.ArchiveTuneTheme
+import moe.rukamori.archivetune.viewmodels.BackupCategory
+import moe.rukamori.archivetune.viewmodels.BackupRestoreViewModel
+
+@AndroidEntryPoint
+class RestoreBackupFileActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val uri = intent?.data
+        if (uri == null) {
+            Toast.makeText(this, R.string.restore_file_not_found, Toast.LENGTH_LONG).show()
+            finish()
+            return
+        }
+        setContent {
+            ArchiveTuneTheme {
+                RestoreBackupFileScreen(
+                    uri = uri,
+                    onNavigateBack = { finish() },
+                )
+            }
+        }
+    }
+}
+
+private sealed class BackupScreenState {
+    data object Validating : BackupScreenState()
+    data class Ready(
+        val availableCategories: Set<BackupCategory>,
+    ) : BackupScreenState()
+    data class Error(val message: String) : BackupScreenState()
+    data object Restoring : BackupScreenState()
+}
+
+@Composable
+private fun RestoreBackupFileScreen(
+    uri: Uri,
+    onNavigateBack: () -> Unit,
+    viewModel: BackupRestoreViewModel = hiltViewModel(),
+) {
+    val context = LocalContext.current
+    var screenState by remember { mutableStateOf<BackupScreenState>(BackupScreenState.Validating) }
+    var selectedCategories by remember { mutableStateOf(BackupCategory.entries.toSet()) }
+    var showRestoreDialog by remember { mutableStateOf(false) }
+
+    val backupRestoreProgress by viewModel.backupRestoreProgress.collectAsStateWithLifecycle()
+
+    LaunchedEffect(uri) {
+        val result = viewModel.validateBackup(context, uri)
+        if (result.isValid) {
+            selectedCategories = result.availableCategories
+            screenState = BackupScreenState.Ready(availableCategories = result.availableCategories)
+            showRestoreDialog = true
+        } else {
+            screenState = BackupScreenState.Error(result.errorMessage ?: context.getString(R.string.restore_corrupted))
+        }
+    }
+
+    when (val state = screenState) {
+        is BackupScreenState.Validating -> {
+            DefaultDialog(
+                onDismiss = onNavigateBack,
+                title = { Text(stringResource(R.string.restore_in_progress)) },
+                buttons = {
+                    TextButton(onClick = onNavigateBack, shapes = ButtonDefaults.shapes()) {
+                        Text(stringResource(android.R.string.cancel))
+                    }
+                },
+            ) {
+                Text(stringResource(R.string.restore_step_verifying))
+            }
+        }
+
+        is BackupScreenState.Error -> {
+            DefaultDialog(
+                onDismiss = onNavigateBack,
+                icon = { Icon(painterResource(R.drawable.alert), null) },
+                title = { Text(stringResource(R.string.restore_failed)) },
+                buttons = {
+                    TextButton(onClick = onNavigateBack, shapes = ButtonDefaults.shapes()) {
+                        Text(stringResource(android.R.string.ok))
+                    }
+                },
+            ) {
+                Text(
+                    text = state.message,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+
+        is BackupScreenState.Ready -> {
+            if (showRestoreDialog) {
+                RestoreOptionsDialog(
+                    title = stringResource(R.string.restore_options_title),
+                    confirmLabel = stringResource(R.string.action_restore),
+                    availableCategories = state.availableCategories,
+                    selected = selectedCategories,
+                    onSelectionChanged = { selectedCategories = it },
+                    onConfirm = {
+                        showRestoreDialog = false
+                        screenState = BackupScreenState.Restoring
+                        viewModel.restore(context, uri, selectedCategories)
+                    },
+                    onDismiss = onNavigateBack,
+                )
+            }
+        }
+
+        is BackupScreenState.Restoring -> {
+            LoadingScreen(
+                isVisible = true,
+                value = backupRestoreProgress?.percent ?: 0,
+                title = backupRestoreProgress?.title,
+                stepText = backupRestoreProgress?.step,
+                indeterminate = backupRestoreProgress?.indeterminate ?: true,
+            )
+        }
+    }
+}
+
+@Composable
+private fun RestoreOptionsDialog(
+    title: String,
+    confirmLabel: String,
+    availableCategories: Set<BackupCategory>,
+    selected: Set<BackupCategory>,
+    onSelectionChanged: (Set<BackupCategory>) -> Unit,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    DefaultDialog(
+        onDismiss = onDismiss,
+        title = { Text(title) },
+        buttons = {
+            TextButton(onClick = onDismiss, shapes = ButtonDefaults.shapes()) {
+                Text(stringResource(android.R.string.cancel))
+            }
+            TextButton(
+                onClick = onConfirm,
+                shapes = ButtonDefaults.shapes(),
+                enabled = selected.isNotEmpty(),
+            ) {
+                Text(confirmLabel)
+            }
+        },
+    ) {
+        Spacer(Modifier.height(8.dp))
+        BackupCategory.entries.forEach { category ->
+            val isChecked = category in selected
+            val isAvailable = category in availableCategories
+            val labelRes =
+                when (category) {
+                    BackupCategory.LIBRARY -> R.string.backup_category_library
+                    BackupCategory.ACCOUNT -> R.string.backup_category_account
+                    BackupCategory.SETTINGS -> R.string.backup_category_settings
+                }
+            val descRes =
+                when (category) {
+                    BackupCategory.LIBRARY -> R.string.backup_category_library_desc
+                    BackupCategory.ACCOUNT -> R.string.backup_category_account_desc
+                    BackupCategory.SETTINGS -> R.string.backup_category_settings_desc
+                }
+            val iconRes =
+                when (category) {
+                    BackupCategory.LIBRARY -> R.drawable.library_music
+                    BackupCategory.ACCOUNT -> R.drawable.account
+                    BackupCategory.SETTINGS -> R.drawable.settings
+                }
+            Surface(
+                modifier = Modifier.fillMaxWidth(),
+                shape = MaterialTheme.shapes.medium,
+                color = Color.Transparent,
+                onClick = {
+                    if (!isAvailable) return@Surface
+                    onSelectionChanged(if (isChecked) selected - category else selected + category)
+                },
+            ) {
+                Row(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .heightIn(min = 72.dp)
+                            .padding(horizontal = 4.dp, vertical = 10.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .size(40.dp)
+                                .clip(MaterialTheme.shapes.large)
+                                .then(
+                                    if (isAvailable) {
+                                        Modifier.background(MaterialTheme.colorScheme.secondaryContainer)
+                                    } else {
+                                        Modifier
+                                    },
+                                ),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Icon(
+                            painter = painterResource(iconRes),
+                            contentDescription = null,
+                            tint =
+                                if (isAvailable) {
+                                    MaterialTheme.colorScheme.onSecondaryContainer
+                                } else {
+                                    MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f)
+                                },
+                            modifier = Modifier.size(24.dp),
+                        )
+                    }
+                    Column(
+                        modifier = Modifier.weight(1f),
+                        verticalArrangement = Arrangement.spacedBy(2.dp),
+                    ) {
+                        Text(
+                            text = stringResource(labelRes),
+                            style = MaterialTheme.typography.bodyLarge,
+                            fontWeight = FontWeight.Medium,
+                            color =
+                                if (isAvailable) {
+                                    MaterialTheme.colorScheme.onSurface
+                                } else {
+                                    MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+                                },
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                        Text(
+                            text = stringResource(descRes),
+                            style = MaterialTheme.typography.bodySmall,
+                            color =
+                                if (isAvailable) {
+                                    MaterialTheme.colorScheme.onSurfaceVariant
+                                } else {
+                                    MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f)
+                                },
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                    Checkbox(
+                        checked = isChecked,
+                        onCheckedChange = { checked ->
+                            if (!isAvailable) return@Checkbox
+                            onSelectionChanged(if (checked) selected + category else selected - category)
+                        },
+                        enabled = isAvailable,
+                    )
+                }
+            }
+        }
+        Spacer(Modifier.height(4.dp))
+    }
+}
+
+

--- a/app/src/main/kotlin/moe/rukamori/archivetune/RestoreBackupFileActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/RestoreBackupFileActivity.kt
@@ -13,6 +13,7 @@ import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -127,7 +128,7 @@ private fun RestoreBackupFileScreen(
         is BackupScreenState.Error -> {
             DefaultDialog(
                 onDismiss = onNavigateBack,
-                icon = { Icon(painterResource(R.drawable.alert), null) },
+                icon = { Icon(painterResource(R.drawable.error), null) },
                 title = { Text(stringResource(R.string.restore_failed)) },
                 buttons = {
                     TextButton(onClick = onNavigateBack, shapes = ButtonDefaults.shapes()) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/BackupAndRestore.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/BackupAndRestore.kt
@@ -144,9 +144,12 @@ fun BackupAndRestore(
     var progressPercentage by rememberSaveable { mutableIntStateOf(0) }
     var showBackupOptionsDialog by rememberSaveable { mutableStateOf(false) }
     var showRestoreOptionsDialog by rememberSaveable { mutableStateOf(false) }
+    var showRestoreValidationError by rememberSaveable { mutableStateOf(false) }
+    var restoreValidationErrorMessage by remember { mutableStateOf("") }
     var showSpotifyLogin by rememberSaveable { mutableStateOf(false) }
     var pendingBackupCategories by remember { mutableStateOf(BackupCategory.entries.toSet()) }
     var pendingRestoreCategories by remember { mutableStateOf(BackupCategory.entries.toSet()) }
+    var pendingRestoreUri by remember { mutableStateOf<Uri?>(null) }
 
     val backupRestoreProgress by viewModel.backupRestoreProgress.collectAsStateWithLifecycle()
     val spotifyState by spotifyAccountViewModel.uiState.collectAsStateWithLifecycle()
@@ -163,7 +166,17 @@ fun BackupAndRestore(
     val restoreLauncher =
         rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
             if (uri != null) {
-                viewModel.restore(context, uri, pendingRestoreCategories)
+                coroutineScope.launch {
+                    val result = viewModel.validateBackup(context, uri)
+                    if (result.isValid) {
+                        pendingRestoreCategories = result.availableCategories
+                        pendingRestoreUri = uri
+                        showRestoreOptionsDialog = true
+                    } else {
+                        restoreValidationErrorMessage = result.errorMessage ?: context.getString(R.string.restore_corrupted)
+                        showRestoreValidationError = true
+                    }
+                }
             }
         }
     val importPlaylistFromCsv =
@@ -216,9 +229,9 @@ fun BackupAndRestore(
             item {
                 PreferenceEntry(
                     title = { Text(stringResource(R.string.action_restore)) },
-                    description = stringResource(R.string.backup_restore_backup_desc),
+                    description = stringResource(R.string.restore_select_backup),
                     icon = { Icon(painterResource(R.drawable.restore), null) },
-                    onClick = { showRestoreOptionsDialog = true },
+                    onClick = { restoreLauncher.launch(arrayOf("application/octet-stream", "application/zip")) },
                 )
             }
 
@@ -288,16 +301,44 @@ fun BackupAndRestore(
     }
 
     if (showRestoreOptionsDialog) {
-        BackupOptionsDialog(
-            title = stringResource(R.string.restore_options_title),
-            confirmLabel = stringResource(R.string.action_restore),
-            onConfirm = { categories ->
-                pendingRestoreCategories = categories
-                showRestoreOptionsDialog = false
-                restoreLauncher.launch(arrayOf("application/octet-stream"))
+        val uri = pendingRestoreUri
+        if (uri != null) {
+            BackupOptionsDialog(
+                title = stringResource(R.string.restore_options_title),
+                confirmLabel = stringResource(R.string.action_restore),
+                onConfirm = { categories ->
+                    pendingRestoreCategories = categories
+                    showRestoreOptionsDialog = false
+                    pendingRestoreUri = null
+                    viewModel.restore(context, uri, categories)
+                },
+                onDismiss = {
+                    showRestoreOptionsDialog = false
+                    pendingRestoreUri = null
+                },
+            )
+        }
+    }
+
+    if (showRestoreValidationError) {
+        DefaultDialog(
+            onDismiss = { showRestoreValidationError = false },
+            title = { Text(stringResource(R.string.restore_failed)) },
+            buttons = {
+                TextButton(
+                    onClick = { showRestoreValidationError = false },
+                    shapes = ButtonDefaults.shapes(),
+                ) {
+                    Text(stringResource(android.R.string.ok))
+                }
             },
-            onDismiss = { showRestoreOptionsDialog = false },
-        )
+        ) {
+            Text(
+                text = restoreValidationErrorMessage,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
     }
 
     if (showSpotifyLogin) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/BackupRestoreViewModel.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/BackupRestoreViewModel.kt
@@ -69,6 +69,12 @@ enum class BackupCategory {
     SETTINGS,
 }
 
+data class BackupValidationResult(
+    val isValid: Boolean,
+    val availableCategories: Set<BackupCategory>,
+    val errorMessage: String?,
+)
+
 internal fun readCsvRecords(reader: Reader): Sequence<List<String>> =
     sequence {
         val pushbackReader = if (reader is PushbackReader) reader else PushbackReader(reader, 1)
@@ -723,6 +729,70 @@ class BackupRestoreViewModel
             }
 
             return songs
+        }
+
+        suspend fun validateBackup(
+            context: Context,
+            uri: Uri,
+        ): BackupValidationResult = withContext(Dispatchers.IO) {
+            try {
+                val stream =
+                    context.applicationContext.contentResolver.openInputStream(uri)
+                if (stream == null) {
+                    return@withContext BackupValidationResult(
+                        isValid = false,
+                        availableCategories = emptySet(),
+                        errorMessage = context.getString(R.string.restore_file_not_found),
+                    )
+                }
+                stream.use { inputStream ->
+                    val zipStream = inputStream.zipInputStream()
+                    val entryNames = mutableSetOf<String>()
+                    zipStream.use { zip ->
+                        var entry = zip.nextEntry
+                        while (entry != null) {
+                            entryNames.add(entry.name)
+                            entry = zip.nextEntry
+                        }
+                    }
+                    if (entryNames.isEmpty()) {
+                        return@withContext BackupValidationResult(
+                            isValid = false,
+                            availableCategories = emptySet(),
+                            errorMessage = context.getString(R.string.restore_invalid_file),
+                        )
+                    }
+                    val categories = mutableSetOf<BackupCategory>()
+                    val hasSettings = SETTINGS_XML_FILENAME in entryNames || SETTINGS_FILENAME in entryNames
+                    val hasDb = entryNames.any { it.startsWith(InternalDatabase.DB_NAME) }
+                    if (hasSettings) {
+                        categories.add(BackupCategory.SETTINGS)
+                        categories.add(BackupCategory.ACCOUNT)
+                    }
+                    if (hasDb) {
+                        categories.add(BackupCategory.LIBRARY)
+                    }
+                    if (categories.isEmpty()) {
+                        return@withContext BackupValidationResult(
+                            isValid = false,
+                            availableCategories = emptySet(),
+                            errorMessage = context.getString(R.string.restore_missing_content),
+                        )
+                    }
+                    BackupValidationResult(
+                        isValid = true,
+                        availableCategories = categories,
+                        errorMessage = null,
+                    )
+                }
+            } catch (e: Exception) {
+                reportException(e)
+                BackupValidationResult(
+                    isValid = false,
+                    availableCategories = emptySet(),
+                    errorMessage = context.getString(R.string.restore_corrupted),
+                )
+            }
         }
 
         companion object {

--- a/app/src/main/res/values-ja/archivetune_strings.xml
+++ b/app/src/main/res/values-ja/archivetune_strings.xml
@@ -451,4 +451,10 @@
     <string name="about_content_desc_discord">Discord</string>
     <string name="about_content_desc_telegram">Telegram</string>
     <string name="about_content_desc_donate">寄付</string>
+    <string name="restore_invalid_file">選択されたファイルは有効なバックアップアーカイブではありません。</string>
+    <string name="restore_missing_content">バックアップアーカイブに復元可能なデータが含まれていません。</string>
+    <string name="restore_corrupted">バックアップファイルが破損しているため、読み取れません。</string>
+    <string name="restore_file_not_found">選択されたファイルを開けませんでした。</string>
+    <string name="backup_select_backup">バックアップファイルを選択</string>
+    <string name="restore_select_backup">復元するバックアップファイルを選択してください。</string>
 </resources>

--- a/app/src/main/res/values-vi/archivetune_strings.xml
+++ b/app/src/main/res/values-vi/archivetune_strings.xml
@@ -589,6 +589,12 @@
     <string name="internal_service">Dịch vụ nội bộ</string>
     <string name="external_service">Dịch vụ bên ngoài</string>
     <!-- Backup data safety -->
+    <string name="restore_invalid_file">Tệp đã chọn không phải là tệp sao lưu hợp lệ.</string>
+    <string name="restore_missing_content">Tệp sao lưu không chứa dữ liệu có thể khôi phục.</string>
+    <string name="restore_corrupted">Tệp sao lưu có vẻ bị hỏng và không thể đọc được.</string>
+    <string name="restore_file_not_found">Không thể mở tệp đã chọn.</string>
+    <string name="backup_select_backup">Chọn Tệp Sao lưu</string>
+    <string name="restore_select_backup">Chọn tệp sao lưu để khôi phục.</string>
     <string name="backup_data_safety">An toàn dữ liệu</string>
     <string name="backup_data_safety_desc">Tạo bản sao lưu di động hoặc khôi phục dữ liệu ứng dụng đã chọn.</string>
     <string name="backup_data_formats">Lưu trữ .backup</string>

--- a/app/src/main/res/values/archivetune_strings.xml
+++ b/app/src/main/res/values/archivetune_strings.xml
@@ -562,6 +562,12 @@
     <string name="backup_category_account_desc">YouTube, Spotify, Last.fm, Libre.fm, Discord &amp; proxy credentials</string>
     <string name="internal_service">Internal Service</string>
     <string name="external_service">External Service</string>
+    <string name="restore_invalid_file">The selected file is not a valid backup archive.</string>
+    <string name="restore_missing_content">The backup archive does not contain any restorable data.</string>
+    <string name="restore_corrupted">The backup file appears to be corrupted and could not be read.</string>
+    <string name="restore_file_not_found">Could not open the selected file.</string>
+    <string name="backup_select_backup">Select Backup File</string>
+    <string name="restore_select_backup">Select a backup file to restore.</string>
     <string name="backup_data_safety">Data safety</string>
     <string name="backup_data_safety_desc">Create a portable backup or restore selected app data.</string>
     <string name="backup_data_formats">.backup archive</string>


### PR DESCRIPTION
## Summary

Adds a dedicated  that registers for  file intents, enabling users to open backup files directly from the file explorer.

## Changes

### RestoreBackupFileActivity (new)
- Registers intent filters for  with  and  schemes
- Pre-flight validation: checks ZIP structure for valid backup contents before showing the dialog
- Shows 'What to restore?' dialog with categories auto-detected from the backup archive
- Comprehensive error handling for all edge cases: null URI, unopenable files, corrupt ZIPs, empty archives, unrecognized formats
- Progress display during restore via existing LoadingScreen component

### BackupAndRestore settings (modified)
- Restore flow now: **file picker → validate → dialog → restore** (previously: dialog → file picker → restore)
- Backup file is validated immediately after selection, with error dialog shown for invalid files

### BackupRestoreViewModel (modified)
- New  suspend method for reusable pre-flight validation
- Returns  with available categories and error messages

### AndroidManifest.xml
- Registered  with VIEW intent filters for  files

### String resources
- Added: Strings for Vietnamese and Japanese translate for new feature

## Fallback Coverage

| Edge Case | Handling |
|-----------|----------|
| Null/empty URI | Toast + finish() |
| Can't open input stream | Error dialog |
| Not a valid ZIP | Error dialog via ZipInputStream catch |
| Empty ZIP | Error dialog |
| No recognized data (no settings.xml, no song.db) | Error dialog |
| Corrupted ZIP entry read | Error dialog via exception handler |
| Restore failure | Existing exception handling in restore() method |