### PR TITLE
fix(playback): eliminate crossfade handoff silence

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/CrossfadeHandoffPolicy.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/CrossfadeHandoffPolicy.kt
@@ -1,0 +1,41 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package moe.rukamori.archivetune.playback
+
+import kotlin.math.PI
+import kotlin.math.abs
+import kotlin.math.cos
+import kotlin.math.sin
+
+internal data class EqualPowerGains(
+    val outgoing: Float,
+    val incoming: Float,
+)
+
+internal fun needsCorrectiveCrossfadeSeek(
+    primaryPositionMs: Long,
+    secondaryPositionMs: Long,
+    maximumDriftMs: Long,
+): Boolean {
+    require(maximumDriftMs >= 0L)
+    return abs(primaryPositionMs - secondaryPositionMs) > maximumDriftMs
+}
+
+internal fun hasPlaybackPositionAdvanced(
+    positionAfterSeekMs: Long,
+    currentPositionMs: Long,
+): Boolean = currentPositionMs > positionAfterSeekMs
+
+internal fun equalPowerGains(progress: Float): EqualPowerGains {
+    val clampedProgress = progress.coerceIn(0f, 1f)
+    val radians = clampedProgress.toDouble() * (PI / 2.0)
+    return EqualPowerGains(
+        outgoing = cos(radians).toFloat(),
+        incoming = sin(radians).toFloat(),
+    )
+}

--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/MusicService.kt
@@ -273,13 +273,10 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
 import javax.inject.Inject
-import kotlin.math.PI
 import kotlin.math.abs
 import kotlin.math.ceil
-import kotlin.math.cos
 import kotlin.math.pow
 import kotlin.math.roundToLong
-import kotlin.math.sin
 import kotlin.time.Duration.Companion.seconds
 
 @OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class, UnstableApi::class)
@@ -519,6 +516,7 @@ class MusicService :
     private var crossfadeBaseVolume = 1f
     private var crossfadeIncomingBaseVolume = 1f
     private var crossfadeProgress = 0f
+    private var crossfadeHandoffProgress = 0f
     private var crossfadePlaybackRequested = false
     private var lyricsPreloadManager: LyricsPreloadManager? = null
 
