### PR TITLE
fix(queue): start radio from selected song

### DIFF
--- a/app/src/main/kotlin/moe/rukamori/archivetune/playback/PlayerConnection.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/playback/PlayerConnection.kt
@@ -42,6 +42,7 @@ import moe.rukamori.archivetune.extensions.getQueueWindows
 import moe.rukamori.archivetune.models.MediaMetadata
 import moe.rukamori.archivetune.playback.MusicService.MusicBinder
 import moe.rukamori.archivetune.playback.queues.Queue
+import moe.rukamori.archivetune.playback.queues.YouTubeQueue
 import moe.rukamori.archivetune.ui.player.refetchCanvasArtworkForPlayback
 import moe.rukamori.archivetune.utils.isLocalMediaId
 import moe.rukamori.archivetune.utils.reportException
@@ -239,6 +240,14 @@ class PlayerConnection(
 
     fun startRadioSeamlessly() {
         service.startRadioSeamlessly()
+    }
+
+    fun startRadio(seed: MediaMetadata) {
+        if (mediaMetadata.value?.id == seed.id) {
+            startRadioSeamlessly()
+        } else {
+            playQueue(YouTubeQueue.radio(seed))
+        }
     }
 
     fun playNext(item: MediaItem) = playNext(listOf(item))

--- a/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/PlayerMenu.kt
+++ b/app/src/main/kotlin/moe/rukamori/archivetune/ui/menu/PlayerMenu.kt
@@ -449,7 +449,7 @@ fun PlayerMenu(
                                         },
                                         text = stringResource(R.string.start_radio),
                                         onClick = {
-                                            playerConnection.startRadioSeamlessly()
+                                            playerConnection.startRadio(mediaMetadata)
                                             onDismiss()
                                         },
                                     ),


### PR DESCRIPTION
## Summary
- Start radio using the song selected from the playback queue.
- Preserve seamless radio behavior when the selected song is already playing.
- Fix the regression introduced when PlayerMenu switched to startRadioSeamlessly().

## Testing
- git diff --check
- Patch validated against the current main branch
- Full Android build was not run because the required Gradle distribution was unavailable in the execution environment

Fixes #1153