### PR TITLE
fix(discord): recover presence after gateway transport invalidation

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/discord/DiscordSocialPresenceClient.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/discord/DiscordSocialPresenceClient.kt
@@ -24,6 +24,9 @@ object DiscordSocialPresenceClient {
     @Volatile private var gateway: GatewayClient? = null
     @Volatile private var activeToken: String? = null
 
+    @Volatile
+    var onTransportInvalidated: ((String) -> Unit)? = null
+
     val isStarted: Boolean
         get() = isConnectionUsable()
 
@@ -199,12 +202,24 @@ object DiscordSocialPresenceClient {
         reason: String,
     ) {
         callbackScope.launch {
+            var invalidated = false
             mutex.withLock {
                 if (gateway === expectedGateway) {
                     tearDownLocked(reason)
+                    invalidated = true
                 }
             }
+            if (invalidated) {
+                notifyTransportInvalidated(reason)
+            }
         }
+    }
+
+    private fun notifyTransportInvalidated(reason: String) {
+        runCatching { onTransportInvalidated?.invoke(reason) }
+            .onFailure { error ->
+                Timber.tag(TAG).w(error, "transport invalidation listener failed")
+            }
     }
 
     private fun cleanNewGateway(newGateway: GatewayClient) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/discord/DiscordSocialPresenceClient.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/discord/DiscordSocialPresenceClient.kt
@@ -23,9 +23,7 @@ object DiscordSocialPresenceClient {
 
     @Volatile private var gateway: GatewayClient? = null
     @Volatile private var activeToken: String? = null
-
-    @Volatile
-    var onTransportInvalidated: ((String) -> Unit)? = null
+    @Volatile private var transportInvalidatedListener: ((String) -> Unit)? = null
 
     val isStarted: Boolean
         get() = isConnectionUsable()
@@ -36,6 +34,10 @@ object DiscordSocialPresenceClient {
         return currentGateway != null &&
             !currentToken.isNullOrBlank() &&
             currentGateway.isReady()
+    }
+
+    fun setOnTransportInvalidated(listener: ((String) -> Unit)?) {
+        transportInvalidatedListener = listener
     }
 
     suspend fun updatePresence(
@@ -216,7 +218,7 @@ object DiscordSocialPresenceClient {
     }
 
     private fun notifyTransportInvalidated(reason: String) {
-        runCatching { onTransportInvalidated?.invoke(reason) }
+        runCatching { transportInvalidatedListener?.invoke(reason) }
             .onFailure { error ->
                 Timber.tag(TAG).w(error, "transport invalidation listener failed")
             }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/discord/DiscordSocialPresenceClient.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/discord/DiscordSocialPresenceClient.kt
@@ -16,14 +16,24 @@ import timber.log.Timber
 
 object DiscordSocialPresenceClient {
     private const val TAG = "DiscordSocialPresenceClient"
+    private const val MAX_SEND_ATTEMPTS = 2
 
     private val mutex = Mutex()
-    private var gateway: GatewayClient? = null
-    private var scope: CoroutineScope? = null
-    private var activeToken: String? = null
+    private val callbackScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    @Volatile private var gateway: GatewayClient? = null
+    @Volatile private var activeToken: String? = null
 
     val isStarted: Boolean
-        get() = activeToken != null
+        get() = isConnectionUsable()
+
+    private fun isConnectionUsable(): Boolean {
+        val currentGateway = gateway
+        val currentToken = activeToken
+        return currentGateway != null &&
+            !currentToken.isNullOrBlank() &&
+            currentGateway.isReady()
+    }
 
     suspend fun updatePresence(
         accessToken: String,
@@ -36,27 +46,41 @@ object DiscordSocialPresenceClient {
                     return@withLock Result.failure(IllegalArgumentException("Discord access token is missing"))
                 }
 
-                val connectResult = ensureConnected(token)
-                if (connectResult.isFailure) return@withLock connectResult
-
                 val presenceJson = buildPresencePayload(token, activity)
-                val sent = gateway?.sendPresenceUpdate(presenceJson) ?: false
-                if (!sent) {
-                    return@withLock Result.failure(Exception("Failed to send presence update"))
+                var lastError: Throwable? = null
+
+                repeat(MAX_SEND_ATTEMPTS) { attempt ->
+                    val connectResult = ensureConnected(token, force = attempt > 0)
+                    if (connectResult.isFailure) return@withLock connectResult
+
+                    val currentGateway = gateway
+                    val sent =
+                        if (currentGateway != null && currentGateway.isReady()) {
+                            currentGateway.sendPresenceUpdate(presenceJson)
+                        } else {
+                            false
+                        }
+
+                    if (sent) {
+                        if (attempt > 0) {
+                            Timber.tag(TAG).i("updatePresence: sent after reconnect attempt=%d", attempt)
+                        }
+                        return@withLock Result.success(Unit)
+                    }
+
+                    lastError = Exception("Failed to send presence update (attempt=$attempt)")
+                    Timber.tag(TAG).w("updatePresence: send failed, reconnecting attempt=%d", attempt)
+                    tearDownLocked("presence_send_failed_$attempt")
                 }
-                Result.success(Unit)
+
+                Result.failure(lastError ?: Exception("Failed to send presence update"))
             }
         }
 
     suspend fun clearPresence(accessToken: String? = null): Result<Unit> =
         withContext(Dispatchers.IO) {
             mutex.withLock {
-                var g = gateway
-                if (g == null && !accessToken.isNullOrBlank()) {
-                    ensureConnected(accessToken)
-                    g = gateway
-                }
-                g ?: return@withLock Result.failure(Exception("Not connected"))
+                val token = accessToken?.trim().orEmpty()
                 val empty =
                     JSONObject().apply {
                         put("activities", JSONArray())
@@ -64,43 +88,146 @@ object DiscordSocialPresenceClient {
                         put("since", JSONObject.NULL)
                         put("status", "online")
                     }
-                g.sendPresenceUpdate(empty)
-                Result.success(Unit)
+
+                var lastError: Throwable? = null
+                repeat(MAX_SEND_ATTEMPTS) { attempt ->
+                    val currentGateway = gateway
+                    if (currentGateway == null || !currentGateway.isReady()) {
+                        if (token.isBlank()) {
+                            return@withLock Result.failure(Exception("Not connected"))
+                        }
+                        val connectResult = ensureConnected(token, force = currentGateway != null || attempt > 0)
+                        if (connectResult.isFailure) return@withLock connectResult
+                    }
+
+                    val activeGateway = gateway
+                    val sent =
+                        if (activeGateway != null && activeGateway.isReady()) {
+                            activeGateway.sendPresenceUpdate(empty)
+                        } else {
+                            false
+                        }
+
+                    if (sent) return@withLock Result.success(Unit)
+
+                    lastError = Exception("Failed to clear presence (attempt=$attempt)")
+                    Timber.tag(TAG).w("clearPresence: send failed, reconnecting attempt=%d", attempt)
+                    tearDownLocked("clear_send_failed_$attempt")
+                    if (token.isBlank()) return@withLock Result.failure(lastError!!)
+                }
+
+                Result.failure(lastError ?: Exception("Failed to clear presence"))
             }
         }
 
     suspend fun close(): Result<Unit> =
         withContext(Dispatchers.IO) {
             mutex.withLock {
-                gateway?.disconnect()
-                gateway = null
-                scope?.cancel()
-                scope = null
-                activeToken = null
+                tearDownLocked("close")
                 DiscordAssetRegistrar.clearCache()
                 Result.success(Unit)
             }
         }
 
-    private fun ensureConnected(token: String): Result<Unit> {
-        if (activeToken == token && gateway != null) return Result.success(Unit)
+    private suspend fun ensureConnected(
+        token: String,
+        force: Boolean = false,
+    ): Result<Unit> {
+        val currentGateway = gateway
+        val currentToken = activeToken
+        if (!force && currentToken == token && currentGateway != null && currentGateway.isReady()) {
+            return Result.success(Unit)
+        }
 
-        gateway?.disconnect()
-        gateway = null
-        scope?.cancel()
-        scope = null
+        if (currentGateway != null) {
+            Timber.tag(TAG).d(
+                "ensureConnected: reconnecting force=%s tokenMatch=%s ready=%s",
+                force,
+                currentToken == token,
+                currentGateway.isReady(),
+            )
+        }
 
-        val newScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        tearDownLocked(if (force) "ensure_force" else "ensure_reconnect")
+
         val newGateway = GatewayClient()
+        attachCallbacks(newGateway)
 
-        return runCatching {
-            runBlocking {
-                newGateway.connect(token)
+        return try {
+            newGateway.connect(token)
+            if (!newGateway.isReady()) {
+                throw IllegalStateException(
+                    "Gateway connected but not ready " +
+                        "(isConnected=${newGateway.isConnected()}, isReady=${newGateway.isReady()})",
+                )
             }
-            scope = newScope
+
             gateway = newGateway
             activeToken = token
+            Timber.tag(TAG).i("ensureConnected: connected token***%s", token.takeLast(6))
+            Result.success(Unit)
+        } catch (e: CancellationException) {
+            cleanNewGateway(newGateway)
+            throw e
+        } catch (e: Exception) {
+            Timber.tag(TAG).e(e, "ensureConnected failed")
+            cleanNewGateway(newGateway)
+            Result.failure(e)
         }
+    }
+
+    private fun attachCallbacks(newGateway: GatewayClient) {
+        newGateway.onClose = { info ->
+            Timber.tag(TAG).w(
+                "gateway closed code=%d reason=%s resumable=%s",
+                info.code,
+                info.reason,
+                info.resumable,
+            )
+            invalidateGatewayAsync(newGateway, "gateway_closed_${info.code}")
+        }
+        newGateway.onError = { error ->
+            Timber.tag(TAG).w(error, "gateway error")
+        }
+        newGateway.onReady = {
+            Timber.tag(TAG).d("gateway ready")
+        }
+    }
+
+    private fun invalidateGatewayAsync(
+        expectedGateway: GatewayClient,
+        reason: String,
+    ) {
+        callbackScope.launch {
+            mutex.withLock {
+                if (gateway === expectedGateway) {
+                    tearDownLocked(reason)
+                }
+            }
+        }
+    }
+
+    private fun cleanNewGateway(newGateway: GatewayClient) {
+        newGateway.onClose = null
+        newGateway.onError = null
+        newGateway.onReady = null
+        newGateway.onDebug = null
+        runCatching { newGateway.disconnect() }
+    }
+
+    // must be called with mutex held
+    private fun tearDownLocked(reason: String) {
+        val currentGateway = gateway
+        if (currentGateway != null) {
+            Timber.tag(TAG).d("tearDownLocked: %s", reason)
+            currentGateway.onClose = null
+            currentGateway.onError = null
+            currentGateway.onReady = null
+            currentGateway.onDebug = null
+            runCatching { currentGateway.disconnect() }
+        }
+        gateway = null
+        activeToken = null
     }
 
     private suspend fun buildPresencePayload(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/discord/GatewayClient.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/discord/GatewayClient.kt
@@ -13,6 +13,7 @@ import okhttp3.*
 import org.json.JSONArray
 import org.json.JSONObject
 import timber.log.Timber
+import java.util.concurrent.atomic.AtomicLong
 import kotlin.random.Random
 
 private sealed class GatewayFrame {
@@ -31,8 +32,8 @@ class GatewayClient {
         private const val TAG = "GatewayClient"
     }
 
-    private var httpClient: OkHttpClient? = null
-    private var wsSession: WebSocket? = null
+    @Volatile private var httpClient: OkHttpClient? = null
+    @Volatile private var wsSession: WebSocket? = null
     private var processingJob: Job? = null
     private var heartbeatJob: Job? = null
     private var helloTimerJob: Job? = null
@@ -46,7 +47,10 @@ class GatewayClient {
     private var sessionState: GatewaySessionState? = null
     private var liveSeq = 0
     private var token = ""
-    private var closed = false
+    @Volatile private var closed = false
+    @Volatile private var readyReceived = false
+    private val connectionGeneration = AtomicLong(0L)
+    @Volatile private var activeConnectionGeneration: Long = 0L
 
     var onReady: ((GatewayReadyEvent) -> Unit)? = null
     var onClose: ((GatewayCloseInfo) -> Unit)? = null
@@ -55,6 +59,12 @@ class GatewayClient {
 
     val latency: Int get() = ping
 
+    fun isConnected(): Boolean =
+        wsSession != null && !closed && processingJob?.isActive == true
+
+    fun isReady(): Boolean =
+        isConnected() && readyReceived
+
     suspend fun connect(accessToken: String) {
         if (wsSession != null) throw IllegalStateException("GatewayClient already connected")
 
@@ -62,6 +72,7 @@ class GatewayClient {
         sessionState = null
         liveSeq = 0
         closed = false
+        readyReceived = false
         lastAck = true
 
         val url = "${GatewayDefaults.GATEWAY_URL}/?v=${GatewayDefaults.GATEWAY_VERSION}&encoding=json"
@@ -80,6 +91,9 @@ class GatewayClient {
                 .url(url)
                 .build()
 
+        val generation = connectionGeneration.incrementAndGet()
+        activeConnectionGeneration = generation
+
         wsSession =
             httpClient!!.newWebSocket(
                 request,
@@ -89,13 +103,18 @@ class GatewayClient {
                         response: Response,
                     ) {
                         response.close()
+                        if (!isActiveGeneration(generation)) {
+                            webSocket.close(1000, "stale")
+                            return
+                        }
                     }
 
                     override fun onMessage(
                         webSocket: WebSocket,
                         text: String,
                     ) {
-                        scope.launch { incomingChannel.send(GatewayFrame.Text(text)) }
+                        if (!isActiveGeneration(generation)) return
+                        publishFrame(GatewayFrame.Text(text))
                     }
 
                     override fun onClosing(
@@ -103,7 +122,8 @@ class GatewayClient {
                         code: Int,
                         reason: String,
                     ) {
-                        scope.launch { incomingChannel.send(GatewayFrame.Close(code, reason)) }
+                        if (!isActiveGeneration(generation)) return
+                        publishFrame(GatewayFrame.Close(code, reason))
                     }
 
                     override fun onClosed(
@@ -111,7 +131,8 @@ class GatewayClient {
                         code: Int,
                         reason: String,
                     ) {
-                        scope.launch { incomingChannel.send(GatewayFrame.Close(code, reason)) }
+                        if (!isActiveGeneration(generation)) return
+                        publishFrame(GatewayFrame.Close(code, reason))
                     }
 
                     override fun onFailure(
@@ -119,8 +140,15 @@ class GatewayClient {
                         t: Throwable,
                         response: Response?,
                     ) {
+                        if (!isActiveGeneration(generation)) return
                         response?.close()
                         onError?.invoke(t)
+                        publishFrame(
+                            GatewayFrame.Close(
+                                response?.code ?: 4000,
+                                t.message ?: "failure",
+                            ),
+                        )
                     }
                 },
             )
@@ -129,7 +157,7 @@ class GatewayClient {
             scope.launch {
                 delay(GatewayDefaults.HELLO_TIMEOUT_MS)
                 debug("HELLO timeout")
-                wsSession?.close(4009, "HELLO timeout")
+                forceClose(4009, "HELLO timeout")
                 ready.completeExceptionally(Exception("HELLO timeout"))
             }
 
@@ -149,9 +177,12 @@ class GatewayClient {
                                         Exception("Gateway closed before ready"),
                                     )
                                 }
+                                return@launch
                             }
                         }
                     }
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     if (!ready.isCompleted) ready.completeExceptionally(e)
                     onError?.invoke(e)
@@ -161,35 +192,47 @@ class GatewayClient {
         ready.await()
     }
 
-    fun sendPresenceUpdate(presenceJson: JSONObject): Boolean = send(GatewayOp.PRESENCE_UPDATE, presenceJson)
+    fun sendPresenceUpdate(presenceJson: JSONObject): Boolean =
+        sendFrame(GatewayOp.PRESENCE_UPDATE, presenceJson, requireReady = true)
 
     fun disconnect() {
-        closed = true
-        stopHeartbeat()
-        helloTimerJob?.cancel()
-        processingJob?.cancel()
-        scope.launch {
-            wsSession?.close(1000, "Client disconnect")
-            wsSession = null
-            httpClient?.dispatcher?.executorService?.shutdown()
-            httpClient = null
-        }
+        shutdownTransport(
+            closeCode = 1000,
+            closeReason = "Client disconnect",
+            cancelProcessing = true,
+        )
     }
 
     private fun send(
         op: Int,
         d: Any?,
+    ): Boolean = sendFrame(op, d, requireReady = false)
+
+    private fun sendFrame(
+        op: Int,
+        d: Any?,
+        requireReady: Boolean,
     ): Boolean {
-        val session = wsSession ?: return false
-        scope.launch {
-            try {
-                val jsonStr = buildJsonString(op, d)
-                session.send(jsonStr)
-            } catch (e: Exception) {
-                onError?.invoke(e)
-            }
+        if (closed || wsSession == null || processingJob?.isActive != true) {
+            debug("sendFrame skipped: not connected op=$op")
+            return false
         }
-        return true
+        if (requireReady && !readyReceived) {
+            debug("sendFrame skipped: gateway not ready op=$op")
+            return false
+        }
+
+        val session = wsSession ?: return false
+        return try {
+            val sent = session.send(buildJsonString(op, d))
+            if (!sent) {
+                debug("sendFrame failed: WebSocket.send returned false op=$op")
+            }
+            sent
+        } catch (e: Exception) {
+            onError?.invoke(e)
+            false
+        }
     }
 
     private fun buildJsonString(
@@ -230,6 +273,7 @@ class GatewayClient {
             when (op) {
                 GatewayOp.HELLO -> {
                     helloTimerJob?.cancel()
+                    helloTimerJob = null
                     val dObj = d as JSONObject
                     val interval = dObj.getInt("heartbeat_interval")
                     startHeartbeat(interval.toLong())
@@ -285,6 +329,7 @@ class GatewayClient {
                 debug("READY: user=${re.user.username} (${re.user.id}) session=${re.sessionId}")
                 sessionState = GatewaySessionState(re.sessionId, liveSeq, re.resumeGatewayUrl)
                 touchSession(re.sessionId, liveSeq, re.resumeGatewayUrl)
+                readyReceived = true
                 ready.complete(Unit)
                 onReady?.invoke(re)
             }
@@ -296,6 +341,7 @@ class GatewayClient {
                     liveSeq,
                     sessionState?.resumeGatewayUrl,
                 )
+                readyReceived = true
                 ready.complete(Unit)
             }
 
@@ -377,7 +423,10 @@ class GatewayClient {
         code: Int,
         reason: String,
     ) {
-        scope.launch { wsSession?.close(code, reason) }
+        val session = wsSession
+        if (session == null || !session.close(code, reason)) {
+            publishFrame(GatewayFrame.Close(code, reason))
+        }
     }
 
     private fun handleClose(
@@ -385,13 +434,16 @@ class GatewayClient {
         code: Int,
     ) {
         if (closed) return
-        closed = true
-        stopHeartbeat()
-        helloTimerJob?.cancel()
         val fatal = NON_RESUMABLE_CLOSE_CODES.contains(code)
         val snapshot = sessionState?.copy(seq = liveSeq)
         if (fatal) sessionState = null
-        wsSession = null
+
+        shutdownTransport(
+            closeCode = null,
+            closeReason = null,
+            cancelProcessing = false,
+        )
+
         onClose?.invoke(
             GatewayCloseInfo(
                 code = code,
@@ -401,6 +453,44 @@ class GatewayClient {
             ),
         )
         debug("close code=$code reason=$reason resumable=${!fatal && snapshot != null}")
+    }
+
+    private fun shutdownTransport(
+        closeCode: Int?,
+        closeReason: String?,
+        cancelProcessing: Boolean,
+    ) {
+        closed = true
+        readyReceived = false
+        stopHeartbeat()
+        helloTimerJob?.cancel()
+        helloTimerJob = null
+        activeConnectionGeneration = connectionGeneration.incrementAndGet()
+
+        val session = wsSession
+        wsSession = null
+        val client = httpClient
+        httpClient = null
+
+        if (cancelProcessing) {
+            processingJob?.cancel()
+            processingJob = null
+        }
+
+        if (closeCode != null) {
+            runCatching { session?.close(closeCode, closeReason ?: "") }
+        }
+        runCatching { client?.dispatcher?.executorService?.shutdown() }
+    }
+
+    private fun isActiveGeneration(generation: Long): Boolean =
+        generation == activeConnectionGeneration
+
+    private fun publishFrame(frame: GatewayFrame) {
+        val result = incomingChannel.trySend(frame)
+        if (result.isFailure) {
+            result.exceptionOrNull()?.let { onError?.invoke(it) }
+        }
     }
 
     private fun debug(msg: String) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/discord/GatewayClient.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/discord/GatewayClient.kt
@@ -34,7 +34,7 @@ class GatewayClient {
 
     @Volatile private var httpClient: OkHttpClient? = null
     @Volatile private var wsSession: WebSocket? = null
-    private var processingJob: Job? = null
+    @Volatile private var processingJob: Job? = null
     private var heartbeatJob: Job? = null
     private var helloTimerJob: Job? = null
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
@@ -1895,7 +1895,6 @@ class MusicService :
             try {
                 DiscordPresenceManager.stop()
                 DiscordPresenceManager.start(
-                    context = this@MusicService,
                     token = key,
                     onTransportInvalidated = { reason ->
                         Timber.tag(DISCORD_SYNC_TAG).w(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
@@ -1897,6 +1897,16 @@ class MusicService :
                 DiscordPresenceManager.start(
                     context = this@MusicService,
                     token = key,
+                    onTransportInvalidated = { reason ->
+                        Timber.tag(DISCORD_SYNC_TAG).w(
+                            "transport invalidated reason=%s; requesting forced sync",
+                            reason,
+                        )
+                        requestDiscordSync(
+                            reason = "transport_invalidated:$reason",
+                            force = true,
+                        )
+                    },
                 )
                 Timber.tag("MusicService").d("Presence manager started")
                 lastPresenceToken = key

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DiscordPresenceManager.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DiscordPresenceManager.kt
@@ -15,7 +15,6 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
@@ -42,11 +41,9 @@ object DiscordPresenceManager {
     private val rpcMutex = Mutex()
     private val cleanupScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
-    private var scope: CoroutineScope? = null
     private var lifecycleObserver: LifecycleEventObserver? = null
     private var rpcInstance: DiscordRPC? = null
     private var rpcToken: String? = null
-    @Volatile private var transportInvalidatedListener: ((String) -> Unit)? = null
 
     private var consecutiveFailures = 0
 
@@ -198,21 +195,23 @@ object DiscordPresenceManager {
         }
 
     fun start(
-        context: Context,
         token: String,
         onTransportInvalidated: ((String) -> Unit)? = null,
     ) {
-        if (onTransportInvalidated != null) {
-            transportInvalidatedListener = onTransportInvalidated
-        }
-        DiscordSocialPresenceClient.onTransportInvalidated = { reason ->
-            Timber.tag(LOG_TAG).w("transport invalidated: %s", reason)
-            transportInvalidatedListener?.invoke(reason)
-        }
+        val transportListener = onTransportInvalidated
+        DiscordSocialPresenceClient.setOnTransportInvalidated(
+            if (transportListener == null) {
+                null
+            } else {
+                { reason ->
+                    Timber.tag(LOG_TAG).w("transport invalidated: %s", reason)
+                    transportListener(reason)
+                }
+            },
+        )
 
         if (!started.getAndSet(true)) {
             consecutiveFailures = 0
-            scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
             lifecycleObserver =
                 LifecycleEventObserver { _, event ->
                     if (event == Lifecycle.Event.ON_DESTROY) {
@@ -274,10 +273,7 @@ object DiscordPresenceManager {
         if (!started.getAndSet(false)) return
 
         updateGeneration.incrementAndGet()
-        DiscordSocialPresenceClient.onTransportInvalidated = null
-        transportInvalidatedListener = null
-        scope?.cancel()
-        scope = null
+        DiscordSocialPresenceClient.setOnTransportInvalidated(null)
 
         lifecycleObserver?.let { observer ->
             ProcessLifecycleOwner.get().lifecycle.removeObserver(observer)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DiscordPresenceManager.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DiscordPresenceManager.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import moe.rukamori.archivetune.db.entities.Song
 import moe.rukamori.archivetune.discord.DiscordOAuthRepository
+import moe.rukamori.archivetune.discord.DiscordSocialPresenceClient
 import moe.rukamori.archivetune.utils.DiscordImageResolver
 import moe.rukamori.archivetune.utils.DiscordRPC
 import timber.log.Timber
@@ -45,6 +46,7 @@ object DiscordPresenceManager {
     private var lifecycleObserver: LifecycleEventObserver? = null
     private var rpcInstance: DiscordRPC? = null
     private var rpcToken: String? = null
+    @Volatile private var transportInvalidatedListener: ((String) -> Unit)? = null
 
     private var consecutiveFailures = 0
 
@@ -198,7 +200,16 @@ object DiscordPresenceManager {
     fun start(
         context: Context,
         token: String,
+        onTransportInvalidated: ((String) -> Unit)? = null,
     ) {
+        if (onTransportInvalidated != null) {
+            transportInvalidatedListener = onTransportInvalidated
+        }
+        DiscordSocialPresenceClient.onTransportInvalidated = { reason ->
+            Timber.tag(LOG_TAG).w("transport invalidated: %s", reason)
+            transportInvalidatedListener?.invoke(reason)
+        }
+
         if (!started.getAndSet(true)) {
             consecutiveFailures = 0
             scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
@@ -263,6 +274,8 @@ object DiscordPresenceManager {
         if (!started.getAndSet(false)) return
 
         updateGeneration.incrementAndGet()
+        DiscordSocialPresenceClient.onTransportInvalidated = null
+        transportInvalidatedListener = null
         scope?.cancel()
         scope = null
 


### PR DESCRIPTION
# Pull Request

## Summary

Harden the Discord Gateway transport so ArchiveTune no longer treats a stale websocket as an active Rich Presence session. The low-level gateway now exposes explicit connected/READY health, reports failed sends honestly, tears down terminal transports synchronously, and invalidates stale callbacks by connection generation. When a remote gateway close invalidates the transport, the presence manager asks `MusicService` for a forced fresh Discord sync so the current song/progress is re-rendered and re-published instead of replaying stale payload data.

## Linked Work

- Closes: -
- Related: #899

## Change Type

- [ ] Feature
- [x] Bug fix
- [ ] UI / UX
- [x] Performance / memory
- [ ] Playback / Media3
- [ ] Lyrics / provider integration
- [ ] Search / YouTube / network data
- [ ] Local library / Room database
- [ ] Widgets / notification / shortcuts
- [ ] Settings / preferences / DataStore
- [x] Discord / Last.fm / ListenBrainz / external integration
- [ ] Localization / strings / fastlane metadata
- [ ] Build / Gradle / CI / release packaging
- [ ] Dependency update
- [ ] Documentation only

## Affected Surfaces

- [x] `:app`
- [ ] `:core`
- [ ] `:lyrics`
- [ ] `:lastfm`
- [ ] `:canvas`
- [ ] `:shazamkit`
- [ ] `:spotifycore`
- [ ] Other:

## Screenshots / Recordings

Not applicable; no UI changes.

| Before | After |
| --- | --- |
| N/A | N/A |

## Behavior Notes

- `DiscordSocialPresenceClient.isStarted` now reflects a usable READY gateway instead of only checking whether an access token is retained.
- Presence updates reconnect once when the existing gateway is unhealthy or a send fails.
- Clear presence also verifies gateway readiness and can reconnect with the supplied token before clearing.
- Remote gateway close/failure invalidates the retained transport without blocking OkHttp callback threads.
- Transport invalidation is propagated to `DiscordPresenceManager`, which lets `MusicService` request a forced Discord sync.
- Forced sync rebuilds the current presence from fresh playback state, so song progress/timestamps are not replayed from an old JSON payload.
- Client-initiated teardown clears callbacks before disconnecting, so user disable/logout/service-stop paths should not trigger a forced visible re-sync.

## Architecture Checklist

- [ ] The change preserves UDF flow: UI -> ViewModel -> UseCase/domain -> Repository/data.
- [ ] Screen state is represented structurally with `Loading`, `Success`, `Empty`, and `Error` where this PR introduces or changes screen state.
- [ ] Composables receive immutable, UI-specific domain models instead of raw Room, network, or service entities.
- [x] Business work is not triggered directly from composition.
- [x] Exceptions are surfaced through explicit state or result types instead of being swallowed.
- [x] No `runBlocking` is introduced in app execution paths.

## Compose / Material Checklist

- [ ] UI state is hoisted out of composable layout code.
- [ ] Reactive state is collected with `collectAsStateWithLifecycle()`.
- [ ] New UI models are annotated with `@Immutable` or `@Stable`.
- [ ] Lazy layouts use stable `key` values and explicit `contentType`.
- [ ] Non-primitive constants, structural lambdas, and allocation-heavy objects in hot paths are remembered.
- [ ] Rapidly changing inputs such as scroll, gesture, animation, or playback progress use `derivedStateOf` where appropriate.
- [ ] UI strings come from `stringResource()` and duplicated visible strings on the same screen are avoided.
- [ ] Interactive elements keep a minimum 48dp touch target.
- [ ] Material 3 / Material 3 Expressive tokens are used for color, typography, shape, and motion instead of hardcoded UI values.
- [ ] Edge-to-edge layouts handle and consume `WindowInsets` correctly when this PR changes screen layout.

Not applicable; no Compose/UI surface changes.

## Concurrency / Performance Checklist

- [x] Business coroutines are scoped to `viewModelScope` or an existing lifecycle-owned application/service scope.
- [x] Disk, database, network, parsing, and heavy mapping work is dispatched to `Dispatchers.IO` or `Dispatchers.Default`.
- [x] Cancellation is handled explicitly where long-running work, playback, downloads, sync, lyrics fetching, or recognition is involved.
- [x] The change avoids blocking the main thread.
- [x] The change avoids unnecessary allocations in recomposition loops, playback loops, polling loops, and provider parsing paths.
- [x] Large lists, images, lyrics payloads, and network responses are bounded, streamed, cached, paged, or mapped off the main thread as appropriate.

## Data / Persistence Checklist

- [ ] Room entity, DAO, or database changes include a schema update under `app/schemas`.
- [ ] Database migrations preserve existing user data and fail clearly when migration is impossible.
- [ ] DataStore or preference-key changes are backward compatible.
- [ ] Network DTOs remain isolated from UI models.
- [ ] Provider responses handle missing, malformed, regional, or rate-limited data without crashing the app.

Not applicable; no database, DataStore, DTO, or persistence changes.

## Playback / Integration Checklist

- [x] Media3 playback, queue, cache, and service behavior remains stable across foreground, background, notification, and process recreation paths.
- [ ] Audio focus, notification controls, widgets, shortcuts, and media session actions are considered when playback behavior changes.
- [x] External integrations handle absent credentials, revoked auth, network failure, and API changes.
- [ ] Native, AAR, or ABI-sensitive changes account for mobile/tv and `universal`, `arm64`, `armeabi`, `x86`, and `x86_64` variants.

## Localization / Assets Checklist

- [ ] User-facing strings are added to the base resources and translated resources are updated or intentionally left for translation follow-up.
- [ ] Unused string resources, drawables, and metadata are removed when replaced.
- [ ] Image assets have explicit display dimensions and are decoded at the displayed size.
- [ ] Fastlane metadata, screenshots, icons, or release text are updated when user-facing store behavior changes.

Not applicable; no strings, assets, or metadata changes.

## Privacy / Security Checklist

- [x] No secrets, keys, tokens, keystores, signing files, private certificates, or local machine paths are committed.
- [x] Logs do not expose access tokens, cookies, auth headers, user identifiers, listening history, or local file paths.
- [x] New network calls are justified by the feature and use existing client, proxy, timeout, and error-handling patterns.
- [x] User data remains local unless the PR explicitly documents the integration and consent path.

## Verification

- [ ] Android Studio sync:
- [x] Manual device/emulator verification: Tested on Poco X7 Pro
- [ ] UI screenshot/recording attached: Not applicable; no UI changes.
- [ ] Accessibility or touch-target review: Not applicable; no UI changes.
- [x] Regression areas checked: Static review of Discord gateway liveness, failed send, remote close, clear/stop, and forced sync paths.
- [x] CI expectation: Existing PR CI should cover compile/build; no Gradle build was run locally for this patch.

## Reviewer Focus

- `DiscordSocialPresenceClient.kt`
  - health-aware `isStarted`
  - retry/reconnect behavior in `updatePresence()` and `clearPresence()`
  - async transport invalidation callback delivered after the mutex is released
- `GatewayClient.kt`
  - READY/connected health checks
  - synchronous shutdown and generation guard behavior
  - honest `WebSocket.send(...)` result handling
  - `processingJob` visibility in `isConnected()` / `sendFrame()`
- `DiscordPresenceManager.kt` and `MusicService.kt`
  - transport invalidation listener lifecycle
  - forced sync path and decision-dedupe bypass
  - stop/disable/logout paths should not revive cleared presence

## Release Notes

Improves Discord Rich Presence reliability after idle gateway disconnects or stale websocket sessions.