### PR TITLE
Fix/liked songs sort stability

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/utils/SyncUtils.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/utils/SyncUtils.kt
@@ -288,7 +288,7 @@ class SyncUtils
                             return@onSuccess
                         }
                         val remoteIds = remoteSongs.map { it.id }.toSet()
-                        if (remoteSongs.isNotEmpty() || authoritative) {
+                        if (authoritative) {
                             val localLikedSongs = database.likedSongsByNameAsc().first()
                             if (!isSyncStillEnabled(gen)) return@onSuccess
                             val staleLikedSongs =
@@ -318,7 +318,7 @@ class SyncUtils
                                         if (!isSyncStillEnabled(gen)) return@withTransaction
                                         if (dbSong == null) {
                                             insert(song.toMediaMetadata()) { it.copy(liked = true, likedDate = timestamp) }
-                                        } else if (!dbSong.song.liked) {
+                                        } else if (!dbSong.song.liked || dbSong.song.likedDate == null) {
                                             update(dbSong.song.copy(liked = true, likedDate = timestamp))
                                         }
                                     }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/utils/SyncUtils.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/utils/SyncUtils.kt
@@ -288,7 +288,7 @@ class SyncUtils
                             return@onSuccess
                         }
                         val remoteIds = remoteSongs.map { it.id }.toSet()