@@ -2423,6 +2421,20 @@ class MusicService :
     private fun applyEffectiveVolume(finalVolume: Float = currentEffectivePlayerVolume()) {
         crossfadeBaseVolume = finalVolume
         val incomingPlayer = secondaryCrossfadePlayer
+        if (crossfadeHandoffInProgress && incomingPlayer != null) {
+            val handoffBaseVolume =
+                secondaryCrossfadeTarget?.let { currentEffectivePlayerVolumeForMediaId(it.mediaId) }
+                    ?: finalVolume
+            crossfadeIncomingBaseVolume = handoffBaseVolume
+            applyCrossfadeVolumes(
+                crossfadeHandoffProgress,
+                handoffBaseVolume,
+                handoffBaseVolume,
+                incomingPlayer,
+                localPlayer,
+            )
+            return
+        }
         if (isCrossfading && incomingPlayer != null) {
             val incomingBaseVolume =
                 secondaryCrossfadeTarget?.let { currentEffectivePlayerVolumeForMediaId(it.mediaId) }
@@ -2481,10 +2493,9 @@ class MusicService :
         outgoingPlayer: ExoPlayer,
         incomingPlayer: ExoPlayer,
     ) {
-        val clampedProgress = progress.coerceIn(0f, 1f)
-        val radians = clampedProgress.toDouble() * (PI / 2.0)
-        outgoingPlayer.volume = (outgoingBaseVolume * cos(radians).toFloat()).coerceIn(0f, maxSafeGainFactor)
-        incomingPlayer.volume = (incomingBaseVolume * sin(radians).toFloat()).coerceIn(0f, maxSafeGainFactor)
+        val gains = equalPowerGains(progress)
+        outgoingPlayer.volume = (outgoingBaseVolume * gains.outgoing).coerceIn(0f, maxSafeGainFactor)
+        incomingPlayer.volume = (incomingBaseVolume * gains.incoming).coerceIn(0f, maxSafeGainFactor)
     }
 
     fun pauseFromSleepTimer() {
@@ -2791,19 +2802,39 @@ class MusicService :
             localPlayer.pauseAtEndOfMediaItems = false
             player.volume = 0f
             crossfadeHandoffInProgress = true
+            crossfadeHandoffProgress = 0f
             player.seekTo(targetIndex, incomingPosition)
             player.playWhenReady = shouldContinuePlayback
             if (shouldContinuePlayback) {
                 if (awaitPrimaryCrossfadeHandoffReady(incomingPlayer)) {
-                    val syncedIncomingPosition = incomingPlayer.currentPosition.coerceAtLeast(0L)
-                    player.seekTo(targetIndex, syncedIncomingPosition)
+                    val primaryPosition = player.currentPosition.coerceAtLeast(0L)
+                    val secondaryPosition = incomingPlayer.currentPosition.coerceAtLeast(0L)
+                    val positionAfterLastSeek =
+                        if (needsCorrectiveCrossfadeSeek(
+                                primaryPositionMs = primaryPosition,
+                                secondaryPositionMs = secondaryPosition,
+                                maximumDriftMs = CROSSFADE_HANDOFF_MAX_DRIFT_MS,
+                            )
+                        ) {
+                            player.seekTo(targetIndex, secondaryPosition)
+                            secondaryPosition
+                        } else {
+                            incomingPosition
+                    }
+
+                    if (awaitPrimaryPositionAdvance(targetIndex, positionAfterLastSeek)) {
+                        performCrossfadeHandoff(targetIndex, incomingPlayer)
+                    }
                 }
+            } else {
+                incomingPlayer.pause()
             }
             currentMediaMetadata.value = player.getMediaItemAt(targetIndex).metadata
             handoffCompleted = true
         } finally {
             if (!handoffCompleted) {
                 crossfadeHandoffInProgress = false
+                crossfadeHandoffProgress = 0f
                 isCrossfading = false
                 crossfadeProgress = 0f
                 crossfadePlaybackRequested = false
@@ -2814,6 +2845,7 @@ class MusicService :
 
         isCrossfading = false
         crossfadeHandoffInProgress = false
+        crossfadeHandoffProgress = 0f
         crossfadeProgress = 0f
         crossfadeIncomingBaseVolume = 1f
         crossfadePlaybackRequested = false
@@ -2835,6 +2867,68 @@ class MusicService :
             delay(25L)
         }
         return player.playbackState == Player.STATE_READY && canHandoffWithoutRebuffer(incomingPlayer)
+    }
+
+    private suspend fun awaitPrimaryPositionAdvance(
+        targetIndex: Int,
+        positionAfterSeekMs: Long,
+    ): Boolean {
+        val deadlineMs = android.os.SystemClock.elapsedRealtime() + CROSSFADE_HANDOFF_READY_TIMEOUT_MS
+        while (kotlinx.coroutines.currentCoroutineContext().isActive && android.os.SystemClock.elapsedRealtime() < deadlineMs) {
+            if (!crossfadePlaybackRequested || !player.playWhenReady) return false
+            if (player.currentMediaItemIndex != targetIndex) return false
+            if (player.playbackState == Player.STATE_IDLE || player.playbackState == Player.STATE_ENDED) return false
+            if (player.playbackState == Player.STATE_READY &&
+                player.isPlaying &&
+                hasPlaybackPositionAdvanced(positionAfterSeekMs, player.currentPosition)
+            ) {
+                return true
+            }
+            delay(CROSSFADE_HANDOFF_POLL_MS)
+        }
+        return player.currentMediaItemIndex == targetIndex &&
+            player.playbackState == Player.STATE_READY &&
+            player.isPlaying &&
+            hasPlaybackPositionAdvanced(positionAfterSeekMs, player.currentPosition)
+    }
+
+    private suspend fun performCrossfadeHandoff(
+        targetIndex: Int,
+        incomingPlayer: ExoPlayer,
+    ) {
+        var startedAtMs = android.os.SystemClock.elapsedRealtime()
+        var lastConfirmedPrimaryPositionMs = player.currentPosition.coerceAtLeast(0L)
+        while (kotlinx.coroutines.currentCoroutineContext().isActive) {
+            if (!crossfadePlaybackRequested || !player.playWhenReady) {
+                incomingPlayer.pause()
+                return
+            }
+            if (player.currentMediaItemIndex != targetIndex) return
+            if (player.playbackState != Player.STATE_READY || !player.isPlaying) {
+                crossfadeHandoffProgress = 0f
+                applyEffectiveVolume()
+                if (!awaitPrimaryPositionAdvance(targetIndex, lastConfirmedPrimaryPositionMs)) return
+                lastConfirmedPrimaryPositionMs = player.currentPosition.coerceAtLeast(0L)
+                startedAtMs = android.os.SystemClock.elapsedRealtime()
+                continue
+            }
+
+            val elapsedMs = android.os.SystemClock.elapsedRealtime() - startedAtMs
+            crossfadeHandoffProgress =
+                (elapsedMs.toFloat() / CROSSFADE_HANDOFF_DURATION_MS.toFloat()).coerceIn(0f, 1f)
+            val handoffBaseVolume =
+                secondaryCrossfadeTarget?.let { currentEffectivePlayerVolumeForMediaId(it.mediaId) }
+                    ?: crossfadeIncomingBaseVolume
+            applyCrossfadeVolumes(
+                crossfadeHandoffProgress,
+                handoffBaseVolume,
+                handoffBaseVolume,
+                incomingPlayer,
+                localPlayer,
+            )
+            if (crossfadeHandoffProgress >= 1f) return
+            delay(CROSSFADE_HANDOFF_FRAME_MS)
+        }
     }
 
     private fun canHandoffWithoutRebuffer(incomingPlayer: ExoPlayer): Boolean {
@@ -2915,6 +3009,7 @@ class MusicService :
         crossfadeJob = null
         isCrossfading = false
         crossfadeHandoffInProgress = false
+        crossfadeHandoffProgress = 0f
         crossfadeProgress = 0f
         crossfadeIncomingBaseVolume = 1f
         crossfadePlaybackRequested = false
@@ -6474,19 +6569,24 @@ class MusicService :
     ) {
         super.onPlayWhenReadyChanged(playWhenReady, reason)
         secondaryCrossfadePlayer?.let { secondaryPlayer ->
-            if (isCrossfading && !crossfadeHandoffInProgress) {
+            if (isCrossfading) {
                 val isEndOfOutgoingItemPause =
                     !playWhenReady &&
                         reason == Player.PLAY_WHEN_READY_CHANGE_REASON_END_OF_MEDIA_ITEM &&
                         localPlayer.pauseAtEndOfMediaItems
                 if (!isEndOfOutgoingItemPause) {
                     crossfadePlaybackRequested = playWhenReady
-                }
-                secondaryPlayer.playWhenReady = crossfadePlaybackRequested
-                if (crossfadePlaybackRequested) {
-                    secondaryPlayer.play()
-                } else if (!isEndOfOutgoingItemPause) {
-                    secondaryPlayer.pause()
+                    secondaryPlayer.playWhenReady = crossfadePlaybackRequested
+                    if (crossfadePlaybackRequested) {
+                        secondaryPlayer.play()
+                    } else {
+                        secondaryPlayer.pause()
+                    }
+                } else if (!crossfadeHandoffInProgress) {
+                    secondaryPlayer.playWhenReady = crossfadePlaybackRequested
+                    if (crossfadePlaybackRequested) {
+                        secondaryPlayer.play()
+                    }
                 }
             }
         }
@@ -8471,6 +8571,10 @@ class MusicService :
         const val CROSSFADE_HANDOFF_READY_TIMEOUT_MS = 5_000L
         const val CROSSFADE_HANDOFF_BUFFER_MS = 5_000L
         const val CROSSFADE_HANDOFF_SEEK_GUARD_MS = 750L
+        const val CROSSFADE_HANDOFF_MAX_DRIFT_MS = 75L
+        const val CROSSFADE_HANDOFF_DURATION_MS = 96L
+        const val CROSSFADE_HANDOFF_FRAME_MS = 8L
+        const val CROSSFADE_HANDOFF_POLL_MS = 10L
         const val CROSSFADE_MIN_BUFFER_BEFORE_START_MS = 5_000L
         const val CROSSFADE_MAX_BUFFER_BEFORE_START_MS = 12_500L
         const val PRIMARY_MIN_BUFFER_MS = 20_000

--- a/app/src/test/kotlin/moe/rukamori/archivetune/playback/CrossfadeHandoffPolicyTest.kt
+++ b/app/src/test/kotlin/moe/rukamori/archivetune/playback/CrossfadeHandoffPolicyTest.kt
@@ -1,0 +1,63 @@
+/*
+ * ArchiveTune (2026)
+ * © Rukamori — github.com/rukamori
+ * GPL-3.0 License | Contributors: see git history
+ * Do not remove or alter this notice. - Per GPL-3.0 Section 4 & Section 5
+ */
+
+package moe.rukamori.archivetune.playback
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CrossfadeHandoffPolicyTest {
+    @Test
+    fun correctiveSeek_isSkipped_whenDriftIsWithinTolerance() {
+        assertFalse(
+            needsCorrectiveCrossfadeSeek(
+                primaryPositionMs = 10_040L,
+                secondaryPositionMs = 10_000L,
+                maximumDriftMs = 75L,
+            ),
+        )
+        assertFalse(needsCorrectiveCrossfadeSeek(10_075L, 10_000L, maximumDriftMs = 75L))
+    }
+
+    @Test
+    fun correctiveSeek_isRequired_whenDriftExceedsTolerance_inEitherDirection() {
+        assertTrue(needsCorrectiveCrossfadeSeek(9_900L, 10_000L, maximumDriftMs = 75L))
+        assertTrue(needsCorrectiveCrossfadeSeek(10_100L, 10_000L, maximumDriftMs = 75L))
+    }
+
+    @Test
+    fun playbackPositionMustMoveForward_afterSeek() {
+        assertFalse(
+            hasPlaybackPositionAdvanced(positionAfterSeekMs = 10_000L, currentPositionMs = 10_000L),
+        )
+        assertFalse(
+            hasPlaybackPositionAdvanced(positionAfterSeekMs = 10_000L, currentPositionMs = 9_999L),
+        )
+        assertTrue(
+            hasPlaybackPositionAdvanced(positionAfterSeekMs = 10_000L, currentPositionMs = 10_001L),
+        )
+    }
+
+    @Test
+    fun equalPowerHandoff_preservesPowerAtEndpointsAndMidpoint() {
+        val start = equalPowerGains(0f)
+        val midpoint = equalPowerGains(0.5f)
+        val end = equalPowerGains(1f)
+
+        assertEquals(1f, start.outgoing, 0.0001f)
+        assertEquals(0f, start.incoming, 0.0001f)
+        assertEquals(1f, end.incoming, 0.0001f)
+        assertEquals(0f, end.outgoing, 0.0001f)
+        assertEquals(
+            1f,
+            midpoint.outgoing * midpoint.outgoing + midpoint.incoming * midpoint.incoming,
+            0.0001f,
+        )
+    }
+}


### PR DESCRIPTION
# Pull Request

## Summary

Fixes the brief silence heard after an overlap crossfade by keeping the secondary ExoPlayer audible until the primary player has demonstrably resumed playback. The handoff now avoids an unnecessary final seek when player drift is already acceptable, waits for actual primary position movement after any required correction, and transfers output with a short equal-power ramp.

This is a fix to ArchiveTune's custom dual-player handoff. Media3 does not provide the crossfade being used here. OpenTune identifies its crossfade improvements as ported from ArchiveTune, which explains why both applications can exhibit the same application-level handoff issue.

## Linked Work

- Closes: #1039
- Related: #1130

## Change Type

- [ ] Feature
- [x] Bug fix
- [ ] UI / UX
- [ ] Performance / memory
- [x] Playback / Media3
- [ ] Lyrics / provider integration
- [ ] Search / YouTube / network data
- [ ] Local library / Room database
- [ ] Widgets / notification / shortcuts
- [ ] Settings / preferences / DataStore
- [ ] Discord / Last.fm / ListenBrainz / external integration
- [ ] Localization / strings / fastlane metadata
- [ ] Build / Gradle / CI / release packaging
- [ ] Dependency update
- [ ] Documentation only

## Affected Surfaces

- [x] `:app`
- [ ] `:core`
- [ ] `:lyrics`
- [ ] `:lastfm`
- [ ] `:canvas`
- [ ] `:shazamkit`
- [ ] `:spotifycore`
- [ ] Other:

## Screenshots / Recordings

| Before | After |
| --- | --- |
| N/A — audio-only service bug | N/A — no visual change |

## Behavior Notes

### Root cause

ArchiveTune performs crossfade with two ExoPlayer instances. At the end of the overlap, the secondary player is already playing the incoming track while the primary seeks to the secondary position. The previous handoff waited for `STATE_READY`, performed another synchronization seek, and immediately stopped the secondary.

`STATE_READY` confirms that the primary is prepared, but does not prove that its position or audio output has resumed after the final seek. Releasing the only demonstrably audible player at that point can expose a short silent interval.

### Handoff behavior

- The secondary remains audible at the incoming track's effective volume during every primary seek.
- Position drift at or below 75 ms is accepted, avoiding the common unnecessary corrective seek.
- When drift exceeds 75 ms, the primary seeks to the live secondary position.
- After the last seek, handoff requires `STATE_READY`, `isPlaying`, and primary position advancement beyond the post-seek position.
- Output transfers through a 96 ms equal-power ramp instead of abruptly releasing the secondary.
- If the primary re-buffers during the ramp, the secondary immediately returns to full effective volume. The ramp restarts only after another demonstrated primary position advance.
- Pause requests continue to pause the secondary during handoff.
- Target-track normalization, user volume, and audio-focus gain remain applied throughout the transfer.
- Existing cancellation, timeout, Cast, player-error, and cleanup paths remain unchanged.
- No arbitrary post-seek delay is used; readiness is based on player state and observed playback progress.

### Test coverage

Focused unit tests cover drift within tolerance, drift requiring correction in both directions, the exact tolerance boundary, post-seek forward movement, and equal-power gain behavior at the endpoints and midpoint.

## Architecture Checklist

- [x] The change preserves the existing service-layer playback architecture. _(No UI/UDF changes)_
- [x] No database, network, repository, or UI models are exposed or changed. _(N/A)_
- [x] Business work is not triggered directly from composition. _(No Compose changes)_
- [x] No `runBlocking` is introduced in app execution paths.

## Compose / Material Checklist

- [x] N/A — no Composable, UI state, layout, string, asset, or interaction changes.

## Concurrency / Performance Checklist

- [x] Handoff work remains in the existing lifecycle-owned service coroutine scope.
- [x] Cancellation is checked in readiness, position, and volume-ramp loops.
- [x] The change does not block the main thread.
- [x] Polling and ramp work are bounded by existing handoff timing and cancellation behavior.
- [x] No new dependency, thread, executor, or long-lived allocation is introduced.

## Data / Persistence Checklist

- [x] N/A — no Room, migration, DataStore, DTO, or persistence changes.

## Playback / Integration Checklist

- [x] Media3 queue and media-session ownership remain with the existing primary player.
- [x] Pause, normalization, audio focus, cancellation, timeout, and error paths were preserved.
- [x] Cast selection and transfer code are unchanged.
- [x] No audio offload, cache, stream resolution, or ABI-sensitive implementation was changed.

## Localization / Assets Checklist

- [x] N/A — no user-facing strings or assets added.

## Privacy / Security Checklist

- [x] No secrets, tokens, identifiers, logs, network calls, or user data handling were added.

## Verification

- [ ] Android Studio sync: not run; Gradle compilation and packaging completed successfully.
- [ ] Manual device/emulator verification: arm64 debug APK produced for device testing; listening verification still pending.
- [x] UI screenshot/recording attached: N/A — audio-only behavior with no visual changes.
- [x] Accessibility or touch-target review: N/A — no UI changes.
- [x] Regression areas checked: drift policy, post-seek advancement, equal-power gains, pause propagation, rebuffer recovery, normalization/audio-focus volume updates, cancellation, timeout, error cleanup, and Cast code paths.
- [x] CI expectation: the repository PR workflow's GMS mobile universal assemble and lint variants pass locally.

Checks run:

- [x] `:app:testGmsMobileUniversalDebugUnitTest`
- [x] `:app:lintGmsMobileUniversalDebug`
- [x] `:app:assembleGmsMobileUniversalDebug`
- [x] `:app:assembleGmsMobileArm64Debug`
- [x] `git diff --check`

Repository task-name notes:

- `./gradlew lintDebug` is ambiguous across the current flavor matrix; `:app:lintGmsMobileUniversalDebug` passed.
- `./gradlew testDebugUnitTest` is ambiguous across the current flavor matrix; `:app:testGmsMobileUniversalDebugUnitTest` passed.
- The repository does not currently define `ktlintCheck`.
- The aggregate `./gradlew assembleDebug` task spans every distribution, device, and ABI debug variant. Verification used the repository PR workflow's universal variant and the target-device arm64 variant; both passed.

## Reviewer Focus

- `MusicService.finishCrossfade()`: confirm the secondary cannot be released on the successful playback path before primary position advancement.
- `MusicService.performCrossfadeHandoff()`: confirm a primary rebuffer restores the secondary before waiting for playback to resume.
- `CrossfadeHandoffPolicy.kt`: confirm the 75 ms correction threshold and equal-power curve are appropriate.
- `CrossfadeHandoffPolicyTest.kt`: confirm boundary and direction coverage for drift and position decisions.

## Release Notes

Fixed the brief silent gap at the end of a crossfade.