### PR TITLE
Add verified ArchiveTune share links and V9 player color fix

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -81,6 +81,17 @@
                     android:scheme="archivetune" />
             </intent-filter>
 
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="archivetune.koiiverse.cloud"
+                    android:path="/share.html"
+                    android:scheme="https" />
+            </intent-filter>
             <!-- Youtube filter -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />

--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -286,6 +286,7 @@ import moe.rukamori.archivetune.ui.theme.extractThemeColor
 import moe.rukamori.archivetune.ui.utils.appBarScrollBehavior
 import moe.rukamori.archivetune.ui.utils.backToMain
 import moe.rukamori.archivetune.ui.utils.resetHeightOffset
+import moe.rukamori.archivetune.utils.ArchiveTuneShareLinks
 import moe.rukamori.archivetune.utils.PreferenceStore
 import moe.rukamori.archivetune.utils.SyncUtils
 import moe.rukamori.archivetune.utils.Updater
@@ -2593,9 +2594,17 @@ class MainActivity : ComponentActivity() {
             return
         }
 
-        when (val path = uri.pathSegments.firstOrNull()) {
+        val deepLinkUri =
+            ArchiveTuneShareLinks.toYouTubeMusicUri(uri)
+                ?: if (ArchiveTuneShareLinks.isArchiveTuneShareUri(uri)) {
+                    return
+                } else {
+                    uri
+                }
+
+        when (val path = deepLinkUri.pathSegments.firstOrNull()) {
             "playlist" -> {
-                uri.getQueryParameter("list")?.let { playlistId ->
+                deepLinkUri.getQueryParameter("list")?.let { playlistId ->
                     if (playlistId.startsWith("OLAK5uy_")) {
                         coroutineScope.launch {
                             YouTube
@@ -2613,13 +2622,13 @@ class MainActivity : ComponentActivity() {
             }
 
             "browse" -> {
-                uri.lastPathSegment?.let { browseId ->
+                deepLinkUri.lastPathSegment?.let { browseId ->
                     navController.navigate("album/$browseId")
                 }
             }
 
             "channel", "c" -> {
-                uri.lastPathSegment?.let { artistId ->
+                deepLinkUri.lastPathSegment?.let { artistId ->
                     navController.navigate("artist/$artistId")
                 }
             }
@@ -2627,12 +2636,12 @@ class MainActivity : ComponentActivity() {
             else -> {
                 val videoId =
                     when {
-                        path == "watch" -> uri.getQueryParameter("v")
-                        uri.host == "youtu.be" -> uri.pathSegments.firstOrNull()
+                        path == "watch" -> deepLinkUri.getQueryParameter("v")
+                        deepLinkUri.host == "youtu.be" -> deepLinkUri.pathSegments.firstOrNull()
                         else -> null
                     }
-                val playlistId = uri.getQueryParameter("list")
-                val shouldShufflePlaylist = uri.requestsShuffledPlayback()
+                val playlistId = deepLinkUri.getQueryParameter("list")
+                val shouldShufflePlaylist = deepLinkUri.requestsShuffledPlayback()
 
                 videoId?.let { vid ->
                     coroutineScope.launch {

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsShareDialog.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/LyricsShareDialog.kt
@@ -99,7 +99,7 @@ fun shareLyricsAsText(
     payload: LyricsSharePayload,
     songId: String?,
 ) {
-    val songLink = songId?.takeIf { it.isNotBlank() }?.let { "https://music.youtube.com/watch?v=$it" }
+    val songLink = songId?.takeIf { it.isNotBlank() }?.let { moe.rukamori.archivetune.utils.ArchiveTuneShareLinks.buildSongShareUrl(it) }
     val shareBody =
         buildString {
             append("\"")

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/AlbumMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/AlbumMenu.kt
@@ -453,7 +453,7 @@ fun AlbumMenu(
                                                     type = "text/plain"
                                                     putExtra(
                                                         Intent.EXTRA_TEXT,
-                                                        "https://music.youtube.com/playlist?list=${album.album.playlistId}",
+                                                        moe.rukamori.archivetune.utils.ArchiveTuneShareLinks.buildAlbumShareUrl(album.album.id),
                                                     )
                                                 }
                                             context.startActivity(Intent.createChooser(intent, null))

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/ArtistMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/ArtistMenu.kt
@@ -195,7 +195,7 @@ fun ArtistMenu(
                                                     type = "text/plain"
                                                     putExtra(
                                                         Intent.EXTRA_TEXT,
-                                                        "https://music.youtube.com/channel/${artist.id}",
+                                                        moe.rukamori.archivetune.utils.ArchiveTuneShareLinks.buildChannelShareUrl(artist.id),
                                                     )
                                                 }
                                             context.startActivity(Intent.createChooser(intent, null))

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/PlayerMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/PlayerMenu.kt
@@ -578,7 +578,7 @@ fun PlayerMenu(
                                             val clip =
                                                 android.content.ClipData.newPlainText(
                                                     context.getString(R.string.copy_link),
-                                                    "https://music.youtube.com/watch?v=${mediaMetadata.id}",
+                                                    moe.rukamori.archivetune.utils.ArchiveTuneShareLinks.buildSongShareUrl(mediaMetadata.id),
                                                 )
                                             clipboard.setPrimaryClip(clip)
                                             android.widget.Toast

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/PlaylistMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/PlaylistMenu.kt
@@ -595,7 +595,7 @@ public fun PlaylistMenu(
                             Intent().apply {
                                 action = Intent.ACTION_SEND
                                 type = "text/plain"
-                                putExtra(Intent.EXTRA_TEXT, "https://music.youtube.com/playlist?list=${dbPlaylist?.playlist?.browseId}")
+                                putExtra(Intent.EXTRA_TEXT, dbPlaylist?.playlist?.browseId?.let { moe.rukamori.archivetune.utils.ArchiveTuneShareLinks.buildPlaylistShareUrl(it) }.orEmpty())
                             }
                         context.startActivity(Intent.createChooser(intent, null))
                     },
@@ -1015,7 +1015,7 @@ public fun PlaylistMenu(
                                     Intent().apply {
                                         action = Intent.ACTION_SEND
                                         type = "text/plain"
-                                        putExtra(Intent.EXTRA_TEXT, shareLink)
+                                        putExtra(Intent.EXTRA_TEXT, moe.rukamori.archivetune.utils.ArchiveTuneShareLinks.fromYouTubeMusicShareUrl(shareLink))
                                     }
                                 context.startActivity(Intent.createChooser(intent, null))
                                 onDismiss()

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/SongMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/SongMenu.kt
@@ -513,7 +513,7 @@ fun SongMenu(
                                     Intent().apply {
                                         action = Intent.ACTION_SEND
                                         type = "text/plain"
-                                        putExtra(Intent.EXTRA_TEXT, "https://music.youtube.com/watch?v=${song.id}")
+                                        putExtra(Intent.EXTRA_TEXT, moe.rukamori.archivetune.utils.ArchiveTuneShareLinks.buildSongShareUrl(song.id))
                                     }
                                 context.startActivity(Intent.createChooser(intent, null))
                             }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/YouTubeAlbumMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/YouTubeAlbumMenu.kt
@@ -406,7 +406,7 @@ fun YouTubeAlbumMenu(
                                         Intent().apply {
                                             action = Intent.ACTION_SEND
                                             type = "text/plain"
-                                            putExtra(Intent.EXTRA_TEXT, albumItem.shareLink)
+                                            putExtra(Intent.EXTRA_TEXT, moe.rukamori.archivetune.utils.ArchiveTuneShareLinks.buildAlbumShareUrl(albumItem.browseId))
                                         }
                                     context.startActivity(Intent.createChooser(intent, null))
                                 },

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/YouTubeArtistMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/YouTubeArtistMenu.kt
@@ -162,7 +162,7 @@ fun YouTubeArtistMenu(
                                             Intent().apply {
                                                 action = Intent.ACTION_SEND
                                                 type = "text/plain"
-                                                putExtra(Intent.EXTRA_TEXT, artist.shareLink)
+                                                putExtra(Intent.EXTRA_TEXT, moe.rukamori.archivetune.utils.ArchiveTuneShareLinks.buildChannelShareUrl(artist.id))
                                             }
                                         context.startActivity(Intent.createChooser(intent, null))
                                         onDismiss()

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/YouTubePlaylistMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/YouTubePlaylistMenu.kt
@@ -995,7 +995,7 @@ fun YouTubePlaylistMenu(
                                     Intent().apply {
                                         action = Intent.ACTION_SEND
                                         type = "text/plain"
-                                        putExtra(Intent.EXTRA_TEXT, playlist.shareLink)
+                                        putExtra(Intent.EXTRA_TEXT, moe.rukamori.archivetune.utils.ArchiveTuneShareLinks.buildPlaylistShareUrl(playlist.id))
                                     }
                                 context.startActivity(Intent.createChooser(intent, null))
                                 onDismiss()

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/YouTubeSongMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/YouTubeSongMenu.kt
@@ -413,7 +413,7 @@ fun YouTubeSongMenu(
                             Intent().apply {
                                 action = Intent.ACTION_SEND
                                 type = "text/plain"
-                                putExtra(Intent.EXTRA_TEXT, song.shareLink)
+                                putExtra(Intent.EXTRA_TEXT, moe.rukamori.archivetune.utils.ArchiveTuneShareLinks.buildSongShareUrl(song.id))
                             }
                         context.startActivity(Intent.createChooser(intent, null))
                         onDismiss()

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerComponents.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/PlayerComponents.kt
@@ -299,7 +299,7 @@ fun PlayerTopActions(
                                         type = "text/plain"
                                         putExtra(
                                             Intent.EXTRA_TEXT,
-                                            "https://music.youtube.com/watch?v=${mediaMetadata.id}",
+                                            moe.rukamori.archivetune.utils.ArchiveTuneShareLinks.buildSongShareUrl(mediaMetadata.id),
                                         )
                                     }
                                 context.startActivity(Intent.createChooser(intent, null))
@@ -363,7 +363,7 @@ fun PlayerTopActions(
                                         type = "text/plain"
                                         putExtra(
                                             Intent.EXTRA_TEXT,
-                                            "https://music.youtube.com/watch?v=${mediaMetadata.id}",
+                                            moe.rukamori.archivetune.utils.ArchiveTuneShareLinks.buildSongShareUrl(mediaMetadata.id),
                                         )
                                     }
                                 context.startActivity(Intent.createChooser(intent, null))
@@ -420,7 +420,7 @@ fun PlayerTopActions(
                                 type = "text/plain"
                                 putExtra(
                                     Intent.EXTRA_TEXT,
-                                    "https://music.youtube.com/watch?v=${mediaMetadata.id}",
+                                    moe.rukamori.archivetune.utils.ArchiveTuneShareLinks.buildSongShareUrl(mediaMetadata.id),
                                 )
                             }
                         context.startActivity(Intent.createChooser(intent, null))
@@ -530,7 +530,7 @@ fun PlayerTopActions(
                                     type = "text/plain"
                                     putExtra(
                                         Intent.EXTRA_TEXT,
-                                        "https://music.youtube.com/watch?v=${mediaMetadata.id}",
+                                        moe.rukamori.archivetune.utils.ArchiveTuneShareLinks.buildSongShareUrl(mediaMetadata.id),
                                     )
                                 }
                             context.startActivity(Intent.createChooser(intent, null))
@@ -595,7 +595,7 @@ fun PlayerTopActions(
                                 type = "text/plain"
                                 putExtra(
                                     Intent.EXTRA_TEXT,
-                                    "https://music.youtube.com/watch?v=${mediaMetadata.id}",
+                                    moe.rukamori.archivetune.utils.ArchiveTuneShareLinks.buildSongShareUrl(mediaMetadata.id),
                                 )
                             }
                         context.startActivity(Intent.createChooser(intent, null))
@@ -3197,7 +3197,7 @@ private fun V9PortraitContent(
 
             V9Header(
                 textColor = textBackgroundColor,
-                containerColor = textButtonColor.copy(alpha = 0.16f),
+                containerColor = textBackgroundColor.copy(alpha = 0.08f),
                 iconColor = textBackgroundColor,
                 onCollapseClick = onCollapseClick,
                 onLyricsClick = onLyricsClick,
@@ -3212,7 +3212,7 @@ private fun V9PortraitContent(
                 canvasFallbackUrl = canvasFallbackUrl,
                 isPlaying = isPlaying,
                 size = artworkSize,
-                placeholderColor = textButtonColor.copy(alpha = 0.12f),
+                placeholderColor = textBackgroundColor.copy(alpha = 0.08f),
             )
 
             Spacer(Modifier.height(metadataGap))
@@ -3233,8 +3233,8 @@ private fun V9PortraitContent(
                 position = position,
                 duration = duration,
                 isPlaying = isPlaying,
-                activeColor = textButtonColor,
-                inactiveColor = textButtonColor.copy(alpha = 0.24f),
+                activeColor = textBackgroundColor,
+                inactiveColor = textBackgroundColor.copy(alpha = 0.24f),
                 textColor = textBackgroundColor,
                 onSliderValueChange = onSliderValueChange,
                 onSliderValueChangeFinished = onSliderValueChangeFinished,
@@ -3248,8 +3248,8 @@ private fun V9PortraitContent(
                 isLoading = isLoading,
                 canSkipPrevious = canSkipPrevious,
                 canSkipNext = canSkipNext,
-                containerColor = textButtonColor.copy(alpha = 0.14f),
-                primaryContainerColor = textButtonColor,
+                containerColor = textBackgroundColor.copy(alpha = 0.08f),
+                primaryContainerColor = textBackgroundColor,
                 iconColor = textBackgroundColor,
                 primaryIconColor = iconButtonColor,
                 onPreviousClick = onPreviousClick,
@@ -3313,7 +3313,7 @@ private fun V9LandscapeContent(
                 canvasFallbackUrl = canvasFallbackUrl,
                 isPlaying = isPlaying,
                 size = artworkSize,
-                placeholderColor = textButtonColor.copy(alpha = 0.12f),
+                placeholderColor = textBackgroundColor.copy(alpha = 0.08f),
             )
 
             Column(
@@ -3325,7 +3325,7 @@ private fun V9LandscapeContent(
             ) {
                 V9Header(
                     textColor = textBackgroundColor,
-                    containerColor = textButtonColor.copy(alpha = 0.16f),
+                    containerColor = textBackgroundColor.copy(alpha = 0.08f),
                     iconColor = textBackgroundColor,
                     onCollapseClick = onCollapseClick,
                     onLyricsClick = onLyricsClick,
@@ -3350,8 +3350,8 @@ private fun V9LandscapeContent(
                     position = position,
                     duration = duration,
                     isPlaying = isPlaying,
-                    activeColor = textButtonColor,
-                    inactiveColor = textButtonColor.copy(alpha = 0.24f),
+                    activeColor = textBackgroundColor,
+                    inactiveColor = textBackgroundColor.copy(alpha = 0.24f),
                     textColor = textBackgroundColor,
                     onSliderValueChange = onSliderValueChange,
                     onSliderValueChangeFinished = onSliderValueChangeFinished,
@@ -3365,8 +3365,8 @@ private fun V9LandscapeContent(
                     isLoading = isLoading,
                     canSkipPrevious = canSkipPrevious,
                     canSkipNext = canSkipNext,
-                    containerColor = textButtonColor.copy(alpha = 0.14f),
-                    primaryContainerColor = textButtonColor,
+                    containerColor = textBackgroundColor.copy(alpha = 0.08f),
+                    primaryContainerColor = textBackgroundColor,
                     iconColor = textBackgroundColor,
                     primaryIconColor = iconButtonColor,
                     onPreviousClick = onPreviousClick,
@@ -4262,3 +4262,4 @@ fun PlayerBackground(
         }
     }
 }
+

--- a/app/src/main/kotlin/moe/rukamori/archivetune/utils/ArchiveTuneShareLinks.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/utils/ArchiveTuneShareLinks.kt
@@ -1,0 +1,144 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package moe.rukamori.archivetune.utils
+
+import android.net.Uri
+
+object ArchiveTuneShareLinks {
+    private const val SCHEME = "https"
+    private const val HOST = "archivetune.koiiverse.cloud"
+    private const val PATH = "share.html"
+
+    const val TYPE_WATCH = "watch"
+    const val TYPE_PLAYLIST = "playlist"
+    const val TYPE_CHANNEL = "channel"
+    const val TYPE_ALBUM = "album"
+
+    fun buildSongShareUrl(
+        videoId: String,
+        playlistId: String? = null,
+    ): String =
+        shareUriBuilder(TYPE_WATCH, videoId)
+            .apply {
+                playlistId
+                    ?.takeIf { it.isNotBlank() }
+                    ?.let { appendQueryParameter("list", it) }
+            }.build()
+            .toString()
+
+    fun buildPlaylistShareUrl(playlistId: String): String = shareUriBuilder(TYPE_PLAYLIST, playlistId).build().toString()
+
+    fun buildChannelShareUrl(channelId: String): String = shareUriBuilder(TYPE_CHANNEL, channelId).build().toString()
+
+    fun buildAlbumShareUrl(browseId: String): String = shareUriBuilder(TYPE_ALBUM, browseId).build().toString()
+
+    fun isArchiveTuneShareUri(uri: Uri): Boolean =
+        uri.scheme.equals(SCHEME, ignoreCase = true) &&
+            uri.host.equals(HOST, ignoreCase = true) &&
+            uri.path == "/$PATH"
+
+    fun toYouTubeMusicUri(uri: Uri): Uri? {
+        if (!isArchiveTuneShareUri(uri)) return null
+
+        val type = uri.getQueryParameter("type")?.takeIf { it in supportedTypes } ?: return null
+        val id = uri.getQueryParameter("id")?.takeIf { it.isNotBlank() } ?: return null
+        val list = uri.getQueryParameter("list")?.takeIf { it.isNotBlank() }
+        if (list != null && type != TYPE_WATCH) return null
+        return when (type) {
+            TYPE_WATCH ->
+                Uri
+                    .Builder()
+                    .scheme(SCHEME)
+                    .authority("music.youtube.com")
+                    .path("watch")
+                    .appendQueryParameter("v", id)
+                    .apply { list?.let { appendQueryParameter("list", it) } }
+                    .build()
+
+            TYPE_PLAYLIST ->
+                Uri
+                    .Builder()
+                    .scheme(SCHEME)
+                    .authority("music.youtube.com")
+                    .path("playlist")
+                    .appendQueryParameter("list", id)
+                    .build()
+
+            TYPE_CHANNEL ->
+                Uri
+                    .Builder()
+                    .scheme(SCHEME)
+                    .authority("music.youtube.com")
+                    .appendPath("channel")
+                    .appendPath(id)
+                    .build()
+
+            TYPE_ALBUM ->
+                Uri
+                    .Builder()
+                    .scheme(SCHEME)
+                    .authority("music.youtube.com")
+                    .appendPath("browse")
+                    .appendPath(id)
+                    .build()
+
+            else -> null
+        }
+    }
+
+    fun fromYouTubeMusicShareUrl(url: String): String {
+        val uri = runCatching { Uri.parse(url) }.getOrNull() ?: return url
+        if (!uri.host.equals("music.youtube.com", ignoreCase = true)) return url
+
+        return when (uri.pathSegments.firstOrNull()) {
+            "watch" ->
+                uri
+                    .getQueryParameter("v")
+                    ?.takeIf { it.isNotBlank() }
+                    ?.let { buildSongShareUrl(it, uri.getQueryParameter("list")) }
+                    ?: url
+
+            "playlist" ->
+                uri
+                    .getQueryParameter("list")
+                    ?.takeIf { it.isNotBlank() }
+                    ?.let(::buildPlaylistShareUrl)
+                    ?: url
+
+            "channel" ->
+                uri
+                    .lastPathSegment
+                    ?.takeIf { it.isNotBlank() }
+                    ?.let(::buildChannelShareUrl)
+                    ?: url
+
+            "browse" ->
+                uri
+                    .lastPathSegment
+                    ?.takeIf { it.isNotBlank() }
+                    ?.let(::buildAlbumShareUrl)
+                    ?: url
+
+            else -> url
+        }
+    }
+
+    private fun shareUriBuilder(
+        type: String,
+        id: String,
+    ): Uri.Builder =
+        Uri
+            .Builder()
+            .scheme(SCHEME)
+            .authority(HOST)
+            .appendPath(PATH)
+            .appendQueryParameter("type", type)
+            .appendQueryParameter("id", id)
+
+    private val supportedTypes = setOf(TYPE_WATCH, TYPE_PLAYLIST, TYPE_CHANNEL, TYPE_ALBUM)
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/ArtistViewModel.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/viewmodels/ArtistViewModel.kt
@@ -229,5 +229,5 @@ class ArtistViewModel
                 }
         }
 
-        private fun artistShareLink(): String = artistPage?.artist?.shareLink ?: "https://music.youtube.com/channel/$artistId"
+        private fun artistShareLink(): String = moe.rukamori.archivetune.utils.ArchiveTuneShareLinks.buildChannelShareUrl(artistPage?.artist?.id ?: artistId)
     }


### PR DESCRIPTION
## Summary
- add a central ArchiveTune share-link utility
- replace public share/copy links with ArchiveTune share URLs
- translate incoming ArchiveTune share links through existing YouTube Music deep-link handling
- register only /share.html as a verified Android App Link
- fix V9 player foreground text color usage

## Notes
The website must serve /.well-known/assetlinks.json with the release APK signing SHA-256 for Android App Link verification to complete.

## Validation
- Reviewed source changes
- Build still needs a clean local/CI run