-                        if (authoritative) {
+                        if (remoteSongs.isNotEmpty() || authoritative) {
                             val localLikedSongs = database.likedSongsByNameAsc().first()
                             if (!isSyncStillEnabled(gen)) return@onSuccess
                             val staleLikedSongs =
@@ -318,7 +318,7 @@ class SyncUtils
                                         if (!isSyncStillEnabled(gen)) return@withTransaction
                                         if (dbSong == null) {
                                             insert(song.toMediaMetadata()) { it.copy(liked = true, likedDate = timestamp) }
-                                        } else if (!dbSong.song.liked || dbSong.song.likedDate != timestamp) {
+                                        } else if (!dbSong.song.liked) {
                                             update(dbSong.song.copy(liked = true, likedDate = timestamp))
                                         }
                                     }


### PR DESCRIPTION
# Pull Request

## Summary

Fixes Liked Songs sort instability when sorted by Date Added (`SyncUtils.kt:syncLikedSongs`).

**UI stutter**: Each sync was rewriting `likedDate` for every already-liked song via `dbSong.song.likedDate != timestamp`, which always evaluated to `true` because `likedSongTimestamp()` generates fresh `LocalDateTime.now()`-based values. Each individual `update()` inside a separate `database.withTransaction` caused Room to invalidate and re-emit the Flow, making the LazyColumn recompose repeatedly until the sync completed.

**Sort position drift**: The constant timestamp rewrites pushed locally-liked songs to the bottom over successive syncs, as their fixed `likedDate` became progressively older relative to YouTube songs refreshed on every entry.

**Fix**: Change the update condition from `!dbSong.song.liked || dbSong.song.likedDate != timestamp` to `!dbSong.song.liked || dbSong.song.likedDate == null`. Already-liked songs with a valid `likedDate` are no longer rewritten on each sync, eliminating both stutter and drift. Songs with `liked = true` but `likedDate = null`  are repaired with a one-time backfill.

## Linked Work

- Closes:
- Related:

## Change Type

- [ ] Feature
- [x] Bug fix
- [ ] UI / UX
- [x] Performance / memory
- [ ] Playback / Media3
- [ ] Lyrics / provider integration
- [ ] Search / YouTube / network data
- [x] Local library / Room database
- [ ] Widgets / notification / shortcuts
- [ ] Settings / preferences / DataStore
- [ ] Discord / Last.fm / ListenBrainz / external integration
- [ ] Localization / strings / fastlane metadata
- [ ] Build / Gradle / CI / release packaging
- [ ] Dependency update
- [ ] Documentation only

## Affected Surfaces

- [x] `:app`
- [ ] `:core`
- [ ] `:lyrics`
- [ ] `:lastfm`
- [ ] `:canvas`
- [ ] `:shazamkit`
- [ ] `:spotifycore`
- [ ] Other:

## Screenshots / Recordings

| Before | After |
| --- | --- |
| 
<img width="480" height="1056" alt="screen-record" src="https://github.com/user-attachments/assets/bcee0ccc-08bb-44bd-83c0-cc9b695ee055" />
 | 
<img width="480" height="1056" alt="screen-record-fixed" src="https://github.com/user-attachments/assets/a1a1528f-934f-4408-be9d-0c144f4b77ad" />
 |

## Behavior Notes

| Song state | Before | After |
|---|---|---|
| `liked = false` | update (new like) | update (new like) — same |
| `liked = true, likedDate = null` | update (rewrites timestamp) | update (one-time backfill) |
| `liked = true, likedDate = valid` | update (unnecessary rewrite every sync) | skip — fixes the bug |

## Architecture Checklist

- [x] The change preserves UDF flow: UI -> ViewModel -> UseCase/domain -> Repository/data.
- [ ] Screen state is represented structurally — N/A: no screen changes.
- [x] Composables receive immutable, UI-specific domain models instead of raw Room, network, or service entities.
- [x] Business work is not triggered directly from composition.
- [x] Exceptions are surfaced through explicit state or result types instead of being swallowed.
- [x] No `runBlocking` is introduced in app execution paths.

## Compose / Material Checklist

Not applicable — no UI or Compose changes.

## Concurrency / Performance Checklist

- [x] Business coroutines are scoped to `viewModelScope` or an existing lifecycle-owned application/service scope.
- [x] Disk, database, network, parsing, and heavy mapping work is dispatched to `Dispatchers.IO` or `Dispatchers.Default`.
- [x] Cancellation is handled explicitly where long-running work, playback, downloads, sync, lyrics fetching, or recognition is involved.
- [x] The change avoids blocking the main thread.
- [x] The change avoids unnecessary allocations in recomposition loops, playback loops, polling loops, and provider parsing paths.
- [x] Large lists, images, lyrics payloads, and network responses are bounded, streamed, cached, paged, or mapped off the main thread as appropriate.

## Data / Persistence Checklist

- [ ] Room entity, DAO, or database changes include a schema update under `app/schemas`. — N/A: no schema change.
- [x] Database migrations preserve existing user data and fail clearly when migration is impossible.
- [x] DataStore or preference-key changes are backward compatible.
- [x] Network DTOs remain isolated from UI models.
- [x] Provider responses handle missing, malformed, regional, or rate-limited data without crashing the app.

## Playback / Integration Checklist

Not applicable — no playback or integration changes.

## Localization / Assets Checklist

Not applicable — no string or asset changes.

## Privacy / Security Checklist

- [x] No secrets, keys, tokens, keystores, signing files, private certificates, or local machine paths are committed.
- [x] Logs do not expose access tokens, cookies, auth headers, user identifiers, listening history, or local file paths.
- [x] New network calls are justified by the feature and use existing client, proxy, timeout, and error-handling patterns.
- [x] User data remains local unless the PR explicitly documents the integration and consent path.

## Verification

- [ ] Android Studio sync: N/A — Gradle CLI build successful (`assembleFossMobileUniversalRelease`).
- [x] Manual device/emulator verification: Tested on physical device. Verified sort order stable across repeated Liked Songs entries, local songs no longer drift, cross-device unlikes reflected after page-entry sync, authoritative sync unchanged.
- [x] UI screenshot/recording attached: GIF recording of pre-fix stutter.
- [ ] Accessibility or touch-target review: N/A.
- [x] Regression areas checked: Library sync, offline downloads, other sort modes (NAME, ARTIST, PLAY_TIME)
- [ ] CI expectation:

## Reviewer Focus

`SyncUtils.kt:318` — the single changed line. The `likedDate == null` backfill is a one-time repair that will never trigger again once the timestamp is set.

## Release Notes

Fixed Liked Songs sort order stutter and drift when sorted by Date Added.