### PR TITLE
feat: add android 17 option in android version chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -155,6 +155,7 @@ body:
     attributes:
       label: Android version
       options:
+        - Android 17
         - Android 16
         - Android 15
         - Android 14


### PR DESCRIPTION
i cant be assed to fill this form out

what changed:
- android 17 released

what i added:
- android 17 option to the android version dropdown menu