### PR TITLE
refactor(settings): standardize settings header scroll behavior

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -1174,15 +1174,16 @@ class MainActivity : ComponentActivity() {
 
                     LaunchedEffect(navBackStackEntry) {
                         val currentRoute = navBackStackEntry?.destination?.route
-                        val wasOnNonTopLevelScreen =
+                        val wasOnSettingsRootRoute = previousRoute == "settings"
+                        val wasOnScrollResetSourceRoute =
                             previousRoute != null &&
-                                previousRoute !in topLevelScreens &&
+                                (previousRoute !in topLevelScreens || wasOnSettingsRootRoute) &&
                                 previousRoute?.startsWith(OnlineSearchResultRoutePrefix) != true
                         val isReturningToHomeOrLibrary =
                             currentRoute == Screens.Home.route ||
                                 currentRoute == Screens.Library.route
 
-                        if (wasOnNonTopLevelScreen && isReturningToHomeOrLibrary) {
+                        if (wasOnScrollResetSourceRoute && isReturningToHomeOrLibrary) {
                             searchBarScrollBehavior.state.resetHeightOffset()
                             topAppBarScrollBehavior.state.resetHeightOffset()
                         }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -1136,14 +1136,6 @@ class MainActivity : ComponentActivity() {
                                 ).add(WindowInsets(top = AppBarHeight, bottom = bottom))
                         }
 
-                    appBarScrollBehavior(
-                        canScroll = {
-                            navBackStackEntry?.destination?.route?.startsWith(OnlineSearchResultRoutePrefix) == false &&
-                                navBackStackEntry?.destination?.route != Screens.Library.route &&
-                                (playerBottomSheetState.isCollapsed || playerBottomSheetState.isDismissed)
-                        },
-                    )
-
                     val searchBarScrollBehavior =
                         appBarScrollBehavior(
                             canScroll = {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
@@ -393,7 +393,7 @@ fun NavGraphBuilder.navigationBuilder(
         AccountSettings(navController, latestVersionName())
     }
     composable("settings/hidden_playlists") {
-        HiddenPlaylistsScreen(navController, scrollBehavior)
+        HiddenPlaylistsScreen(navController)
     }
     composable("settings/appearance") {
         AppearanceSettings(navController)
@@ -405,7 +405,7 @@ fun NavGraphBuilder.navigationBuilder(
         PalettePickerScreen(navController)
     }
     composable("settings/appearance/lyrics_animations") {
-        LyricsAnimationSettings(navController, scrollBehavior)
+        LyricsAnimationSettings(navController)
     }
     composable("settings/appearance/theme_creator") {
         ThemeCreatorScreen(navController)
@@ -423,13 +423,13 @@ fun NavGraphBuilder.navigationBuilder(
         PlayerSettings(navController)
     }
     composable("settings/storage") {
-        StorageSettings(navController, scrollBehavior)
+        StorageSettings(navController)
     }
     composable("settings/privacy") {
         PrivacySettings(navController)
     }
     composable("settings/backup_restore") {
-        BackupAndRestore(navController, scrollBehavior)
+        BackupAndRestore(navController)
     }
     composable("settings/discord") {
         DiscordSettings(navController)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
@@ -477,7 +477,7 @@ fun NavGraphBuilder.navigationBuilder(
         ChangelogScreen(navController, scrollBehavior, channel = channel)
     }
     composable("settings/about") {
-        AboutScreen(navController, scrollBehavior)
+        AboutScreen(navController)
     }
     composable("settings/po_token") {
         PoTokenScreen(navController, scrollBehavior)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
@@ -420,13 +420,13 @@ fun NavGraphBuilder.navigationBuilder(
         InternetSettings(navController, scrollBehavior)
     }
     composable("settings/player") {
-        PlayerSettings(navController, scrollBehavior)
+        PlayerSettings(navController)
     }
     composable("settings/storage") {
         StorageSettings(navController, scrollBehavior)
     }
     composable("settings/privacy") {
-        PrivacySettings(navController, scrollBehavior)
+        PrivacySettings(navController)
     }
     composable("settings/backup_restore") {
         BackupAndRestore(navController, scrollBehavior)
@@ -435,7 +435,7 @@ fun NavGraphBuilder.navigationBuilder(
         DiscordSettings(navController)
     }
     composable("settings/integration") {
-        IntegrationScreen(navController, scrollBehavior)
+        IntegrationScreen(navController)
     }
     composable("settings/ai_integration") {
         AiIntegrationSettings(navController)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
@@ -396,7 +396,7 @@ fun NavGraphBuilder.navigationBuilder(
         HiddenPlaylistsScreen(navController, scrollBehavior)
     }
     composable("settings/appearance") {
-        AppearanceSettings(navController, scrollBehavior)
+        AppearanceSettings(navController)
     }
     composable("settings/appearance/aod_customized") {
         AodCustomizedScreen(navController)
@@ -417,7 +417,7 @@ fun NavGraphBuilder.navigationBuilder(
         LyricsSettings(navController)
     }
     composable("settings/internet") {
-        InternetSettings(navController, scrollBehavior)
+        InternetSettings(navController)
     }
     composable("settings/player") {
         PlayerSettings(navController)
@@ -480,7 +480,7 @@ fun NavGraphBuilder.navigationBuilder(
         AboutScreen(navController)
     }
     composable("settings/po_token") {
-        PoTokenScreen(navController, scrollBehavior)
+        PoTokenScreen(navController)
     }
     composable("customize_background") {
         CustomizeBackground(navController)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
@@ -444,7 +444,7 @@ fun NavGraphBuilder.navigationBuilder(
         MusicTogetherScreen(navController)
     }
     composable("settings/lastfm") {
-        LastFMSettings(navController, scrollBehavior)
+        LastFMSettings(navController)
     }
     composable("settings/discord/experimental") {
         moe.rukamori.archivetune.ui.screens.settings
@@ -474,7 +474,7 @@ fun NavGraphBuilder.navigationBuilder(
             channelName?.let {
                 runCatching { UpdateChannel.valueOf(it) }.getOrNull()
             } ?: defaultUpdateChannel
-        ChangelogScreen(navController, scrollBehavior, channel = channel)
+        ChangelogScreen(navController, channel = channel)
     }
     composable("settings/about") {
         AboutScreen(navController)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
@@ -399,7 +399,7 @@ fun NavGraphBuilder.navigationBuilder(
         AppearanceSettings(navController, scrollBehavior)
     }
     composable("settings/appearance/aod_customized") {
-        AodCustomizedScreen(navController, scrollBehavior)
+        AodCustomizedScreen(navController)
     }
     composable("settings/appearance/palette_picker") {
         PalettePickerScreen(navController)
@@ -432,7 +432,7 @@ fun NavGraphBuilder.navigationBuilder(
         BackupAndRestore(navController, scrollBehavior)
     }
     composable("settings/discord") {
-        DiscordSettings(navController, scrollBehavior)
+        DiscordSettings(navController)
     }
     composable("settings/integration") {
         IntegrationScreen(navController, scrollBehavior)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/NavigationBuilder.kt
@@ -387,10 +387,10 @@ fun NavGraphBuilder.navigationBuilder(
         YouTubeBrowseScreen(navController)
     }
     composable("settings") {
-        SettingsScreen(navController, scrollBehavior, latestVersionName())
+        SettingsScreen(navController, latestVersionName())
     }
     composable("settings/account") {
-        AccountSettings(navController, scrollBehavior, latestVersionName())
+        AccountSettings(navController, latestVersionName())
     }
     composable("settings/hidden_playlists") {
         HiddenPlaylistsScreen(navController, scrollBehavior)
@@ -441,7 +441,7 @@ fun NavGraphBuilder.navigationBuilder(
         AiIntegrationSettings(navController)
     }
     composable("settings/music_together") {
-        MusicTogetherScreen(navController, scrollBehavior)
+        MusicTogetherScreen(navController)
     }
     composable("settings/lastfm") {
         LastFMSettings(navController, scrollBehavior)
@@ -455,7 +455,7 @@ fun NavGraphBuilder.navigationBuilder(
     }
     if (BuildConfig.UPDATER_AVAILABLE) {
         composable("settings/update") {
-            UpdateScreen(navController, scrollBehavior, onUpToDate = onClearUpdateBadge)
+            UpdateScreen(navController, onUpToDate = onClearUpdateBadge)
         }
     }
     composable(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AboutScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AboutScreen.kt
@@ -84,6 +84,7 @@ import coil3.compose.AsyncImage
 import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.ui.component.IconButton
+import moe.rukamori.archivetune.ui.utils.appBarScrollBehavior
 import moe.rukamori.archivetune.ui.utils.backToMain
 import moe.rukamori.archivetune.viewmodels.AboutContributorUiCollection
 import moe.rukamori.archivetune.viewmodels.AboutContributorsUiState
@@ -104,11 +105,15 @@ import moe.rukamori.archivetune.viewmodels.TeamMemberCollection
 @Composable
 fun AboutScreen(
     navController: NavController,
-    scrollBehavior: TopAppBarScrollBehavior,
     viewModel: AboutViewModel = hiltViewModel(),
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val uriHandler = LocalUriHandler.current
+
+    // Scroll behavior dimiliki secara lokal oleh screen ini (pola HistoryScreen),
+    // bukan diwarisi dari MainActivity. Ini memastikan state collapse tidak carry-over
+    // antar-route dan menghindari double-attach nested scroll (lihat scroll-qa-analysis.md H).
+    val scrollBehavior = appBarScrollBehavior()
 
     LaunchedEffect(viewModel, uriHandler) {
         viewModel.effects.collect { effect ->

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AboutScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AboutScreen.kt
@@ -109,10 +109,6 @@ fun AboutScreen(
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val uriHandler = LocalUriHandler.current
-
-    // Scroll behavior dimiliki secara lokal oleh screen ini (pola HistoryScreen),
-    // bukan diwarisi dari MainActivity. Ini memastikan state collapse tidak carry-over
-    // antar-route dan menghindari double-attach nested scroll (lihat scroll-qa-analysis.md H).
     val scrollBehavior = appBarScrollBehavior()
 
     LaunchedEffect(viewModel, uriHandler) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AccountSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AccountSettings.kt
@@ -77,7 +77,6 @@ import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBarDefaults
-import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
@@ -130,6 +129,7 @@ import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.InfoLabel
 import moe.rukamori.archivetune.ui.component.TextFieldDialog
 import moe.rukamori.archivetune.ui.screens.buildLoginRoute
+import moe.rukamori.archivetune.ui.utils.appBarScrollBehavior
 import moe.rukamori.archivetune.ui.utils.backToMain
 import moe.rukamori.archivetune.utils.PreferenceStore
 import moe.rukamori.archivetune.utils.SavedAccount
@@ -159,11 +159,11 @@ private data class SavedAccountCollection(
 @Composable
 fun AccountSettings(
     navController: NavController,
-    scrollBehavior: TopAppBarScrollBehavior,
     latestVersionName: String,
 ) {
     val context = LocalContext.current
     val uriHandler = LocalUriHandler.current
+    val scrollBehavior = appBarScrollBehavior()
 
     val accountLabel = stringResource(R.string.account)
     val generalLabel = stringResource(R.string.general)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AodCustomizedScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AodCustomizedScreen.kt
@@ -104,6 +104,7 @@ import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.PreferenceEntry
 import moe.rukamori.archivetune.ui.component.PreferenceGroup
 import moe.rukamori.archivetune.ui.component.SwitchPreference
+import moe.rukamori.archivetune.ui.utils.appBarScrollBehavior
 import moe.rukamori.archivetune.ui.utils.backToMain
 import moe.rukamori.archivetune.ui.utils.supportsArtworkGlowShadow
 import moe.rukamori.archivetune.ui.utils.toComposeShape
@@ -141,8 +142,8 @@ private data class AodPreviewSettings(
 @Composable
 fun AodCustomizedScreen(
     navController: NavController,
-    scrollBehavior: androidx.compose.material3.TopAppBarScrollBehavior,
 ) {
+    val scrollBehavior = appBarScrollBehavior()
     val (thumbnailShape, onThumbnailShapeChange) =
         rememberEnumPreference(
             AodThumbnailShapeKey,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/AppearanceSettings.kt
@@ -26,9 +26,11 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsPadding
@@ -42,6 +44,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SuggestionChip
@@ -49,7 +52,6 @@ import androidx.compose.material3.SuggestionChipDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -127,7 +129,6 @@ import kotlin.math.roundToInt
 @Composable
 fun AppearanceSettings(
     navController: NavController,
-    scrollBehavior: TopAppBarScrollBehavior,
 ) {
     val context = LocalContext.current
     val defaultDisableAnimations = remember(context) { context.isLowRamDevice() }
@@ -386,12 +387,33 @@ fun AppearanceSettings(
         }
     }
 
-    Column(
-        Modifier
-            .windowInsetsPadding(LocalPlayerAwareWindowInsets.current)
-            .verticalScroll(rememberScrollState())
-            .padding(bottom = SettingsDimensions.ScreenBottomPadding),
-    ) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.appearance)) },
+                navigationIcon = {
+                    IconButton(
+                        onClick = navController::navigateUp,
+                        onLongClick = navController::backToMain,
+                    ) {
+                        Icon(
+                            painterResource(R.drawable.arrow_back),
+                            contentDescription = null,
+                        )
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        val topPadding = innerPadding.calculateTopPadding()
+
+        Column(
+            Modifier
+                .padding(top = topPadding)
+                .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom))
+                .verticalScroll(rememberScrollState())
+                .padding(bottom = SettingsDimensions.ScreenBottomPadding),
+        ) {
         PreferenceGroup(title = stringResource(R.string.theme)) {
             item {
                 SwitchPreference(
@@ -881,22 +903,8 @@ fun AppearanceSettings(
                 )
             }
         }
+        }
     }
-
-    TopAppBar(
-        title = { Text(stringResource(R.string.appearance)) },
-        navigationIcon = {
-            IconButton(
-                onClick = navController::navigateUp,
-                onLongClick = navController::backToMain,
-            ) {
-                Icon(
-                    painterResource(R.drawable.arrow_back),
-                    contentDescription = null,
-                )
-            }
-        },
-    )
 }
 
 @Composable

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/BackupAndRestore.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/BackupAndRestore.kt
@@ -53,13 +53,13 @@ import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -137,7 +137,6 @@ private const val SpotifyLoginUserAgent =
 @Composable
 fun BackupAndRestore(
     navController: NavController,
-    scrollBehavior: TopAppBarScrollBehavior,
     viewModel: BackupRestoreViewModel = hiltViewModel(),
     spotifyAccountViewModel: SpotifyAccountViewModel = hiltViewModel(),
 ) {
@@ -221,10 +220,38 @@ fun BackupAndRestore(
         }
     }
 
-    Box(Modifier.fillMaxSize()) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.backup_restore)) },
+                navigationIcon = {
+                    IconButton(
+                        onClick = navController::navigateUp,
+                        onLongClick = navController::backToMain,
+                    ) {
+                        Icon(
+                            painterResource(R.drawable.arrow_back),
+                            contentDescription = null,
+                        )
+                    }
+                },
+            )
+        },
+        snackbarHost = {
+            SnackbarHost(
+                hostState = snackbarHostState,
+                modifier = Modifier
+                    .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Bottom))
+                    .padding(16.dp),
+            )
+        },
+    ) { innerPadding ->
+        val topPadding = innerPadding.calculateTopPadding()
+
         Column(
             Modifier
-                .windowInsetsPadding(LocalPlayerAwareWindowInsets.current)
+                .padding(top = topPadding)
+                .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom))
                 .verticalScroll(rememberScrollState())
                 .padding(bottom = SettingsDimensions.ScreenBottomPadding),
         ) {
@@ -279,30 +306,6 @@ fun BackupAndRestore(
                 )
             }
         }
-
-        TopAppBar(
-            title = { Text(stringResource(R.string.backup_restore)) },
-            navigationIcon = {
-                IconButton(
-                    onClick = navController::navigateUp,
-                    onLongClick = navController::backToMain,
-                ) {
-                    Icon(
-                        painterResource(R.drawable.arrow_back),
-                        contentDescription = null,
-                    )
-                }
-            },
-            scrollBehavior = scrollBehavior,
-        )
-
-        SnackbarHost(
-            hostState = snackbarHostState,
-            modifier = Modifier
-                .align(Alignment.BottomCenter)
-                .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Bottom))
-                .padding(16.dp),
-        )
     }
 
     if (showBackupOptionsDialog) {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/ChangelogScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/ChangelogScreen.kt
@@ -98,7 +98,7 @@ fun ChangelogScreen(
             modifier =
                 Modifier
                     .fillMaxSize()
-                    .padding(paddingValues)
+                    .padding(top = paddingValues.calculateTopPadding())
                     .windowInsetsPadding(
                         LocalPlayerAwareWindowInsets.current.only(
                             WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/ChangelogScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/ChangelogScreen.kt
@@ -38,7 +38,6 @@ import java.util.Locale
 @Composable
 fun ChangelogScreen(
     navController: NavController,
-    scrollBehavior: TopAppBarScrollBehavior,
     channel: UpdateChannel = UpdateChannel.STABLE,
 ) {
     val coroutineScope = rememberCoroutineScope()
@@ -92,7 +91,6 @@ fun ChangelogScreen(
                         )
                     }
                 },
-                scrollBehavior = scrollBehavior,
             )
         },
     ) { paddingValues ->

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DiscordSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/DiscordSettings.kt
@@ -61,6 +61,7 @@ import moe.rukamori.archivetune.ui.component.PreferenceGroup
 import moe.rukamori.archivetune.ui.component.SwitchPreference
 import moe.rukamori.archivetune.ui.theme.PlayerColorExtractor
 import moe.rukamori.archivetune.ui.theme.extractThemeColor
+import moe.rukamori.archivetune.ui.utils.appBarScrollBehavior
 import moe.rukamori.archivetune.ui.utils.backToMain
 import moe.rukamori.archivetune.utils.ArtworkStorage
 import moe.rukamori.archivetune.utils.discordAlbumMusicUrl
@@ -84,9 +85,9 @@ private val DiscordLargeTextOptions = listOf("song", "artist", "album", "app", "
 @Composable
 fun DiscordSettings(
     navController: NavController,
-    scrollBehavior: TopAppBarScrollBehavior,
 ) {
     val playerConnection = LocalPlayerConnection.current ?: return
+    val scrollBehavior = appBarScrollBehavior()
     val song by playerConnection.currentSong.collectAsStateWithLifecycle(initialValue = null)
     val coroutineScope = rememberCoroutineScope()
     val context = LocalContext.current

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/HiddenPlaylistsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/HiddenPlaylistsScreen.kt
@@ -32,15 +32,12 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
-import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -61,7 +58,6 @@ import moe.rukamori.archivetune.ui.utils.backToMain
 @Composable
 fun HiddenPlaylistsScreen(
     navController: NavController,
-    scrollBehavior: TopAppBarScrollBehavior,
 ) {
     val database = LocalDatabase.current
     val allPlaylists by database.playlists(
@@ -72,7 +68,6 @@ fun HiddenPlaylistsScreen(
     val hiddenPlaylists = allPlaylists.filter { it.playlist.isHidden }
 
     Scaffold(
-        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(R.string.hidden_playlists)) },
@@ -84,11 +79,6 @@ fun HiddenPlaylistsScreen(
                         )
                     }
                 },
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.surface,
-                    scrolledContainerColor = MaterialTheme.colorScheme.surfaceContainer,
-                ),
-                scrollBehavior = scrollBehavior,
             )
         },
     ) { innerPadding ->

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/HiddenPlaylistsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/HiddenPlaylistsScreen.kt
@@ -72,7 +72,10 @@ fun HiddenPlaylistsScreen(
             TopAppBar(
                 title = { Text(stringResource(R.string.hidden_playlists)) },
                 navigationIcon = {
-                    IconButton(onClick = { navController.backToMain() }, onLongClick = {}) {
+                    IconButton(
+                        onClick = navController::navigateUp,
+                        onLongClick = navController::backToMain,
+                    ) {
                         Icon(
                             painter = painterResource(R.drawable.arrow_back),
                             contentDescription = null,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/IntegrationScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/IntegrationScreen.kt
@@ -8,7 +8,6 @@
 package moe.rukamori.archivetune.ui.screens.settings
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
@@ -17,14 +16,13 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.navigation.NavController
@@ -45,32 +43,42 @@ import moe.rukamori.archivetune.utils.rememberPreference
 @Composable
 fun IntegrationScreen(
     navController: NavController,
-    scrollBehavior: TopAppBarScrollBehavior,
 ) {
-    val context = LocalContext.current
-
     val (listenBrainzEnabled, onListenBrainzEnabledChange) = rememberPreference(ListenBrainzEnabledKey, false)
     val (listenBrainzToken, onListenBrainzTokenChange) = rememberPreference(ListenBrainzTokenKey, "")
 
     var showListenBrainzTokenEditor = remember { mutableStateOf(false) }
 
-    Column(
-        Modifier
-            .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom))
-            .verticalScroll(rememberScrollState())
-            .padding(bottom = SettingsDimensions.ScreenBottomPadding),
-    ) {
-        Spacer(
-            Modifier.windowInsetsPadding(
-                LocalPlayerAwareWindowInsets.current.only(
-                    WindowInsetsSides.Top,
-                ),
-            ),
-        )
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.integration)) },
+                navigationIcon = {
+                    IconButton(
+                        onClick = navController::navigateUp,
+                        onLongClick = navController::backToMain,
+                    ) {
+                        Icon(
+                            painterResource(R.drawable.arrow_back),
+                            contentDescription = null,
+                        )
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        val topPadding = innerPadding.calculateTopPadding()
 
-        PreferenceGroup(title = stringResource(R.string.general)) {
-            item {
-                PreferenceEntry(
+        Column(
+            Modifier
+                .padding(top = topPadding)
+                .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom))
+                .verticalScroll(rememberScrollState())
+                .padding(bottom = SettingsDimensions.ScreenBottomPadding),
+        ) {
+            PreferenceGroup(title = stringResource(R.string.general)) {
+                item {
+                    PreferenceEntry(
                     title = { Text(stringResource(R.string.discord_integration)) },
                     icon = { Icon(painterResource(R.drawable.discord), null) },
                     onClick = {
@@ -81,8 +89,8 @@ fun IntegrationScreen(
         }
 
         PreferenceGroup(title = stringResource(R.string.scrobbling)) {
-            item {
-                PreferenceEntry(
+                item {
+                    PreferenceEntry(
                     title = { Text(stringResource(R.string.lastfm_integration)) },
                     icon = { Icon(painterResource(R.drawable.token), null) },
                     onClick = {
@@ -92,7 +100,7 @@ fun IntegrationScreen(
             }
 
             item {
-                SwitchPreference(
+                    SwitchPreference(
                     title = { Text(stringResource(R.string.listenbrainz_scrobbling)) },
                     description = stringResource(R.string.listenbrainz_scrobbling_description),
                     icon = { Icon(painterResource(R.drawable.token), null) },
@@ -102,7 +110,7 @@ fun IntegrationScreen(
             }
 
             item {
-                PreferenceEntry(
+                    PreferenceEntry(
                     title = {
                         Text(
                             if (listenBrainzToken.isBlank()) {
@@ -118,23 +126,9 @@ fun IntegrationScreen(
                     onClick = { showListenBrainzTokenEditor.value = true },
                 )
             }
+            }
         }
     }
-
-    TopAppBar(
-        title = { Text(stringResource(R.string.integration)) },
-        navigationIcon = {
-            IconButton(
-                onClick = navController::navigateUp,
-                onLongClick = navController::backToMain,
-            ) {
-                Icon(
-                    painterResource(R.drawable.arrow_back),
-                    contentDescription = null,
-                )
-            }
-        },
-    )
 
     if (showListenBrainzTokenEditor.value) {
         TextFieldDialog(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/InternetSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/InternetSettings.kt
@@ -18,8 +18,10 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -36,11 +38,11 @@ import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -141,7 +143,6 @@ fun InternetWarningBox(modifier: Modifier = Modifier) {
 @Composable
 fun InternetSettings(
     navController: NavController,
-    scrollBehavior: TopAppBarScrollBehavior,
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -175,12 +176,33 @@ fun InternetSettings(
             else -> stringResource(R.string.ip_rotation_desc)
         }
 
-    Column(
-        Modifier
-            .windowInsetsPadding(LocalPlayerAwareWindowInsets.current)
-            .verticalScroll(rememberScrollState())
-            .padding(bottom = SettingsDimensions.ScreenBottomPadding),
-    ) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.internet)) },
+                navigationIcon = {
+                    IconButton(
+                        onClick = navController::navigateUp,
+                        onLongClick = navController::backToMain,
+                    ) {
+                        Icon(
+                            painterResource(R.drawable.arrow_back),
+                            contentDescription = null,
+                        )
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        val topPadding = innerPadding.calculateTopPadding()
+
+        Column(
+            Modifier
+                .padding(top = topPadding)
+                .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom))
+                .verticalScroll(rememberScrollState())
+                .padding(bottom = SettingsDimensions.ScreenBottomPadding),
+        ) {
         InternetWarningBox()
 
         PreferenceGroup(title = stringResource(R.string.dns_over_https)) {
@@ -406,6 +428,7 @@ fun InternetSettings(
                 )
             }
         }
+        }
     }
 
     if (testingProxy) {
@@ -432,22 +455,6 @@ fun InternetSettings(
             },
         )
     }
-
-    TopAppBar(
-        title = { Text(stringResource(R.string.internet)) },
-        navigationIcon = {
-            IconButton(
-                onClick = navController::navigateUp,
-                onLongClick = navController::backToMain,
-            ) {
-                Icon(
-                    painterResource(R.drawable.arrow_back),
-                    contentDescription = null,
-                )
-            }
-        },
-        scrollBehavior = scrollBehavior,
-    )
 }
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LastFMSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LastFMSettings.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
@@ -35,11 +34,11 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -50,6 +49,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -76,56 +76,62 @@ import kotlin.math.roundToInt
 @Composable
 fun LastFMSettings(
     navController: NavController,
-    scrollBehavior: TopAppBarScrollBehavior,
     viewModel: LastFmSettingsViewModel = hiltViewModel(),
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
 
-    LastFmSettingsContent(
-        state = state,
-        onOpenServiceEditor = viewModel::openServiceEditor,
-        onDismissServiceEditor = viewModel::dismissServiceEditor,
-        onServiceProviderChange = viewModel::updateServiceProvider,
-        onCustomEndpointChange = viewModel::updateCustomEndpoint,
-        onApiKeyOverrideChange = viewModel::updateApiKeyOverride,
-        onSecretOverrideChange = viewModel::updateSecretOverride,
-        onSaveServiceEditor = viewModel::saveServiceEditor,
-        onOpenLoginDialog = viewModel::openLoginDialog,
-        onDismissLoginDialog = viewModel::dismissLoginDialog,
-        onLoginUsernameChange = viewModel::updateLoginUsername,
-        onLoginPasswordChange = viewModel::updateLoginPassword,
-        onLogin = viewModel::login,
-        onLogout = viewModel::logout,
-        onScrobblingChange = viewModel::setScrobblingEnabled,
-        onNowPlayingChange = viewModel::setNowPlayingEnabled,
-        onOpenTimingEditor = viewModel::openTimingEditor,
-        onDismissTimingEditor = viewModel::dismissTimingEditor,
-        onTimingMinTrackDurationChange = viewModel::updateTimingMinTrackDuration,
-        onTimingDelayPercentChange = viewModel::updateTimingDelayPercent,
-        onTimingDelaySecondsChange = viewModel::updateTimingDelaySeconds,
-        onSaveTimingEditor = viewModel::saveTimingEditor,
-    )
-
-    TopAppBar(
-        title = { Text(stringResource(R.string.lastfm_integration)) },
-        navigationIcon = {
-            IconButton(
-                onClick = navController::navigateUp,
-                onLongClick = navController::backToMain,
-            ) {
-                Icon(
-                    painterResource(R.drawable.arrow_back),
-                    contentDescription = null,
-                )
-            }
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.lastfm_integration)) },
+                navigationIcon = {
+                    IconButton(
+                        onClick = navController::navigateUp,
+                        onLongClick = navController::backToMain,
+                    ) {
+                        Icon(
+                            painterResource(R.drawable.arrow_back),
+                            contentDescription = null,
+                        )
+                    }
+                },
+            )
         },
-        scrollBehavior = scrollBehavior,
-    )
+    ) { innerPadding ->
+        val topPadding = innerPadding.calculateTopPadding()
+
+        LastFmSettingsContent(
+            state = state,
+            topPadding = topPadding,
+            onOpenServiceEditor = viewModel::openServiceEditor,
+            onDismissServiceEditor = viewModel::dismissServiceEditor,
+            onServiceProviderChange = viewModel::updateServiceProvider,
+            onCustomEndpointChange = viewModel::updateCustomEndpoint,
+            onApiKeyOverrideChange = viewModel::updateApiKeyOverride,
+            onSecretOverrideChange = viewModel::updateSecretOverride,
+            onSaveServiceEditor = viewModel::saveServiceEditor,
+            onOpenLoginDialog = viewModel::openLoginDialog,
+            onDismissLoginDialog = viewModel::dismissLoginDialog,
+            onLoginUsernameChange = viewModel::updateLoginUsername,
+            onLoginPasswordChange = viewModel::updateLoginPassword,
+            onLogin = viewModel::login,
+            onLogout = viewModel::logout,
+            onScrobblingChange = viewModel::setScrobblingEnabled,
+            onNowPlayingChange = viewModel::setNowPlayingEnabled,
+            onOpenTimingEditor = viewModel::openTimingEditor,
+            onDismissTimingEditor = viewModel::dismissTimingEditor,
+            onTimingMinTrackDurationChange = viewModel::updateTimingMinTrackDuration,
+            onTimingDelayPercentChange = viewModel::updateTimingDelayPercent,
+            onTimingDelaySecondsChange = viewModel::updateTimingDelaySeconds,
+            onSaveTimingEditor = viewModel::saveTimingEditor,
+        )
+    }
 }
 
 @Composable
 private fun LastFmSettingsContent(
     state: LastFmSettingsScreenState,
+    topPadding: Dp,
     onOpenServiceEditor: () -> Unit,
     onDismissServiceEditor: () -> Unit,
     onServiceProviderChange: (LastFmProvider) -> Unit,
@@ -150,16 +156,11 @@ private fun LastFmSettingsContent(
 ) {
     Column(
         Modifier
+            .padding(top = topPadding)
             .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom))
             .verticalScroll(rememberScrollState())
             .padding(bottom = SettingsDimensions.ScreenBottomPadding),
     ) {
-        Spacer(
-            Modifier.windowInsetsPadding(
-                LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Top),
-            ),
-        )
-
         when (state) {
             LastFmSettingsScreenState.Loading -> {
                 LastFmSettingsLoading()

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LyricsAnimationSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/LyricsAnimationSettings.kt
@@ -9,7 +9,6 @@ package moe.rukamori.archivetune.ui.screens.settings
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsetsSides
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.windowInsetsPadding
@@ -17,18 +16,16 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.R
@@ -46,39 +43,36 @@ import moe.rukamori.archivetune.utils.rememberPreference
 @Composable
 fun LyricsAnimationSettings(
     navController: NavController,
-    scrollBehavior: TopAppBarScrollBehavior,
 ) {
     val (bounceFactor, onBounceFactorChange) = rememberPreference(LyricsV2BounceFactorKey, defaultValue = 1f)
     val (glowFactor, onGlowFactorChange) = rememberPreference(LyricsV2GlowFactorKey, defaultValue = 1f)
     val (fillTransitionWidth, onFillTransitionWidthChange) = rememberPreference(LyricsV2FillTransitionWidthKey, defaultValue = 8f)
     val (lrcBounceEnabled, onLrcBounceEnabledChange) = rememberPreference(LyricsV2LrcBounceEnabledKey, defaultValue = true)
 
-    Column(
-        modifier =
-            Modifier
-                .fillMaxSize()
-                .nestedScroll(scrollBehavior.nestedScrollConnection),
-    ) {
-        TopAppBar(
-            title = { Text(text = stringResource(R.string.lyrics_animation_style)) },
-            navigationIcon = {
-                IconButton(
-                    onClick = navController::navigateUp,
-                    onLongClick = navController::backToMain,
-                ) {
-                    Icon(
-                        painter = painterResource(R.drawable.arrow_back),
-                        contentDescription = null,
-                    )
-                }
-            },
-            scrollBehavior = scrollBehavior,
-        )
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(text = stringResource(R.string.lyrics_animation_style)) },
+                navigationIcon = {
+                    IconButton(
+                        onClick = navController::navigateUp,
+                        onLongClick = navController::backToMain,
+                    ) {
+                        Icon(
+                            painter = painterResource(R.drawable.arrow_back),
+                            contentDescription = null,
+                        )
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        val topPadding = innerPadding.calculateTopPadding()
 
         Column(
             modifier =
                 Modifier
-                    .weight(1f)
+                    .padding(top = topPadding)
                     .verticalScroll(rememberScrollState())
                     .windowInsetsPadding(
                         LocalPlayerAwareWindowInsets.current.only(

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/MusicTogetherScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/MusicTogetherScreen.kt
@@ -71,7 +71,6 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBarDefaults
-import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -99,6 +98,7 @@ import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.LocalPlayerConnection
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.ui.component.TextFieldDialog
+import moe.rukamori.archivetune.ui.utils.appBarScrollBehavior
 import moe.rukamori.archivetune.ui.utils.backToMain
 import moe.rukamori.archivetune.viewmodels.MusicTogetherActivityLogItemUiModel
 import moe.rukamori.archivetune.viewmodels.MusicTogetherActivityLogUiModels
@@ -120,11 +120,11 @@ import moe.rukamori.archivetune.ui.component.IconButton as AtIconButton
 @Composable
 fun MusicTogetherScreen(
     navController: NavController,
-    scrollBehavior: TopAppBarScrollBehavior,
     viewModel: MusicTogetherViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
     val playerConnection = LocalPlayerConnection.current
+    val scrollBehavior = appBarScrollBehavior()
     val screenState by viewModel.state.collectAsStateWithLifecycle()
     val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
     val useSupportingPane = windowSizeClass.isWidthAtLeastBreakpoint(WindowSizeClass.WIDTH_DP_MEDIUM_LOWER_BOUND)

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlayerSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PlayerSettings.kt
@@ -8,7 +8,6 @@
 package moe.rukamori.archivetune.ui.screens.settings
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
@@ -17,9 +16,9 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -79,7 +78,6 @@ import moe.rukamori.archivetune.utils.rememberPreference
 @Composable
 fun PlayerSettings(
     navController: NavController,
-    scrollBehavior: TopAppBarScrollBehavior,
 ) {
     val (audioQuality, onAudioQualityChange) =
         rememberEnumPreference(
@@ -262,23 +260,36 @@ fun PlayerSettings(
         )
     }
 
-    Column(
-        Modifier
-            .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom))
-            .verticalScroll(rememberScrollState())
-            .padding(bottom = SettingsDimensions.ScreenBottomPadding),
-    ) {
-        Spacer(
-            Modifier.windowInsetsPadding(
-                LocalPlayerAwareWindowInsets.current.only(
-                    WindowInsetsSides.Top,
-                ),
-            ),
-        )
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.player_and_audio)) },
+                navigationIcon = {
+                    IconButton(
+                        onClick = navController::navigateUp,
+                        onLongClick = navController::backToMain,
+                    ) {
+                        Icon(
+                            painterResource(R.drawable.arrow_back),
+                            contentDescription = null,
+                        )
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        val topPadding = innerPadding.calculateTopPadding()
 
-        PreferenceGroup(title = stringResource(R.string.player)) {
-            item {
-                EnumListPreference(
+        Column(
+            Modifier
+                .padding(top = topPadding)
+                .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom))
+                .verticalScroll(rememberScrollState())
+                .padding(bottom = SettingsDimensions.ScreenBottomPadding),
+        ) {
+            PreferenceGroup(title = stringResource(R.string.player)) {
+                item {
+                    EnumListPreference(
                     title = { Text(stringResource(R.string.audio_quality)) },
                     icon = { Icon(painterResource(R.drawable.graphic_eq), null) },
                     selectedValue = audioQuality,
@@ -323,7 +334,7 @@ fun PlayerSettings(
             }
 
             item {
-                SwitchPreference(
+                    SwitchPreference(
                     title = { Text(stringResource(R.string.low_data_mode_title)) },
                     description = stringResource(R.string.low_data_mode_description),
                     icon = { Icon(painterResource(R.drawable.android_cell), null) },
@@ -342,7 +353,7 @@ fun PlayerSettings(
             }
 
             item {
-                SwitchPreference(
+                    SwitchPreference(
                     title = { Text(stringResource(R.string.audio_crossfade_title)) },
                     description = stringResource(R.string.audio_crossfade_description),
                     icon = { Icon(painterResource(R.drawable.animation), null) },
@@ -365,7 +376,7 @@ fun PlayerSettings(
             }
 
             item {
-                SwitchPreference(
+                    SwitchPreference(
                     title = { Text(stringResource(R.string.crossfade_gapless_title)) },
                     description = stringResource(R.string.crossfade_gapless_description),
                     icon = { Icon(painterResource(R.drawable.fast_forward), null) },
@@ -376,7 +387,7 @@ fun PlayerSettings(
             }
 
             item {
-                SwitchPreference(
+                    SwitchPreference(
                     title = { Text(stringResource(R.string.skip_silence)) },
                     icon = { Icon(painterResource(R.drawable.fast_forward), null) },
                     checked = skipSilence,
@@ -386,7 +397,7 @@ fun PlayerSettings(
             }
 
             item {
-                SwitchPreference(
+                    SwitchPreference(
                     title = { Text(stringResource(R.string.audio_normalization)) },
                     icon = { Icon(painterResource(R.drawable.volume_up), null) },
                     checked = audioNormalization,
@@ -395,7 +406,7 @@ fun PlayerSettings(
             }
 
             item {
-                SwitchPreference(
+                    SwitchPreference(
                     title = { Text(stringResource(R.string.audio_offload)) },
                     description = stringResource(R.string.audio_offload_desc),
                     icon = { Icon(painterResource(R.drawable.speed), null) },
@@ -411,7 +422,7 @@ fun PlayerSettings(
             }
 
             item {
-                SwitchPreference(
+                    SwitchPreference(
                     title = { Text(stringResource(R.string.seek_seconds_addup)) },
                     description = stringResource(R.string.seek_seconds_addup_description),
                     icon = { Icon(painterResource(R.drawable.arrow_forward), null) },
@@ -421,7 +432,7 @@ fun PlayerSettings(
             }
 
             item {
-                SwitchPreference(
+                    SwitchPreference(
                     title = { Text(stringResource(R.string.pause_on_device_mute)) },
                     description = stringResource(R.string.pause_on_device_mute_desc),
                     icon = { Icon(painterResource(R.drawable.volume_off), null) },
@@ -456,7 +467,7 @@ fun PlayerSettings(
             }
 
             item {
-                SwitchPreference(
+                    SwitchPreference(
                     title = { Text(stringResource(R.string.auto_start_on_bluetooth)) },
                     description = stringResource(R.string.auto_start_on_bluetooth_desc),
                     icon = { Icon(painterResource(R.drawable.bluetooth), null) },
@@ -467,8 +478,8 @@ fun PlayerSettings(
         }
 
         PreferenceGroup(title = stringResource(R.string.queue)) {
-            item {
-                SwitchPreference(
+                item {
+                    SwitchPreference(
                     title = { Text(stringResource(R.string.persistent_queue)) },
                     description = stringResource(R.string.persistent_queue_desc),
                     icon = { Icon(painterResource(R.drawable.queue_music), null) },
@@ -478,7 +489,7 @@ fun PlayerSettings(
             }
 
             item {
-                SwitchPreference(
+                    SwitchPreference(
                     title = { Text(stringResource(R.string.permanent_shuffle)) },
                     description = stringResource(R.string.permanent_shuffle_desc),
                     icon = { Icon(painterResource(R.drawable.shuffle), null) },
@@ -488,7 +499,7 @@ fun PlayerSettings(
             }
 
             item {
-                SwitchPreference(
+                    SwitchPreference(
                     title = { Text(stringResource(R.string.auto_download_on_like)) },
                     description = stringResource(R.string.auto_download_on_like_desc),
                     icon = { Icon(painterResource(R.drawable.download), null) },
@@ -498,7 +509,7 @@ fun PlayerSettings(
             }
 
             item {
-                SwitchPreference(
+                    SwitchPreference(
                     title = { Text(stringResource(R.string.auto_skip_next_on_error)) },
                     description = stringResource(R.string.auto_skip_next_on_error_desc),
                     icon = { Icon(painterResource(R.drawable.skip_next), null) },
@@ -509,8 +520,8 @@ fun PlayerSettings(
         }
 
         PreferenceGroup(title = stringResource(R.string.misc)) {
-            item {
-                SwitchPreference(
+                item {
+                    SwitchPreference(
                     title = { Text(stringResource(R.string.stop_music_on_task_clear)) },
                     icon = { Icon(painterResource(R.drawable.clear_all), null) },
                     checked = stopMusicOnTaskClear,
@@ -519,7 +530,7 @@ fun PlayerSettings(
             }
 
             item {
-                SwitchPreference(
+                    SwitchPreference(
                     title = { Text(stringResource(R.string.wakelock)) },
                     description = stringResource(R.string.wakelock_desc),
                     icon = { Icon(painterResource(R.drawable.bolt), null) },
@@ -529,7 +540,7 @@ fun PlayerSettings(
             }
 
             item {
-                PreferenceEntry(
+                    PreferenceEntry(
                     title = { Text(stringResource(R.string.artist_separators)) },
                     description = artistSeparators.map { "\"$it\"" }.joinToString("  "),
                     icon = { Icon(painterResource(R.drawable.artist), null) },
@@ -538,7 +549,7 @@ fun PlayerSettings(
             }
 
             item {
-                PreferenceEntry(
+                    PreferenceEntry(
                     title = { Text(stringResource(R.string.manage_playlist_tags)) },
                     description = stringResource(R.string.manage_playlist_tags_desc),
                     icon = { Icon(painterResource(R.drawable.style), null) },
@@ -547,7 +558,7 @@ fun PlayerSettings(
             }
 
             item {
-                SwitchPreference(
+                    SwitchPreference(
                     title = { Text(stringResource(R.string.external_downloader)) },
                     description = stringResource(R.string.external_downloader_desc),
                     icon = { Icon(painterResource(R.drawable.download), null) },
@@ -557,7 +568,7 @@ fun PlayerSettings(
             }
 
             item {
-                PreferenceEntry(
+                    PreferenceEntry(
                     title = { Text(stringResource(R.string.external_downloader_package)) },
                     description = externalDownloaderPackage.ifEmpty { stringResource(R.string.external_downloader_package_desc) },
                     icon = { Icon(painterResource(R.drawable.integration), null) },
@@ -565,21 +576,7 @@ fun PlayerSettings(
                     isEnabled = externalDownloaderEnabled,
                 )
             }
+            }
         }
     }
-
-    TopAppBar(
-        title = { Text(stringResource(R.string.player_and_audio)) },
-        navigationIcon = {
-            IconButton(
-                onClick = navController::navigateUp,
-                onLongClick = navController::backToMain,
-            ) {
-                Icon(
-                    painterResource(R.drawable.arrow_back),
-                    contentDescription = null,
-                )
-            }
-        },
-    )
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PoTokenScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PoTokenScreen.kt
@@ -51,10 +51,10 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -109,7 +109,6 @@ private val SUPPORTED_CLIENTS =
 @Composable
 fun PoTokenScreen(
     navController: NavController,
-    scrollBehavior: TopAppBarScrollBehavior,
     viewModel: PoTokenViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
@@ -283,25 +282,40 @@ fun PoTokenScreen(
         }
     }
 
-    Column(
-        Modifier
-            .windowInsetsPadding(
-                LocalPlayerAwareWindowInsets.current.only(
-                    WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom,
-                ),
-            ).verticalScroll(rememberScrollState())
-            .padding(bottom = SettingsDimensions.ScreenBottomPadding)
-            .animateContentSize(
-                animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
-            ),
-    ) {
-        Spacer(
-            Modifier.windowInsetsPadding(
-                LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Top),
-            ),
-        )
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.po_token_generation)) },
+                navigationIcon = {
+                    IconButton(
+                        onClick = navController::navigateUp,
+                        onLongClick = navController::backToMain,
+                    ) {
+                        Icon(
+                            painterResource(R.drawable.arrow_back),
+                            contentDescription = null,
+                        )
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        val topPadding = innerPadding.calculateTopPadding()
 
-        PreferenceGroup {
+        Column(
+            Modifier
+                .padding(top = topPadding)
+                .windowInsetsPadding(
+                    LocalPlayerAwareWindowInsets.current.only(
+                        WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom,
+                    ),
+                ).verticalScroll(rememberScrollState())
+                .padding(bottom = SettingsDimensions.ScreenBottomPadding)
+                .animateContentSize(
+                    animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
+                ),
+        ) {
+            PreferenceGroup {
             item {
                 SwitchPreference(
                     title = { Text(stringResource(R.string.web_client_po_token)) },
@@ -443,22 +457,8 @@ fun PoTokenScreen(
                 Spacer(Modifier.height(24.dp))
             }
         }
+        }
     }
-
-    TopAppBar(
-        title = { Text(stringResource(R.string.po_token_generation)) },
-        navigationIcon = {
-            IconButton(
-                onClick = navController::navigateUp,
-                onLongClick = navController::backToMain,
-            ) {
-                Icon(
-                    painterResource(R.drawable.arrow_back),
-                    contentDescription = null,
-                )
-            }
-        },
-    )
 }
 
 @Composable

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PrivacySettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/PrivacySettings.kt
@@ -10,7 +10,6 @@
 package moe.rukamori.archivetune.ui.screens.settings
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
@@ -22,10 +21,10 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -55,7 +54,6 @@ import moe.rukamori.archivetune.utils.rememberPreference
 @Composable
 fun PrivacySettings(
     navController: NavController,
-    scrollBehavior: TopAppBarScrollBehavior,
 ) {
     val database = LocalDatabase.current
     val (pauseListenHistory, onPauseListenHistoryChange) =
@@ -153,23 +151,36 @@ fun PrivacySettings(
         )
     }
 
-    Column(
-        Modifier
-            .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom))
-            .verticalScroll(rememberScrollState())
-            .padding(bottom = SettingsDimensions.ScreenBottomPadding),
-    ) {
-        Spacer(
-            Modifier.windowInsetsPadding(
-                LocalPlayerAwareWindowInsets.current.only(
-                    WindowInsetsSides.Top,
-                ),
-            ),
-        )
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.privacy)) },
+                navigationIcon = {
+                    IconButton(
+                        onClick = navController::navigateUp,
+                        onLongClick = navController::backToMain,
+                    ) {
+                        Icon(
+                            painterResource(R.drawable.arrow_back),
+                            contentDescription = null,
+                        )
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        val topPadding = innerPadding.calculateTopPadding()
 
-        PreferenceGroup(title = stringResource(R.string.listen_history)) {
-            item {
-                SwitchPreference(
+        Column(
+            Modifier
+                .padding(top = topPadding)
+                .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom))
+                .verticalScroll(rememberScrollState())
+                .padding(bottom = SettingsDimensions.ScreenBottomPadding),
+        ) {
+            PreferenceGroup(title = stringResource(R.string.listen_history)) {
+                item {
+                    SwitchPreference(
                     title = { Text(stringResource(R.string.pause_listen_history)) },
                     icon = { Icon(painterResource(R.drawable.history), null) },
                     checked = pauseListenHistory,
@@ -178,7 +189,7 @@ fun PrivacySettings(
             }
 
             item {
-                PreferenceEntry(
+                    PreferenceEntry(
                     title = { Text(stringResource(R.string.clear_listen_history)) },
                     icon = { Icon(painterResource(R.drawable.delete_history), null) },
                     onClick = { showClearListenHistoryDialog = true },
@@ -187,8 +198,8 @@ fun PrivacySettings(
         }
 
         PreferenceGroup(title = stringResource(R.string.search_history)) {
-            item {
-                SwitchPreference(
+                item {
+                    SwitchPreference(
                     title = { Text(stringResource(R.string.pause_search_history)) },
                     icon = { Icon(painterResource(R.drawable.search_off), null) },
                     checked = pauseSearchHistory,
@@ -197,7 +208,7 @@ fun PrivacySettings(
             }
 
             item {
-                PreferenceEntry(
+                    PreferenceEntry(
                     title = { Text(stringResource(R.string.clear_search_history)) },
                     icon = { Icon(painterResource(R.drawable.clear_all), null) },
                     onClick = { showClearSearchHistoryDialog = true },
@@ -206,8 +217,8 @@ fun PrivacySettings(
         }
 
         PreferenceGroup(title = stringResource(R.string.misc)) {
-            item {
-                SwitchPreference(
+                item {
+                    SwitchPreference(
                     title = { Text(stringResource(R.string.haptics)) },
                     description = stringResource(R.string.haptics_desc),
                     icon = { Icon(painterResource(R.drawable.vibration), null) },
@@ -217,7 +228,7 @@ fun PrivacySettings(
             }
 
             item {
-                SwitchPreference(
+                    SwitchPreference(
                     title = { Text(stringResource(R.string.disable_screenshot)) },
                     description = stringResource(R.string.disable_screenshot_desc),
                     icon = { Icon(painterResource(R.drawable.screenshot), null) },
@@ -225,21 +236,7 @@ fun PrivacySettings(
                     onCheckedChange = onDisableScreenshotChange,
                 )
             }
+            }
         }
     }
-
-    TopAppBar(
-        title = { Text(stringResource(R.string.privacy)) },
-        navigationIcon = {
-            IconButton(
-                onClick = navController::navigateUp,
-                onLongClick = navController::backToMain,
-            ) {
-                Icon(
-                    painterResource(R.drawable.arrow_back),
-                    contentDescription = null,
-                )
-            }
-        },
-    )
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/SettingsScreen.kt
@@ -33,7 +33,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
-import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -52,6 +51,7 @@ import moe.rukamori.archivetune.BuildConfig
 import moe.rukamori.archivetune.LocalPlayerAwareWindowInsets
 import moe.rukamori.archivetune.R
 import moe.rukamori.archivetune.ui.component.IconButton
+import moe.rukamori.archivetune.ui.utils.appBarScrollBehavior
 import moe.rukamori.archivetune.ui.utils.backToMain
 import moe.rukamori.archivetune.utils.Updater
 
@@ -59,7 +59,6 @@ import moe.rukamori.archivetune.utils.Updater
 @Composable
 fun SettingsScreen(
     navController: NavController,
-    scrollBehavior: TopAppBarScrollBehavior,
     latestVersionName: String,
     onClearUpdateBadge: () -> Unit = {},
 ) {
@@ -104,6 +103,7 @@ fun SettingsScreen(
             }
         }
 
+    val scrollBehavior = appBarScrollBehavior()
     val shouldShowPermissionHint = !isStorageGranted || !isNotificationGranted
     val hasUpdate =
         BuildConfig.UPDATER_AVAILABLE &&

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/StorageSettings.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/StorageSettings.kt
@@ -12,13 +12,11 @@ package moe.rukamori.archivetune.ui.screens.settings
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsetsSides
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
@@ -39,6 +37,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearWavyProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SheetState
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
@@ -46,7 +45,6 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -106,7 +104,6 @@ import moe.rukamori.archivetune.viewmodels.StorageSettingsViewModel
 @Composable
 fun StorageSettings(
     navController: NavController,
-    scrollBehavior: TopAppBarScrollBehavior,
     viewModel: StorageSettingsViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
@@ -278,9 +275,38 @@ fun StorageSettings(
         }
     }
 
-    Box(Modifier.fillMaxSize()) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.storage)) },
+                navigationIcon = {
+                    IconButton(
+                        onClick = navController::navigateUp,
+                        onLongClick = navController::backToMain,
+                    ) {
+                        Icon(
+                            painterResource(R.drawable.arrow_back),
+                            contentDescription = null,
+                        )
+                    }
+                },
+            )
+        },
+        snackbarHost = {
+            SnackbarHost(
+                hostState = snackbarHostState,
+                modifier =
+                    Modifier
+                        .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Bottom))
+                        .padding(16.dp),
+            )
+        },
+    ) { innerPadding ->
+        val topPadding = innerPadding.calculateTopPadding()
+
         Column(
             Modifier
+                .padding(top = topPadding)
                 .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom))
                 .verticalScroll(rememberScrollState())
                 .padding(
@@ -290,12 +316,6 @@ fun StorageSettings(
                     bottom = SettingsDimensions.ScreenBottomPadding,
                 ),
         ) {
-            Spacer(
-                Modifier.windowInsetsPadding(
-                    LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Top),
-                ),
-            )
-
             StorageFolderSection(
                 state = screenState,
                 smartTrimmer = smartTrimmer,
@@ -525,31 +545,6 @@ fun StorageSettings(
                 )
             }
         }
-
-        TopAppBar(
-            title = { Text(stringResource(R.string.storage)) },
-            navigationIcon = {
-                IconButton(
-                    onClick = navController::navigateUp,
-                    onLongClick = navController::backToMain,
-                ) {
-                    Icon(
-                        painterResource(R.drawable.arrow_back),
-                        contentDescription = null,
-                    )
-                }
-            },
-            scrollBehavior = scrollBehavior,
-        )
-
-        SnackbarHost(
-            hostState = snackbarHostState,
-            modifier =
-                Modifier
-                    .align(Alignment.BottomCenter)
-                    .windowInsetsPadding(LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Bottom))
-                    .padding(16.dp),
-        )
     }
 
     val successState = screenState as? StorageSettingsScreenState.Success

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/UpdateScreen.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/UpdateScreen.kt
@@ -71,7 +71,6 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBarDefaults
-import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.WavyProgressIndicatorDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -114,6 +113,7 @@ import moe.rukamori.archivetune.ui.component.BottomSheetPage
 import moe.rukamori.archivetune.ui.component.BottomSheetPageState
 import moe.rukamori.archivetune.ui.component.IconButton
 import moe.rukamori.archivetune.ui.component.MarkdownText
+import moe.rukamori.archivetune.ui.utils.appBarScrollBehavior
 import moe.rukamori.archivetune.ui.utils.backToMain
 import moe.rukamori.archivetune.utils.AppUpdateInstaller
 import moe.rukamori.archivetune.utils.GitCommit
@@ -130,11 +130,11 @@ import kotlin.math.roundToInt
 @Composable
 fun UpdateScreen(
     navController: NavController,
-    scrollBehavior: TopAppBarScrollBehavior,
     onUpToDate: () -> Unit = {},
 ) {
     val context = LocalContext.current
     val uriHandler = LocalUriHandler.current
+    val scrollBehavior = appBarScrollBehavior()
     val coroutineScope = rememberCoroutineScope()
     val nightlyInstallUrl = remember { Updater.getLatestNightlyDownloadUrl() }
 


### PR DESCRIPTION
# Pull Request

## Summary

Refactors the Settings header/scroll architecture. Collapsible Settings screens now own local app-bar scroll behavior, while static Settings subpages use standardized `Scaffold` + static `TopAppBar` layouts. This also fixes the residual Settings-to-main app-bar carry-over, Changelog player-aware bottom padding, and Hidden Playlists back-button behavior.

## Linked Work

- Closes: -
- Related: -

## Change Type

- [ ] Feature
- [x] Bug fix
- [x] UI / UX
- [ ] Performance / memory
- [ ] Playback / Media3
- [ ] Lyrics / provider integration
- [ ] Search / YouTube / network data
- [ ] Local library / Room database
- [ ] Widgets / notification / shortcuts
- [x] Settings / preferences / DataStore
- [x] Discord / Last.fm / ListenBrainz / external integration
- [ ] Localization / strings / fastlane metadata
- [ ] Build / Gradle / CI / release packaging
- [ ] Dependency update
- [ ] Documentation only

## Affected Surfaces

- [x] `:app`
- [ ] `:core`
- [ ] `:lyrics`
- [ ] `:lastfm`
- [ ] `:canvas`
- [ ] `:shazamkit`
- [ ] `:spotifycore`
- [ ] Other:

## Screenshots / Recordings

| Before | After |
| --- | --- |
| Not attached | Not attached |

## Behavior Notes

- Localized collapsible app-bar behavior for Settings-related screens that should remain collapsible:
  - `SettingsScreen`
  - `AccountSettings`
  - `UpdateScreen`
  - `AboutScreen`
  - `MusicTogetherScreen`
  - `DiscordSettings`
  - `AodCustomizedScreen`
- Standardized static Settings subpages to use static `Scaffold` top bars and removed obsolete `scrollBehavior` plumbing from:
  - `AppearanceSettings`
  - `PlayerSettings`
  - `PrivacySettings`
  - `IntegrationScreen`
  - `PoTokenScreen`
  - `InternetSettings`
  - `StorageSettings`
  - `BackupAndRestore`
  - `LyricsAnimationSettings`
  - `HiddenPlaylistsScreen`
  - `LastFMSettings`
  - `ChangelogScreen`
- Preserves player-aware horizontal/bottom insets while moving top spacing to `Scaffold` content padding where appropriate.
- Keeps global `topAppBarScrollBehavior` and NavigationBuilder `scrollBehavior` support for non-settings routes that still depend on shared shell scroll behavior.
- Fixes Changelog bottom spacing by avoiding double application of Scaffold bottom padding and player-aware bottom insets.
- Aligns `HiddenPlaylistsScreen` back behavior with other Settings screens: tap navigates up, long press returns to main.

## Architecture Checklist

- [x] The change preserves UDF flow: UI -> ViewModel -> UseCase/domain -> Repository/data.
- [ ] Screen state is represented structurally with `Loading`, `Success`, `Empty`, and `Error` where this PR introduces or changes screen state.
- [ ] Composables receive immutable, UI-specific domain models instead of raw Room, network, or service entities.
- [x] Business work is not triggered directly from composition.
- [ ] Exceptions are surfaced through explicit state or result types instead of being swallowed.
- [x] No `runBlocking` is introduced in app execution paths.

## Compose / Material Checklist

- [x] UI state is hoisted out of composable layout code.
- [x] Reactive state is collected with `collectAsStateWithLifecycle()` where existing screens already use it.
- [ ] New UI models are annotated with `@Immutable` or `@Stable`.
- [ ] Lazy layouts use stable `key` values and explicit `contentType`.
- [x] Non-primitive constants, structural lambdas, and allocation-heavy objects in hot paths are remembered where applicable to existing code.
- [ ] Rapidly changing inputs such as scroll, gesture, animation, or playback progress use `derivedStateOf` where appropriate.
- [x] UI strings come from `stringResource()` and no new user-facing strings are introduced.
- [x] Interactive elements keep a minimum 48dp touch target.
- [x] Material 3 / Material 3 Expressive tokens are used for color, typography, shape, and motion instead of hardcoded UI values.
- [x] Edge-to-edge layouts handle and consume `WindowInsets` correctly when this PR changes screen layout.

## Concurrency / Performance Checklist

- [x] Business coroutines are scoped to `viewModelScope` or an existing lifecycle-owned application/service scope.
- [x] Disk, database, network, parsing, and heavy mapping work is dispatched to `Dispatchers.IO` or `Dispatchers.Default` where existing code requires it.
- [ ] Cancellation is handled explicitly where long-running work, playback, downloads, sync, lyrics fetching, or recognition is involved.
- [x] The change avoids blocking the main thread.
- [x] The change avoids unnecessary allocations in recomposition loops, playback loops, polling loops, and provider parsing paths.
- [ ] Large lists, images, lyrics payloads, and network responses are bounded, streamed, cached, paged, or mapped off the main thread as appropriate.

## Data / Persistence Checklist

- [ ] Room entity, DAO, or database changes include a schema update under `app/schemas`.
- [ ] Database migrations preserve existing user data and fail clearly when migration is impossible.
- [x] DataStore or preference-key changes are backward compatible.
- [x] Network DTOs remain isolated from UI models.
- [ ] Provider responses handle missing, malformed, regional, or rate-limited data without crashing the app.

## Playback / Integration Checklist

- [x] Media3 playback, queue, cache, and service behavior remains stable across foreground, background, notification, and process recreation paths.
- [x] Audio focus, notification controls, widgets, shortcuts, and media session actions are considered when playback behavior changes.
- [x] External integrations handle absent credentials, revoked auth, network failure, and API changes.
- [ ] Native, AAR, or ABI-sensitive changes account for mobile/tv and `universal`, `arm64`, `armeabi`, `x86`, and `x86_64` variants.

## Localization / Assets Checklist

- [ ] User-facing strings are added to the base resources and translated resources are updated or intentionally left for translation follow-up.
- [ ] Unused string resources, drawables, and metadata are removed when replaced.
- [ ] Image assets have explicit display dimensions and are decoded at the displayed size.
- [ ] Fastlane metadata, screenshots, icons, or release text are updated when user-facing store behavior changes.

## Privacy / Security Checklist

- [x] No secrets, keys, tokens, keystores, signing files, private certificates, or local machine paths are committed.
- [x] Logs do not expose access tokens, cookies, auth headers, user identifiers, listening history, or local file paths.
- [ ] New network calls are justified by the feature and use existing client, proxy, timeout, and error-handling patterns.
- [x] User data remains local unless the PR explicitly documents the integration and consent path.

## Verification

- [x] Android Studio sync: Passed locally.
- [x] Manual device/emulator verification: Settings header/navigation flows were tested locally; no regressions observed.
- [ ] UI screenshot/recording attached: Not attached.
- [x] Accessibility or touch-target review: Back-button behavior was checked, including long-press behavior on static Settings pages.
- [x] Regression areas checked: Settings-to-main navigation, collapsible app-bar state isolation, static Settings subpage spacing, player-aware bottom padding, Changelog spacing, Hidden Playlists back behavior.
- [x] CI expectation: Expected to pass; no build-system or dependency changes are included.

## Reviewer Focus

- Verify the split between local collapsible screens and static Settings subpages in `NavigationBuilder.kt`.
- Verify static Settings subpages no longer receive or use shared `scrollBehavior`.
- Review `LocalPlayerAwareWindowInsets` handling where top padding was moved to `Scaffold` content padding and horizontal/bottom insets remain player-aware.
- Pay close attention to `StorageSettings`, `BackupAndRestore`, `LastFMSettings`, and `ChangelogScreen` because they include dialogs, sheets, snackbar placement, or async loading states.
- Confirm non-settings routes still receive `scrollBehavior` and continue to rely on the existing shell app-bar behavior.

## Release Notes

Improves Settings header consistency and fixes scroll-state, bottom-padding, and back-navigation behavior across Settings pages.