### PR TITLE
fix: harden network security config, WebView mixed content, OkHttp timeouts, and prevent AOD BackHandler crash

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -48,7 +48,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
-        android:usesCleartextTraffic="true"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:supportsRtl="false"
         android:theme="@style/Theme.ArchiveTune"
         tools:targetApi="tiramisu">

--- a/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/MainActivity.kt
@@ -2411,7 +2411,7 @@ class MainActivity : ComponentActivity() {
                             }
                         }
 
-                        BackHandler(enabled = playerBottomSheetState.isExpanded) {
+                        BackHandler(enabled = playerBottomSheetState.isExpanded && !aodModeEnabled) {
                             playerBottomSheetState.collapseSoft()
                         }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/discord/DiscordAssetRegistrar.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/discord/DiscordAssetRegistrar.kt
@@ -21,12 +21,19 @@ import org.json.JSONObject
 import timber.log.Timber
 import java.net.URI
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
 
 object DiscordAssetRegistrar {
     private const val TAG = "DiscordAssetRegistrar"
     private const val API_BASE = "https://discord.com/api/v10"
 
-    private val client = OkHttpClient()
+    private val client =
+        OkHttpClient
+            .Builder()
+            .connectTimeout(10, TimeUnit.SECONDS)
+            .readTimeout(15, TimeUnit.SECONDS)
+            .writeTimeout(10, TimeUnit.SECONDS)
+            .build()
     private val cache = ConcurrentHashMap<String, String>()
     private val mutex = Mutex()
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/BottomSheet.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/component/BottomSheet.kt
@@ -67,6 +67,7 @@ fun BottomSheet(
     modifier: Modifier = Modifier,
     backgroundColor: Color,
     onDismiss: (() -> Unit)? = null,
+    backHandlerEnabled: Boolean = true,
     collapsedContent: @Composable BoxScope.() -> Unit,
     content: @Composable BoxScope.() -> Unit,
 ) {
@@ -92,7 +93,7 @@ fun BottomSheet(
                     ),
                 ),
     ) {
-        if (state.isExpandedOrExpanding) {
+        if (state.isExpandedOrExpanding && backHandlerEnabled) {
             BackHandler(onBack = state::collapseSoft)
         }
 

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/player/Player.kt
@@ -897,15 +897,17 @@ fun BottomSheetPlayer(
             }
         }
 
-    BackHandler(
-        enabled =
-            queueSheetState.isExpandedOrExpanding ||
-                state.isExpandedOrExpanding,
-    ) {
-        when {
-            isLyricsScreenVisible && state.isExpandedOrExpanding -> isLyricsScreenVisible = false
-            queueSheetState.isExpandedOrExpanding -> queueSheetState.collapseSoft()
-            state.isExpandedOrExpanding -> state.collapseSoft()
+    if (!aodModeEnabled) {
+        BackHandler(
+            enabled =
+                queueSheetState.isExpandedOrExpanding ||
+                    state.isExpandedOrExpanding,
+        ) {
+            when {
+                isLyricsScreenVisible && state.isExpandedOrExpanding -> isLyricsScreenVisible = false
+                queueSheetState.isExpandedOrExpanding -> queueSheetState.collapseSoft()
+                state.isExpandedOrExpanding -> state.collapseSoft()
+            }
         }
     }
 
@@ -1075,6 +1077,7 @@ fun BottomSheetPlayer(
         onDismiss = {
             playerConnection.service.stopAndClearPlayback(clearPersistentState = true)
         },
+        backHandlerEnabled = !aodModeEnabled,
         collapsedContent = {
             MiniPlayer(
                 position = position,

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/BackupAndRestore.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/BackupAndRestore.kt
@@ -966,7 +966,7 @@ private fun WebView.configureSpotifyLoginWebView() {
         setSupportZoom(true)
         builtInZoomControls = true
         displayZoomControls = false
-        mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
+        mixedContentMode = WebSettings.MIXED_CONTENT_NEVER_ALLOW
         userAgentString = SpotifyLoginUserAgent
     }
 }

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/ListenBrainzManager.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/screens/settings/ListenBrainzManager.kt
@@ -17,6 +17,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import timber.log.Timber
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
 object ListenBrainzManager {
@@ -25,7 +26,13 @@ object ListenBrainzManager {
     private var scope: CoroutineScope? = null
     private var job: Job? = null
     private var lifecycleObserver: Any? = null
-    private val httpClient = OkHttpClient()
+    private val httpClient =
+        OkHttpClient
+            .Builder()
+            .connectTimeout(10, TimeUnit.SECONDS)
+            .readTimeout(15, TimeUnit.SECONDS)
+            .writeTimeout(10, TimeUnit.SECONDS)
+            .build()
 
     private val _lastSubmitTime = MutableStateFlow<Long?>(null)
     val lastSubmitTimeFlow = _lastSubmitTime.asStateFlow()

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ ArchiveTune (2026)
+  ~ © Rukamori — github.com/rukamori
+  ~ GPL-3.0 License | Contributors: see git history
+  ~ Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+-->
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false" />
+</network-security-config>


### PR DESCRIPTION
# Pull Request

## Summary

Addresses four security and stability issues found during code review. Replaces the broad `usesCleartextTraffic` flag with a strict `network_security_config.xml`; hardens the Spotify OAuth WebView against mixed-content injection; adds explicit OkHttpClient timeouts to two bare clients that could hang indefinitely; and fixes a crash (`IllegalStateException`) when `BackHandler` is composed during AOD mode under Navigation 2.9.8 on certain devices (vivo, Android 16).

## Linked Work

- Closes:
- Related:

## Change Type

- [ ] Feature
- [x] Bug fix
- [ ] UI / UX
- [ ] Performance / memory
- [ ] Playback / Media3
- [ ] Lyrics / provider integration
- [ ] Search / YouTube / network data
- [ ] Local library / Room database
- [ ] Widgets / notification / shortcuts
- [x] Settings / preferences / DataStore
- [x] Discord / Last.fm / ListenBrainz / external integration
- [ ] Localization / strings / fastlane metadata
- [ ] Build / Gradle / CI / release packaging
- [ ] Dependency update
- [ ] Documentation only

## Affected Surfaces

- [x] `:app`
- [ ] `:core`
- [ ] `:lyrics`
- [ ] `:lastfm`
- [ ] `:canvas`
- [ ] `:shazamkit`
- [ ] `:spotifycore`
- Other:

## Screenshots / Recordings

<!-- No UI changes — security and crash fix only. -->

| Before | After |
| --- | --- |
| N/A — no visual change | N/A — no visual change |

## Behavior Notes

**1 · Network Security Config**
`android:usesCleartextTraffic="true"` has been removed from `AndroidManifest.xml` and replaced with `@xml/network_security_config` which sets `cleartextTrafficPermitted="false"` globally. All existing API calls in the app already use HTTPS, so no runtime behaviour changes. The Vivo/MIUI system webview used in `BackupAndRestore` is HTTPS-only and unaffected.

**2 · WebView mixed-content**
`configureSpotifyLoginWebView()` now uses `MIXED_CONTENT_NEVER_ALLOW` instead of `MIXED_CONTENT_COMPATIBILITY_MODE`. The Spotify OAuth endpoint is served entirely over HTTPS so no functional regression is expected.

**3 · OkHttpClient timeouts**
`DiscordAssetRegistrar` and `ListenBrainzManager` previously used `OkHttpClient()` with no timeouts. Each now uses `OkHttpClient.Builder()` with `connectTimeout(10, SECONDS)` / `readTimeout(15, SECONDS)` / `writeTimeout(10, SECONDS)`, matching the pattern used by `MegalobizLyricsProvider` and `AiContentFilterRepository`.

**4 · AOD BackHandler crash**
Navigation 2.9.8 changed `BackHandler` to require `LocalNavigationEventDispatcherOwner` (provided by `NavHost`) or `LocalOnBackPressedDispatcherOwner`. The player `BottomSheet` and related overlays are rendered outside `NavHost`; when AOD mode expands the sheet these `BackHandler` calls crash on devices where the fallback owner is not reachable (confirmed: vivo V2513, Android 16 SDK 36).

Fix: three `BackHandler` registrations are now gated on `!aodModeEnabled`:
- `BottomSheet.kt` — new `backHandlerEnabled: Boolean = true` param (default preserves existing behaviour for all other callers)
- `Player.kt` — `if (!aodModeEnabled)` guard around own `BackHandler`; passes `backHandlerEnabled = !aodModeEnabled` to `BottomSheet`
- `MainActivity.kt` — `&& !aodModeEnabled` added to the outer player-sheet `BackHandler` enabled condition

Back-press is semantically irrelevant during AOD (the screen acts as a locked display), so the guard is also the correct UX behaviour.

Crash stack (device: vivo V2513, Android 16 / SDK 36, app 14.1.0):
```
java.lang.IllegalStateException: No NavigationEventDispatcherOwner was provided
via LocalNavigationEventDispatcherOwner and no OnBackPressedDispatcherOwner was
provided via LocalOnBackPressedDispatcherOwner. Please provide one of the two.
    at ...oo.onAttachedToWindow(...)
    at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:4449)
```

## Architecture Checklist

- [x] The change preserves UDF flow: UI → ViewModel → UseCase/domain → Repository/data.
- [x] Screen state is represented structurally with `Loading`, `Success`, `Empty`, and `Error` where this PR introduces or changes screen state. _(N/A — no new screen state)_
- [x] Composables receive immutable, UI-specific domain models instead of raw Room, network, or service entities. _(N/A)_
- [x] Business work is not triggered directly from composition.
- [x] Exceptions are surfaced through explicit state or result types instead of being swallowed.
- [x] No `runBlocking` is introduced in app execution paths.

## Compose / Material Checklist

- [x] UI state is hoisted out of composable layout code. _(N/A — no new composables)_
- [x] Reactive state is collected with `collectAsStateWithLifecycle()`. _(N/A)_
- [x] New UI models are annotated with `@Immutable` or `@Stable`. _(N/A — no new models)_
- [x] Lazy layouts use stable `key` values and explicit `contentType`. _(N/A)_
- [x] Non-primitive constants, structural lambdas, and allocation-heavy objects in hot paths are remembered. _(N/A)_
- [x] Rapidly changing inputs use `derivedStateOf` where appropriate. _(N/A)_
- [x] UI strings come from `stringResource()`. _(No new strings added)_
- [x] Interactive elements keep a minimum 48dp touch target. _(N/A — no new interactive elements)_
- [x] Material 3 tokens used for color, typography, shape, and motion. _(N/A)_
- [x] Edge-to-edge layouts handle `WindowInsets` correctly. _(N/A — no layout changes)_

## Concurrency / Performance Checklist

- [x] Business coroutines are scoped to `viewModelScope` or an existing lifecycle-owned scope.
- [x] Disk, database, network, parsing, and heavy mapping work is dispatched to `Dispatchers.IO` or `Dispatchers.Default`.
- [x] Cancellation is handled explicitly.
- [x] The change avoids blocking the main thread.
- [x] The change avoids unnecessary allocations in recomposition loops.
- [x] Large lists, images, and network responses are bounded, streamed, cached, paged, or mapped off the main thread. _(N/A)_

## Data / Persistence Checklist

- [x] Room entity, DAO, or database changes include a schema update. _(N/A — no DB changes)_
- [x] Database migrations preserve existing user data. _(N/A)_
- [x] DataStore or preference-key changes are backward compatible. _(N/A)_
- [x] Network DTOs remain isolated from UI models.
- [x] Provider responses handle missing, malformed, or rate-limited data without crashing.

## Playback / Integration Checklist

- [x] Media3 playback, queue, cache, and service behavior remains stable. _(No playback changes)_
- [x] Audio focus and media session actions are considered. _(N/A)_
- [x] External integrations handle absent credentials, revoked auth, and network failure. _(OkHttp timeout additions improve resilience)_
- [x] Native/ABI-sensitive changes account for all variants. _(N/A)_

## Privacy / Security Checklist

- [x] No secrets, keys, tokens, or local paths are committed.
- [x] Logs do not expose tokens, cookies, or user data.
- [x] New network calls are justified and use existing client patterns. _(No new network calls — timeout additions only)_
- [x] User data remains local.

## Verification

- [x] Android Studio sync: successful
- [x] Manual device/emulator verification: AOD crash reproduced on vivo V2513 (Android 16) without fix; confirmed resolved with fix applied
- [x] UI screenshot/recording attached: N/A — no UI changes
- [x] Accessibility or touch-target review: N/A — no new interactive elements
- [x] Regression areas checked: Spotify login WebView, Discord rich presence, ListenBrainz scrobbling, AOD mode entry/exit, back-press from expanded player
- [x] CI expectation: `lintGmsMobileUniversalDebug` — zero new warnings or errors (verified locally)

## Reviewer Focus

- `BottomSheet.kt` — the new `backHandlerEnabled` param defaults to `true` so all existing call sites are unaffected; only the player path sets it to `false` during AOD. Confirm default is correct.
- `network_security_config.xml` — confirm `cleartextTrafficPermitted="false"` does not break any HTTP endpoint still in use (review confirms all calls are HTTPS).
- `BackupAndRestore.kt:configureSpotifyLoginWebView()` — confirm Spotify OAuth page is fully HTTPS and `MIXED_CONTENT_NEVER_ALLOW` does not break the login flow.

## Release Notes

Security: replaced cleartext-traffic flag with a strict Network Security Config, hardened Spotify WebView mixed-content mode, added OkHttp timeouts to Discord and ListenBrainz clients, and fixed a crash when entering AOD mode on Navigation 2.9.8 devices.